### PR TITLE
[Fix] Remove multi-word proper nouns from status checker script

### DIFF
--- a/Scripts/CI/common.py
+++ b/Scripts/CI/common.py
@@ -23,13 +23,10 @@ from typing import List, Set
 # A set of words that get omitted during letter-case checks.
 # This set will be updated when a special word appears in a new sample.
 exception_proper_nouns = {
-    'ArcGIS Online',
-    'ArcGIS Pro',
     'GeoPackage',
     'OAuth',
     'OpenStreetMap',
-    'SwiftUI',
-    'Web Mercator'
+    'SwiftUI'
 }
 
 # A set of category folder names for legacy support.


### PR DESCRIPTION
## Description

This PR updates the CI script's exception proper noun list. In the current script logic, these cases won't be hit.

## Linked Issue(s)

- `common-samples/pull/3811`

## How To Test

No need to test. It will give error in the status check in the future if I made it wrong. 😏 
