### PR TITLE
[Setup] Move issue reference to Swift repo

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,7 @@ URL to README:
 
 ## Linked Issue(s)
 
-- `common-samples/issues/`
+- `swift/issues/`
 
 ## How To Test
 


### PR DESCRIPTION
## Description

As we are moving samples issues back to home repo, update the issue ref in the template.