### PR TITLE
[Fix] Fix year string in about view

### DIFF
--- a/Shared/Supporting Files/Views/AboutView.swift
+++ b/Shared/Supporting Files/Views/AboutView.swift
@@ -19,7 +19,7 @@ struct AboutView: View {
     @Environment(\.presentationMode) private var presentationMode
     
     var copyrightText: Text {
-        Text("Copyright © 2022-\(Date(), format: .dateTime.year()) Esri. All Rights Reserved.")
+        Text("Copyright © 2022 Esri. All Rights Reserved.")
     }
     
     var body: some View {


### PR DESCRIPTION
Remove redundant year component. See comment in https://github.com/ArcGIS/arcgis-runtime-samples-swift/pull/3#discussion_r879811059 

Other retro-fixes can also go in this PR ⏳ 