### PR TITLE
[Fix] `@unknown default` warnings

### DIFF
--- a/Shared/Samples/Set surface placement mode/SetSurfacePlacementModeView.swift
+++ b/Shared/Samples/Set surface placement mode/SetSurfacePlacementModeView.swift
@@ -187,6 +187,7 @@ private extension SurfacePlacement {
         case .drapedFlat: return "Draped Flat"
         case .relative: return "Relative"
         case .relativeToScene: return "Relative to Scene"
+        @unknown default: return "Unknown"
         }
     }
 }

--- a/Shared/Samples/Show device location/ShowDeviceLocationView.swift
+++ b/Shared/Samples/Show device location/ShowDeviceLocationView.swift
@@ -135,6 +135,7 @@ private extension LocationDisplay.AutoPanMode {
         case .recenter: return "Recenter"
         case .navigation: return "Navigation"
         case .compassNavigation: return "Compass Navigation"
+        @unknown default: return "Unknown"
         }
     }
     
@@ -145,6 +146,7 @@ private extension LocationDisplay.AutoPanMode {
         case .recenter: return "LocationDisplayDefaultIcon"
         case .navigation: return "LocationDisplayNavigationIcon"
         case .compassNavigation: return "LocationDisplayHeadingIcon"
+        @unknown default: return "LocationDisplayOffIcon"
         }
     }
 }


### PR DESCRIPTION
## Description

This PR fixes a binary framework only issue. See Zach's comment here: https://github.com/Esri/arcgis-maps-sdk-swift-samples/pull/101#pullrequestreview-1214446015

## Linked Issue(s)

See: https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/issues/214

## How To Test

Build with binary framework and it doesn't show more unknown default warnings.
