### PR TITLE
[Update] Replace deprecated API `presentationMode`

### DIFF
--- a/Shared/Supporting Files/Views/AboutView.swift
+++ b/Shared/Supporting Files/Views/AboutView.swift
@@ -16,7 +16,7 @@ import SwiftUI
 import ArcGIS
 
 struct AboutView: View {
-    @Environment(\.dismiss) var dismiss: DismissAction
+    @Environment(\.dismiss) private var dismiss: DismissAction
     
     var copyrightText: Text {
         Text("Copyright © 2022 Esri. All Rights Reserved.")


### PR DESCRIPTION

## Description

This PR fixes [`presentationMode`](https://developer.apple.com/documentation/swiftui/environmentvalues/presentationmode) which is deprecated in iOS 16. Learned that from the BNR training. It is replaced by https://developer.apple.com/documentation/swiftui/environmentvalues/dismiss

## Linked Issue(s)

- https://github.com/ArcGIS/arcgis-runtime-samples-swift/projects/1#card-85034070

## How To Test

The view behaves the same as before - tap button to dismiss.
