### PR TITLE
[Update] Remove redundant `import ArcGIS`

### DIFF
--- a/Shared/SamplesApp+Samples.swift.tache
+++ b/Shared/SamplesApp+Samples.swift.tache
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import SwiftUI
-import ArcGIS
 
 extension SamplesApp {
     /// The samples for this app.

--- a/Shared/Supporting Files/Models/Sample.swift
+++ b/Shared/Supporting Files/Models/Sample.swift
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import SwiftUI
-import ArcGIS
 
 /// A type that represents a sample in the sample viewer.
 protocol Sample {

--- a/Shared/Supporting Files/Views/AboutView.swift
+++ b/Shared/Supporting Files/Views/AboutView.swift
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import SwiftUI
-import ArcGIS
 
 struct AboutView: View {
     @Environment(\.dismiss) private var dismiss: DismissAction

--- a/Shared/Supporting Files/Views/ContentView.swift
+++ b/Shared/Supporting Files/Views/ContentView.swift
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import SwiftUI
-import ArcGIS
 
 struct ContentView: View {
     /// All samples retrieved from the Samples directory.


### PR DESCRIPTION
## Description

This PR removes extra `import ArcGIS` that aren't needed. They can be added back if we make future changes that use ArcGIS APIs.
