### PR TITLE
[Update] Change accent color's dark variant

### DIFF
--- a/Shared/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/Shared/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -20,12 +20,12 @@
         }
       ],
       "color" : {
-        "color-space" : "display-p3",
+        "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.961",
-          "green" : "0.522",
-          "red" : "0.863"
+          "blue" : "0.987",
+          "green" : "0.501",
+          "red" : "0.918"
         }
       },
       "idiom" : "universal"


### PR DESCRIPTION
## Description

This PR fixes the accent color's dark variant. Previously it was not legible on a translucent toolbar. 

## Linked Issue(s)

- (Sarat) `swift/issues/3146`
- (Phil R) https://github.com/ArcGIS/arcgis-maps-sdk-swift-samples/pull/31#discussion_r931611419
- (David) https://github.com/ArcGIS/arcgis-maps-sdk-swift-samples/pull/66#issuecomment-1233569563

## How To Test

- Run the app in dark mode
- Go to any sample that has translucent background, e.g., toolbar, code picker, etc., to see if it makes your eyes happy

## To Discuss

Believe it or not, I got this color from Android's "material design"'s doc page! https://m2.material.io/design/color/dark-theme.html 🤖 