### PR TITLE
[Update] Change deprecated navigation methods

### DIFF
--- a/Shared/Supporting Files/Views/AboutView.swift
+++ b/Shared/Supporting Files/Views/AboutView.swift
@@ -55,14 +55,15 @@ struct AboutView: View {
                     Link("API Reference", destination: .apiReference)
                 }
             }
-            .navigationBarTitle("About", displayMode: .inline)
-            .navigationBarItems(
-                trailing: Button(action: {
-                    dismiss()
-                }, label: {
-                    Text("Done").bold()
-                })
-            )
+            .navigationTitle("About")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") {
+                        dismiss()
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Description

This PR updates the 2 deprecated methods in iOS 16

- https://developer.apple.com/documentation/swiftui/view/navigationbartitle(_:)-6p1k7
- https://developer.apple.com/documentation/swiftui/view/navigationbaritems(trailing:)

Also, `confirmationAction` placement is used to make the "Done" button bold automatically, and it makes more sense semantically.

## Linked Issue(s)

- https://github.com/ArcGIS/arcgis-runtime-samples-swift/projects/1#card-85069801
- https://github.com/ArcGIS/arcgis-runtime-samples-swift/projects/1#card-85069789

## How To Test

No visual changes.
