### PR TITLE
[Update] Clear callout when query is cleared in Search with geocode

### DIFF
--- a/Shared/Samples/Search with geocode/SearchWithGeocodeView.swift
+++ b/Shared/Samples/Search with geocode/SearchWithGeocodeView.swift
@@ -115,6 +115,12 @@ struct SearchWithGeocodeView: View {
                 .queryCenter($queryCenter)
                 .geoViewExtent($geoViewExtent)
                 .isGeoViewNavigating($isGeoViewNavigating)
+                .onQueryChanged { query in
+                    if query.isEmpty {
+                        // Hides the callout when query is cleared.
+                        calloutPlacement = nil
+                    }
+                }
                 .padding()
             }
         }


### PR DESCRIPTION
## Description

This PR addresses #58 

## Linked Issue(s)

- #14 
- #58
- https://github.com/ArcGIS/arcgis-runtime-toolkit-swift/issues/68#issuecomment-1226133122

## How To Test

Input a query string and select a result pin to show a callout. Clear the query and see the callout dismiss.

## Screenshots

![clear](https://user-images.githubusercontent.com/9660181/186742758-397d0c34-3789-4f3e-9799-d0886178f07b.gif)

