### PR TITLE
[Setup] Swap `AnyView` to `@ViewBuilder`

### DIFF
--- a/Scripts/GenerateSampleViewSourceCode.swift
+++ b/Scripts/GenerateSampleViewSourceCode.swift
@@ -112,7 +112,7 @@ private let sampleStructs = sampleMetadata
 private let sampleViewCases = sampleMetadata
     .map { sample in
         return """
-                case "\(sample.title)":
+                case is \(sample.structName):
                     \(sample.viewName)()
         """
     }

--- a/Scripts/GenerateSampleViewSourceCode.swift
+++ b/Scripts/GenerateSampleViewSourceCode.swift
@@ -104,27 +104,31 @@ private let sampleStructs = sampleMetadata
             var snippets: [String] { \(sample.snippets) }
             var tags: Set<String> { \(sample.keywords) }
             \(portalItemIDs.isEmpty ? "" : "var hasDependencies: Bool { true }\n")
-            func makeBody() -> AnyView { .init(\(sample.viewName)()) }
         }
         """
     }
     .joined(separator: "\n")
 
+private let sampleViewCases = sampleMetadata
+    .map { sample in
+        return """
+                case "\(sample.title)":
+                    \(sample.viewName)()
+        """
+    }
+    .joined(separator: "\n")
+
 private let entries = sampleMetadata
-    .map { sample in "\(sample.structName)()" }
-    .joined(separator: ",\n        ")
-private let arrayRepresentation = """
-    [
-            \(entries)
-        ]
-    """
+    .map { sample in "        \(sample.structName)()" }
+    .joined(separator: ",\n")
 
 do {
     let templateFile = try String(contentsOf: templateURL, encoding: .utf8)
     // Replaces the empty array code stub, i.e. [], with the array representation.
     let content = templateFile
-        .replacingOccurrences(of: "[/* samples */]", with: arrayRepresentation)
+        .replacingOccurrences(of: "/* samples */", with: entries)
         .replacingOccurrences(of: "/* structs */", with: sampleStructs)
+        .replacingOccurrences(of: "/* sample view cases */", with: sampleViewCases)
     try content.write(to: outputFileURL, atomically: true, encoding: .utf8)
 } catch {
     print("Error reading or writing template file: \(error.localizedDescription)")

--- a/Shared/SamplesApp+Samples.swift.tache
+++ b/Shared/SamplesApp+Samples.swift.tache
@@ -16,7 +16,21 @@ import SwiftUI
 
 extension SamplesApp {
     /// The samples for this app.
-    static let samples: [Sample] = [/* samples */]
+    static let samples: [Sample] = [
+/* samples */
+    ]
+}
+
+extension SampleDetailView {
+    /// The sample views for this app.
+    @ViewBuilder
+    func sampleView(for name: String?) -> some View {
+        switch name {
+/* sample view cases */
+        default:
+            EmptyView()
+        }
+    }
 }
 
 // MARK: Sample Structs

--- a/Shared/SamplesApp+Samples.swift.tache
+++ b/Shared/SamplesApp+Samples.swift.tache
@@ -24,8 +24,8 @@ extension SamplesApp {
 extension SampleDetailView {
     /// The sample views for this app.
     @ViewBuilder
-    func sampleView(for name: String?) -> some View {
-        switch name {
+    func view(for sample: Sample) -> some View {
+        switch sample {
 /* sample view cases */
         default:
             EmptyView()

--- a/Shared/SamplesApp+Samples.swift.tache
+++ b/Shared/SamplesApp+Samples.swift.tache
@@ -28,7 +28,7 @@ extension SampleDetailView {
         switch sample {
 /* sample view cases */
         default:
-            EmptyView()
+            fatalError("Unknown \(sample.name) sample view generated.")
         }
     }
 }

--- a/Shared/Supporting Files/Models/Sample.swift
+++ b/Shared/Supporting Files/Models/Sample.swift
@@ -30,9 +30,6 @@ protocol Sample {
     
     /// A Boolean value that indicates whether a sample has offline data dependencies.
     var hasDependencies: Bool { get }
-    
-    /// Creates the view for the sample.
-    func makeBody() -> AnyView
 }
 
 // MARK: Computed Variables

--- a/Shared/Supporting Files/Views/SampleDetailView.swift
+++ b/Shared/Supporting Files/Views/SampleDetailView.swift
@@ -58,7 +58,7 @@ struct SampleDetailView: View {
                         }
                         .padding()
                     case .downloaded:
-                        sampleView(for: sample.name)
+                        view(for: sample)
                     }
                 }
                 .task {
@@ -67,7 +67,7 @@ struct SampleDetailView: View {
                 }
             } else {
                 // 'onDemandResource' is not created in this branch.
-                sampleView(for: sample.name)
+                view(for: sample)
             }
         }
         .environment(\.isSampleInfoViewVisible, isSampleInfoViewVisible)

--- a/Shared/Supporting Files/Views/SampleDetailView.swift
+++ b/Shared/Supporting Files/Views/SampleDetailView.swift
@@ -58,7 +58,7 @@ struct SampleDetailView: View {
                         }
                         .padding()
                     case .downloaded:
-                        sample.makeBody()
+                        sampleView(for: sample.name)
                     }
                 }
                 .task {
@@ -67,7 +67,7 @@ struct SampleDetailView: View {
                 }
             } else {
                 // 'onDemandResource' is not created in this branch.
-                sample.makeBody()
+                sampleView(for: sample.name)
             }
         }
         .environment(\.isSampleInfoViewVisible, isSampleInfoViewVisible)


### PR DESCRIPTION
## Description

This PR proposes to remove `AnyView` and use `@ViewBuilder` instead, so that we don't need to deal with type-erased `AnyView` which Apple suggests against: https://developer.apple.com/videos/play/wwdc2021/10022/?time=701

## Linked Issue(s)

- `swift/issues/2300`

## How To Test

App works the same as before.

## To Discuss

See below