### PR TITLE
[Fix] `void_function_in_ternary` linter rule

### DIFF
--- a/Shared/Samples/Clip geometry/ClipGeometryView.swift
+++ b/Shared/Samples/Clip geometry/ClipGeometryView.swift
@@ -79,7 +79,11 @@ struct ClipGeometryView: View {
             .toolbar {
                 ToolbarItem(placement: .bottomBar) {
                     Button(geometriesAreClipped ? "Reset" : "Clip") {
-                        geometriesAreClipped ? reset() : clipGeometries()
+                        if geometriesAreClipped {
+                            reset()
+                        } else {
+                            clipGeometries()
+                        }
                         geometriesAreClipped.toggle()
                     }
                 }

--- a/Shared/Samples/Cut geometry/CutGeometryView.swift
+++ b/Shared/Samples/Cut geometry/CutGeometryView.swift
@@ -71,7 +71,11 @@ struct CutGeometryView: View {
             .toolbar {
                 ToolbarItem(placement: .bottomBar) {
                     Button(isGeometryCut ? "Reset" : "Cut") {
-                        isGeometryCut ? reset() : cutGeometry()
+                        if isGeometryCut {
+                            reset()
+                        } else {
+                            cutGeometry()
+                        }
                         isGeometryCut.toggle()
                     }
                 }


### PR DESCRIPTION
## Description

This PR fixes 2 linter rule violations. I'm using SwiftLint 0.49.1.

> Void Function in Ternary Violation: Using ternary to call Void functions should be avoided. (void_function_in_ternary)

## Linked Issue(s)

- https://github.com/realm/SwiftLint/issues/2358

## How To Test

Build without warning.
