### PR TITLE
[Fix] `OfflineMapTask` instantiation pattern

### DIFF
--- a/Shared/Samples/Generate offline map/GenerateOfflineMapView.swift
+++ b/Shared/Samples/Generate offline map/GenerateOfflineMapView.swift
@@ -159,7 +159,7 @@ private extension GenerateOfflineMapView {
             do {
                 // Waits for the online map to load.
                 try await onlineMap.load()
-                offlineMapTask = OfflineMapTask(portalItem: napervillePortalItem)
+                offlineMapTask = OfflineMapTask(onlineMap: onlineMap)
                 isGenerateDisabled = false
             } catch {
                 self.error = error

--- a/Shared/Samples/Generate offline map/README.md
+++ b/Shared/Samples/Generate offline map/README.md
@@ -15,7 +15,7 @@ When the map loads, zoom to the extent you want to take offline. The red border 
 ## How it works
 
 1. Create a `Map` instance with a `PortalItem`.
-2. Create an `OfflineMapTask` instance with a `PortalItem`.
+2. Create an `OfflineMapTask` instance with the online map.
 3. Create `GenerateOfflineMapParameters` parameters for the offline map task with `OfflineMapTask.makeDefaultGenerateOfflineMapParameters(areaOfInterest:)`.
 4. Create a `GenerateOfflineMapJob` with `OfflineMapTask.makeGenerateOfflineMapJob(parameters:downloadDirectory:)`, using the parameters and specifying a download directory URL.
 5. Start the job and await its output.


### PR DESCRIPTION
## Description

This PR fixes `Generate offline map` to avoid 2 instances of a map. Please refer to the issues below for more details. Thanks @sbiswas96 !

## Linked Issue(s)

- `common-samples/issues/3808`
- `waverley/issues/2500`
- https://github.com/Esri/arcgis-runtime-samples-qt/pull/1553

## How To Test

- Sample still behaves the same
- README reads correctly 
