### PR TITLE
[Fix] Update method name for `getGeodatabaseFeatureTable`

### DIFF
--- a/Shared/Samples/Display feature layers/DisplayFeatureLayersView.swift
+++ b/Shared/Samples/Display feature layers/DisplayFeatureLayersView.swift
@@ -65,7 +65,7 @@ struct DisplayFeatureLayersView: View {
         }
         // Creates a feature layer from the geodatabase's feature table and
         // sets the current feature layer to it.
-        let featureTable = geodatabase.getGeodatabaseFeatureTable(tableName: "Trailheads")!
+        let featureTable = geodatabase.featureTable(named: "Trailheads")!
         let featureLayer = FeatureLayer(featureTable: featureTable)
         setFeatureLayer(featureLayer, viewpoint: .losAngelesCA)
     }


### PR DESCRIPTION
## Description

This PR fixes a method name change in `DisplayFeatureLayersView`.

Please use latest swift API and toolkit v.next to test.