### PR TITLE
[Update] Use model to manage geo view and data

### DIFF
--- a/Shared/Samples/Add feature layers/AddFeatureLayersView.swift
+++ b/Shared/Samples/Add feature layers/AddFeatureLayersView.swift
@@ -79,7 +79,7 @@ private struct ChallengeHandler: AuthenticationChallengeHandler {
 }
 
 private extension AddFeatureLayersView {
-    private class Model: ObservableObject {
+    class Model: ObservableObject {
         /// A map with a topographic basemap style.
         let map = Map(basemapStyle: .arcGISTopographic)
         

--- a/Shared/Samples/Add feature layers/AddFeatureLayersView.swift
+++ b/Shared/Samples/Add feature layers/AddFeatureLayersView.swift
@@ -79,6 +79,8 @@ private struct ChallengeHandler: AuthenticationChallengeHandler {
 }
 
 private extension AddFeatureLayersView {
+    /// The model used to store the geo model and other expensive objects
+    /// used in this view.
     class Model: ObservableObject {
         /// A map with a topographic basemap style.
         let map = Map(basemapStyle: .arcGISTopographic)

--- a/Shared/Samples/Add feature layers/AddFeatureLayersView.swift
+++ b/Shared/Samples/Add feature layers/AddFeatureLayersView.swift
@@ -19,135 +19,39 @@ struct AddFeatureLayersView: View {
     /// A Boolean value indicating whether to show an alert.
     @State private var isShowingAlert = false
     
-    /// The error shown in the alert.
-    @State private var error: Error? {
-        didSet { isShowingAlert = error != nil }
-    }
-    
-    /// The feature layer source that is displayed.
-    @State private var selectedFeatureLayerSource: FeatureLayerSource = .serviceFeatureTable
-    
     /// The current viewpoint of the map view.
     @State private var viewpoint: Viewpoint?
     
-    /// The geodatabase used to create the feature layer.
-    @State private var geodatabase: Geodatabase!
-    
-    /// The GeoPackage used to create the feature layer.
-    @State private var geoPackage: GeoPackage!
-    
-    /// A map with a topographic basemap style.
-    @StateObject private var map = Map(basemapStyle: .arcGISTopographic)
-    
-    /// Loads a feature layer with a service feature table.
-    private func loadServiceFeatureTable() {
-        // Creates a service feature table from a feature service.
-        let featureTable = ServiceFeatureTable(url: .damageAssessment)
-        let featureLayer = FeatureLayer(featureTable: featureTable)
-        setFeatureLayer(featureLayer, viewpoint: .napervilleIL)
-    }
-    
-    /// Loads a feature layer with a portal item.
-    private func loadPortalItemFeatureTable() {
-        let featureLayer = FeatureLayer(
-            item: PortalItem(
-                portal: .arcGISOnline(connection: .anonymous),
-                id: .treesOfPortland
-            )
-        )
-        setFeatureLayer(featureLayer, viewpoint: .portlandOR)
-    }
-    
-    /// Loads a feature layer with a local geodatabase.
-    private func loadGeodatabaseFeatureTable() async throws {
-        // Loads the geodatabase if it does not exist.
-        if geodatabase == nil {
-            geodatabase = Geodatabase(fileURL: .laTrails)
-            try await geodatabase.load()
-        }
-        // Creates a feature layer from the geodatabase's feature table and
-        // sets the current feature layer to it.
-        let featureTable = geodatabase.featureTable(named: "Trailheads")!
-        let featureLayer = FeatureLayer(featureTable: featureTable)
-        setFeatureLayer(featureLayer, viewpoint: .losAngelesCA)
-    }
-    
-    /// Loads a feature layer with a local GeoPackage.
-    private func loadGeoPackageFeatureTable() async throws {
-        // Loads the GeoPackage if it does not exist.
-        if geoPackage == nil {
-            geoPackage = GeoPackage(fileURL: .auroraCO)
-            try await geoPackage.load()
-        }
-        // Creates a feature layer from the GeoPackage's feature tables and
-        // sets the current feature layer to the first one.
-        let featureTable = geoPackage.featureTables.first!
-        let featureLayer = FeatureLayer(featureTable: featureTable)
-        setFeatureLayer(featureLayer, viewpoint: .auroraCO)
-    }
-    
-    /// Loads a feature layer with a local shapefile.
-    private func loadShapefileFeatureTable() {
-        let shapefileFeatureTable = ShapefileFeatureTable(fileURL: .reserveBoundaries)
-        let featureLayer = FeatureLayer(featureTable: shapefileFeatureTable)
-        setFeatureLayer(featureLayer, viewpoint: .scotland)
-    }
-    
-    /// Sets the map's operational layers to the given feature layer and updates the current viewpoint.
-    private func setFeatureLayer(_ featureLayer: FeatureLayer, viewpoint: Viewpoint) {
-        // Updates the map's operational layers.
-        map.removeAllOperationalLayers()
-        map.addOperationalLayer(featureLayer)
-        // Updates the current viewpoint.
-        self.viewpoint = viewpoint
-    }
-    
-    /// Updates the feature layer to reflect the source chosen by the user.
-    private func updateFeatureLayer() async {
-        do {
-            switch selectedFeatureLayerSource {
-            case .serviceFeatureTable:
-                loadServiceFeatureTable()
-            case .portalItem:
-                loadPortalItemFeatureTable()
-            case .geodatabase:
-                try await loadGeodatabaseFeatureTable()
-            case .geoPackage:
-                try await loadGeoPackageFeatureTable()
-            case .shapefile:
-                loadShapefileFeatureTable()
-            }
-        } catch {
-            // Updates the error and shows an alert if any failures occur.
-            self.error = error
-        }
-    }
+    /// The view model for the sample.
+    @StateObject private var model = Model()
     
     var body: some View {
-        MapView(map: map, viewpoint: viewpoint)
+        MapView(map: model.map, viewpoint: viewpoint)
             .onViewpointChanged(kind: .centerAndScale) { viewpoint = $0 }
             .toolbar {
                 ToolbarItem(placement: .bottomBar) {
-                    Picker("Feature Layer", selection: $selectedFeatureLayerSource) {
+                    Picker("Feature Layer", selection: $model.selectedFeatureLayerSource) {
                         ForEach(FeatureLayerSource.allCases, id: \.self) { source in
                             Text(source.label)
                         }
                     }
-                    .task(id: selectedFeatureLayerSource) {
+                    .task(id: model.selectedFeatureLayerSource) {
                         // Loads the selected feature layer.
-                        await updateFeatureLayer()
+                        await model.updateFeatureLayer()
+                        viewpoint = model.featureLayerViewpoint
+                        isShowingAlert = model.error != nil
                     }
                 }
             }
-            .alert(isPresented: $isShowingAlert, presentingError: error)
+            .alert(isPresented: $isShowingAlert, presentingError: model.error)
             .onAppear {
                 // Updates the URL session challenge handler to use the
                 // specified credentials and tokens for any challenges.
-                ArcGISEnvironment.authenticationChallengeHandler = ChallengeHandler()
+                ArcGISEnvironment.authenticationManager.authenticationChallengeHandler = ChallengeHandler()
             }
             .onDisappear {
                 // Resets the URL session challenge handler to use default handling.
-                ArcGISEnvironment.authenticationChallengeHandler = nil
+                ArcGISEnvironment.authenticationManager.authenticationChallengeHandler = nil
             }
     }
 }
@@ -160,8 +64,115 @@ private struct ChallengeHandler: AuthenticationChallengeHandler {
         // NOTE: Never hardcode login information in a production application.
         // This is done solely for the sake of the sample.
         return .continueWithCredential(
-            try await .token(challenge: challenge, username: "viewer01", password: "I68VGU^nMurF")
+            try await TokenCredential.credential(for: challenge, username: "viewer01", password: "I68VGU^nMurF")
         )
+    }
+}
+
+private extension AddFeatureLayersView {
+    private class Model: ObservableObject {
+        /// A map with a topographic basemap style.
+        let map = Map(basemapStyle: .arcGISTopographic)
+        
+        /// The geodatabase used to create the feature layer.
+        private var geodatabase: Geodatabase!
+        
+        /// The GeoPackage used to create the feature layer.
+        private var geoPackage: GeoPackage!
+        
+        /// An error when loading a feature layer.
+        var error: Error?
+        
+        /// The viewpoint for a specific feature layer.
+        var featureLayerViewpoint: Viewpoint?
+        
+        /// The feature layer source that is displayed.
+        @Published var selectedFeatureLayerSource: FeatureLayerSource = .serviceFeatureTable
+        
+        /// Loads a feature layer with a service feature table.
+        private func loadServiceFeatureTable() {
+            // Creates a service feature table from a feature service.
+            let featureTable = ServiceFeatureTable(url: .damageAssessment)
+            let featureLayer = FeatureLayer(featureTable: featureTable)
+            setFeatureLayer(featureLayer, viewpoint: .napervilleIL)
+        }
+        
+        /// Loads a feature layer with a portal item.
+        private func loadPortalItemFeatureTable() {
+            let featureLayer = FeatureLayer(
+                item: PortalItem(
+                    portal: .arcGISOnline(connection: .anonymous),
+                    id: .treesOfPortland
+                )
+            )
+            setFeatureLayer(featureLayer, viewpoint: .portlandOR)
+        }
+        
+        /// Loads a feature layer with a local geodatabase.
+        private func loadGeodatabaseFeatureTable() async throws {
+            // Loads the geodatabase if it does not exist.
+            if geodatabase == nil {
+                geodatabase = Geodatabase(fileURL: .laTrails)
+                try await geodatabase.load()
+            }
+            // Creates a feature layer from the geodatabase's feature table and
+            // sets the current feature layer to it.
+            let featureTable = geodatabase.featureTable(named: "Trailheads")!
+            let featureLayer = FeatureLayer(featureTable: featureTable)
+            setFeatureLayer(featureLayer, viewpoint: .losAngelesCA)
+        }
+        
+        /// Loads a feature layer with a local GeoPackage.
+        private func loadGeoPackageFeatureTable() async throws {
+            // Loads the GeoPackage if it does not exist.
+            if geoPackage == nil {
+                geoPackage = GeoPackage(fileURL: .auroraCO)
+                try await geoPackage.load()
+            }
+            // Creates a feature layer from the GeoPackage's feature tables and
+            // sets the current feature layer to the first one.
+            let featureTable = geoPackage.featureTables.first!
+            let featureLayer = FeatureLayer(featureTable: featureTable)
+            setFeatureLayer(featureLayer, viewpoint: .auroraCO)
+        }
+        
+        /// Loads a feature layer with a local shapefile.
+        private func loadShapefileFeatureTable() {
+            let shapefileFeatureTable = ShapefileFeatureTable(fileURL: .reserveBoundaries)
+            let featureLayer = FeatureLayer(featureTable: shapefileFeatureTable)
+            setFeatureLayer(featureLayer, viewpoint: .scotland)
+        }
+        
+        /// Sets the map's operational layers to the given feature layer and updates the current viewpoint.
+        private func setFeatureLayer(_ featureLayer: FeatureLayer, viewpoint: Viewpoint) {
+            // Updates the map's operational layers.
+            map.removeAllOperationalLayers()
+            map.addOperationalLayer(featureLayer)
+            // Updates the current viewpoint.
+            featureLayerViewpoint = viewpoint
+        }
+        
+        /// Updates the feature layer to reflect the source chosen by the user.
+        func updateFeatureLayer() async {
+            do {
+                switch selectedFeatureLayerSource {
+                case .serviceFeatureTable:
+                    loadServiceFeatureTable()
+                case .portalItem:
+                    loadPortalItemFeatureTable()
+                case .geodatabase:
+                    try await loadGeodatabaseFeatureTable()
+                case .geoPackage:
+                    try await loadGeoPackageFeatureTable()
+                case .shapefile:
+                    loadShapefileFeatureTable()
+                }
+                self.error = nil
+            } catch {
+                // Updates the error and shows an alert if any failures occur.
+                self.error = error
+            }
+        }
     }
 }
 

--- a/Shared/Samples/Add feature layers/AddFeatureLayersView.swift
+++ b/Shared/Samples/Add feature layers/AddFeatureLayersView.swift
@@ -105,7 +105,7 @@ private extension AddFeatureLayersView {
         }
         
         /// Loads a feature layer with a portal item.
-        private func loadPortalItemFeatureTable() async throws  {
+        private func loadPortalItemFeatureTable() async throws {
             let portalItem = PortalItem(
                 portal: .arcGISOnline(connection: .anonymous),
                 id: .treesOfPortland
@@ -144,7 +144,7 @@ private extension AddFeatureLayersView {
         }
         
         /// Loads a feature layer with a local shapefile.
-        private func loadShapefileFeatureTable() async throws  {
+        private func loadShapefileFeatureTable() async throws {
             let shapefileFeatureTable = ShapefileFeatureTable(fileURL: .reserveBoundaries)
             try await shapefileFeatureTable.load()
             let featureLayer = FeatureLayer(featureTable: shapefileFeatureTable)

--- a/Shared/Samples/Add raster from file/AddRasterFromFileView.swift
+++ b/Shared/Samples/Add raster from file/AddRasterFromFileView.swift
@@ -16,23 +16,25 @@ import ArcGIS
 import SwiftUI
 
 struct AddRasterFromFileView: View {
-    /// Makes a map with a raster layer.
-    private static func makeMap() -> Map {
-        /// A map with a standard imagery basemap style.
-        let map = Map(basemapStyle: .arcGISImageryStandard)
-        // Gets the Shasta.tif file URL.
-        let shastaURL = Bundle.main.url(forResource: "Shasta", withExtension: "tif", subdirectory: "raster-file/raster-file")!
-        // Creates a raster with the file URL.
-        let raster = Raster(fileURL: shastaURL)
-        // Creates a raster layer using the raster object.
-        let rasterLayer = RasterLayer(raster: raster)
-        // Adds the raster layer to the map's operational layer.
-        map.addOperationalLayer(rasterLayer)
-        return map
+    private class Model: ObservableObject {
+        /// A map with imagery basemap and a raster layer.
+        let map: Map = {
+            /// A map with a standard imagery basemap style.
+            let map = Map(basemapStyle: .arcGISImageryStandard)
+            // Gets the Shasta.tif file URL.
+            let shastaURL = Bundle.main.url(forResource: "Shasta", withExtension: "tif", subdirectory: "raster-file/raster-file")!
+            // Creates a raster with the file URL.
+            let raster = Raster(fileURL: shastaURL)
+            // Creates a raster layer using the raster object.
+            let rasterLayer = RasterLayer(raster: raster)
+            // Adds the raster layer to the map's operational layer.
+            map.addOperationalLayer(rasterLayer)
+            return map
+        }()
     }
     
-    /// A map with a standard imagery basemap style.
-    @StateObject private var map = makeMap()
+    /// The view model for the sample.
+    @StateObject private var model = Model()
     
     /// A Boolean value indicating whether to show an alert.
     @State private var isShowingAlert = false
@@ -47,12 +49,12 @@ struct AddRasterFromFileView: View {
     
     var body: some View {
         // Creates a map view with a viewpoint to display the map.
-        MapView(map: map, viewpoint: viewpoint)
+        MapView(map: model.map, viewpoint: viewpoint)
             .onViewpointChanged(kind: .centerAndScale) { viewpoint = $0 }
             .alert(isPresented: $isShowingAlert, presentingError: error)
             .task {
                 do {
-                    let rasterLayer = map.operationalLayers.first!
+                    let rasterLayer = model.map.operationalLayers.first!
                     try await rasterLayer.load()
                     viewpoint = Viewpoint(center: rasterLayer.fullExtent!.center, scale: 8e4)
                 } catch {

--- a/Shared/Samples/Add raster from file/AddRasterFromFileView.swift
+++ b/Shared/Samples/Add raster from file/AddRasterFromFileView.swift
@@ -18,7 +18,9 @@ import SwiftUI
 struct AddRasterFromFileView: View {
     private class Model: ObservableObject {
         /// A map with imagery basemap and a raster layer.
-        let map: Map = {
+        let map: Map
+        
+        init() {
             /// A map with a standard imagery basemap style.
             let map = Map(basemapStyle: .arcGISImageryStandard)
             // Gets the Shasta.tif file URL.
@@ -29,8 +31,8 @@ struct AddRasterFromFileView: View {
             let rasterLayer = RasterLayer(raster: raster)
             // Adds the raster layer to the map's operational layer.
             map.addOperationalLayer(rasterLayer)
-            return map
-        }()
+            self.map = map
+        }
     }
     
     /// The view model for the sample.

--- a/Shared/Samples/Add raster from file/AddRasterFromFileView.swift
+++ b/Shared/Samples/Add raster from file/AddRasterFromFileView.swift
@@ -18,21 +18,7 @@ import SwiftUI
 struct AddRasterFromFileView: View {
     private class Model: ObservableObject {
         /// A map with imagery basemap and a raster layer.
-        let map: Map
-        
-        init() {
-            /// A map with a standard imagery basemap style.
-            let map = Map(basemapStyle: .arcGISImageryStandard)
-            // Gets the Shasta.tif file URL.
-            let shastaURL = Bundle.main.url(forResource: "Shasta", withExtension: "tif", subdirectory: "raster-file/raster-file")!
-            // Creates a raster with the file URL.
-            let raster = Raster(fileURL: shastaURL)
-            // Creates a raster layer using the raster object.
-            let rasterLayer = RasterLayer(raster: raster)
-            // Adds the raster layer to the map's operational layer.
-            map.addOperationalLayer(rasterLayer)
-            self.map = map
-        }
+        let map = Map(basemapStyle: .arcGISImageryStandard)
     }
     
     /// The view model for the sample.
@@ -56,8 +42,15 @@ struct AddRasterFromFileView: View {
             .alert(isPresented: $isShowingAlert, presentingError: error)
             .task {
                 do {
-                    let rasterLayer = model.map.operationalLayers.first!
+                    // Gets the Shasta.tif file URL.
+                    let shastaURL = Bundle.main.url(forResource: "Shasta", withExtension: "tif", subdirectory: "raster-file/raster-file")!
+                    // Creates a raster with the file URL.
+                    let raster = Raster(fileURL: shastaURL)
+                    // Creates a raster layer using the raster object.
+                    let rasterLayer = RasterLayer(raster: raster)
                     try await rasterLayer.load()
+                    // Adds the raster layer to the map's operational layer.
+                    model.map.addOperationalLayer(rasterLayer)
                     viewpoint = Viewpoint(center: rasterLayer.fullExtent!.center, scale: 8e4)
                 } catch {
                     // Presents an error message if the raster fails to load.

--- a/Shared/Samples/Add raster from file/AddRasterFromFileView.swift
+++ b/Shared/Samples/Add raster from file/AddRasterFromFileView.swift
@@ -16,6 +16,8 @@ import ArcGIS
 import SwiftUI
 
 struct AddRasterFromFileView: View {
+    /// The model used to store the geo model and other expensive objects
+    /// used in this view.
     private class Model: ObservableObject {
         /// A map with imagery basemap and a raster layer.
         let map = Map(basemapStyle: .arcGISImageryStandard)

--- a/Shared/Samples/Add raster from file/AddRasterFromFileView.swift
+++ b/Shared/Samples/Add raster from file/AddRasterFromFileView.swift
@@ -43,6 +43,7 @@ struct AddRasterFromFileView: View {
             .onViewpointChanged(kind: .centerAndScale) { viewpoint = $0 }
             .alert(isPresented: $isShowingAlert, presentingError: error)
             .task {
+                guard model.map.operationalLayers.isEmpty else { return }
                 do {
                     // Gets the Shasta.tif file URL.
                     let shastaURL = Bundle.main.url(forResource: "Shasta", withExtension: "tif", subdirectory: "raster-file/raster-file")!

--- a/Shared/Samples/Add scene layer from service/AddSceneLayerFromServiceView.swift
+++ b/Shared/Samples/Add scene layer from service/AddSceneLayerFromServiceView.swift
@@ -25,6 +25,8 @@ struct AddSceneLayerFromServiceView: View {
 }
 
 private extension AddSceneLayerFromServiceView {
+    /// The model used to store the geo model and other expensive objects
+    /// used in this view.
     class Model: ObservableObject {
         let scene: ArcGIS.Scene = {
             // Creates a scene and sets an initial viewpoint.

--- a/Shared/Samples/Add scene layer from service/AddSceneLayerFromServiceView.swift
+++ b/Shared/Samples/Add scene layer from service/AddSceneLayerFromServiceView.swift
@@ -24,8 +24,8 @@ struct AddSceneLayerFromServiceView: View {
     }
 }
 
-extension AddSceneLayerFromServiceView {
-    private class Model: ObservableObject {
+private extension AddSceneLayerFromServiceView {
+    class Model: ObservableObject {
         let scene: ArcGIS.Scene = {
             // Creates a scene and sets an initial viewpoint.
             let scene = Scene(basemapStyle: .arcGISTopographic)

--- a/Shared/Samples/Browse building floors/BrowseBuildingFloorsView.swift
+++ b/Shared/Samples/Browse building floors/BrowseBuildingFloorsView.swift
@@ -34,6 +34,8 @@ struct BrowseBuildingFloorsView: View {
     /// A Boolean value indicating whether the map is loaded.
     @State private var isMapLoaded = false
     
+    /// The model used to store the geo model and other expensive objects
+    /// used in this view.
     private class Model: ObservableObject {
         /// A floor-aware web map of Building L on the Esri Redlands campus.
         let map = Map(

--- a/Shared/Samples/Browse building floors/BrowseBuildingFloorsView.swift
+++ b/Shared/Samples/Browse building floors/BrowseBuildingFloorsView.swift
@@ -34,23 +34,28 @@ struct BrowseBuildingFloorsView: View {
     /// A Boolean value indicating whether the map is loaded.
     @State private var isMapLoaded = false
     
-    /// A floor-aware web map of Building L on the Esri Redlands campus.
-    @StateObject private var map = Map(
-        item: PortalItem(
-            portal: .arcGISOnline(connection: .anonymous),
-            id: .esriBuildingL
+    private class Model: ObservableObject {
+        /// A floor-aware web map of Building L on the Esri Redlands campus.
+        let map = Map(
+            item: PortalItem(
+                portal: .arcGISOnline(connection: .anonymous),
+                id: .esriBuildingL
+            )
         )
-    )
+    }
+    
+    /// The view model for the sample.
+    @StateObject private var model = Model()
     
     var body: some View {
-        MapView(map: map)
+        MapView(map: model.map)
             .onViewpointChanged(kind: .centerAndScale) { viewpoint = $0 }
             .onNavigatingChanged { isMapNavigating = $0 }
             .alert(isPresented: $isShowingAlert, presentingError: error)
             .ignoresSafeArea(.keyboard, edges: .bottom)
             .overlay(alignment: .bottomTrailing) {
                 if isMapLoaded,
-                   let floorManager = map.floorManager {
+                   let floorManager = model.map.floorManager {
                     FloorFilter(
                         floorManager: floorManager,
                         alignment: .bottomTrailing,
@@ -67,7 +72,7 @@ struct BrowseBuildingFloorsView: View {
             }
             .task {
                 do {
-                    try await map.load()
+                    try await model.map.load()
                     isMapLoaded = true
                 } catch {
                     self.error = error

--- a/Shared/Samples/Clip geometry/ClipGeometryView.swift
+++ b/Shared/Samples/Clip geometry/ClipGeometryView.swift
@@ -23,7 +23,7 @@ struct ClipGeometryView: View {
     @StateObject private var model = Model()
     
     var body: some View {
-        MapView(map: model.map, graphicsOverlays: [model.coloradoGraphicsOverlay, model.envelopesGraphicsOverlay, model.clippedGraphicsOverlay])
+        MapView(map: model.map, graphicsOverlays: model.graphicsOverlays)
             .toolbar {
                 ToolbarItem(placement: .bottomBar) {
                     Button(geometriesAreClipped ? "Reset" : "Clip") {
@@ -50,24 +50,29 @@ private extension ClipGeometryView {
         }()
         
         /// The graphics overlay containing an unclipped graphic of Colorado.
-        var coloradoGraphicsOverlay = GraphicsOverlay(
+        private var coloradoGraphicsOverlay = GraphicsOverlay(
             graphics: [
                 Graphic(geometry: .coloradoEnvelope, symbol: .coloradoFill)
             ]
         )
         
         /// The graphics overlay containing graphics of the other envelopes, outlined by a dotted red line.
-        var envelopesGraphicsOverlay = GraphicsOverlay(
+        private var envelopesGraphicsOverlay = GraphicsOverlay(
             graphics: Geometry.envelopes.map {
                 Graphic(geometry: $0, symbol: SimpleLineSymbol(style: .dot, color: .red, width: 3))
             }
         )
         
         /// The graphics overlay containing clipped graphics.
-        var clippedGraphicsOverlay = GraphicsOverlay()
+        private var clippedGraphicsOverlay = GraphicsOverlay()
         
         /// The unclipped graphic of Colorado.
         private var coloradoGraphic: Graphic { coloradoGraphicsOverlay.graphics.first! }
+        
+        /// The graphics overlays used in this sample.
+        var graphicsOverlays: [GraphicsOverlay] {
+            return [coloradoGraphicsOverlay, envelopesGraphicsOverlay, clippedGraphicsOverlay]
+        }
         
         /// Clips the geometry of Colorado to the given envelope.
         /// - Parameter envelope: The envelope to clip the geometry of Colorado to.

--- a/Shared/Samples/Clip geometry/ClipGeometryView.swift
+++ b/Shared/Samples/Clip geometry/ClipGeometryView.swift
@@ -40,6 +40,8 @@ struct ClipGeometryView: View {
 }
 
 private extension ClipGeometryView {
+    /// The model used to store the geo model and other expensive objects
+    /// used in this view.
     class Model: ObservableObject {
         /// A map with a topographic basemap style and an initial viewpoint of Colorado.
         let map: Map = {

--- a/Shared/Samples/Clip geometry/ClipGeometryView.swift
+++ b/Shared/Samples/Clip geometry/ClipGeometryView.swift
@@ -50,21 +50,21 @@ private extension ClipGeometryView {
         }()
         
         /// The graphics overlay containing an unclipped graphic of Colorado.
-        private var coloradoGraphicsOverlay = GraphicsOverlay(
+        private let coloradoGraphicsOverlay = GraphicsOverlay(
             graphics: [
                 Graphic(geometry: .coloradoEnvelope, symbol: .coloradoFill)
             ]
         )
         
         /// The graphics overlay containing graphics of the other envelopes, outlined by a dotted red line.
-        private var envelopesGraphicsOverlay = GraphicsOverlay(
+        private let envelopesGraphicsOverlay = GraphicsOverlay(
             graphics: Geometry.envelopes.map {
                 Graphic(geometry: $0, symbol: SimpleLineSymbol(style: .dot, color: .red, width: 3))
             }
         )
         
         /// The graphics overlay containing clipped graphics.
-        private var clippedGraphicsOverlay = GraphicsOverlay()
+        private let clippedGraphicsOverlay = GraphicsOverlay()
         
         /// The unclipped graphic of Colorado.
         private var coloradoGraphic: Graphic { coloradoGraphicsOverlay.graphics.first! }

--- a/Shared/Samples/Clip geometry/ClipGeometryView.swift
+++ b/Shared/Samples/Clip geometry/ClipGeometryView.swift
@@ -19,75 +19,82 @@ struct ClipGeometryView: View {
     /// A Boolean value indicating whether the geometries are clipped.
     @State private var geometriesAreClipped = false
     
-    /// A map with a topographic basemap style and an initial viewpoint of Colorado.
-    @StateObject private var map: Map = {
-        let map = Map(basemapStyle: .arcGISTopographic)
-        // Sets the initial viewpoint to Colorado and adds additional padding.
-        map.initialViewpoint = Viewpoint(targetExtent: .coloradoEnvelope.expanded(by: 2))
-        return map
-    }()
-    
-    /// The graphics overlay containing an unclipped graphic of Colorado.
-    @StateObject private var coloradoGraphicsOverlay = GraphicsOverlay(
-        graphics: [
-            Graphic(geometry: .coloradoEnvelope, symbol: .coloradoFill)
-        ]
-    )
-    
-    /// The graphics overlay containing graphics of the other envelopes, outlined by a dotted red line.
-    @StateObject private var envelopesGraphicsOverlay = GraphicsOverlay(
-        graphics: Geometry.envelopes.map {
-            Graphic(geometry: $0, symbol: SimpleLineSymbol(style: .dot, color: .red, width: 3))
-        }
-    )
-    
-    /// The graphics overlay containing clipped graphics.
-    @StateObject private var clippedGraphicsOverlay = GraphicsOverlay()
-    
-    /// The unclipped graphic of Colorado.
-    private var coloradoGraphic: Graphic { coloradoGraphicsOverlay.graphics.first! }
-    
-    /// Clips the geometry of Colorado to the given envelope.
-    /// - Parameter envelope: The envelope to clip the geometry of Colorado to.
-    /// - Returns: The clipped graphic.
-    private func clipColoradoGeometry(to envelope: Envelope) -> Graphic {
-        // Uses the geometry engine to create a new geometry for the area of
-        // Colorado that overlaps the given envelope.
-        let clippedGeometry = GeometryEngine.clip(coloradoGraphic.geometry!, to: envelope)
-        // Creates and returns the clipped graphic from the clipped geometry if there is an overlap.
-        return Graphic(geometry: clippedGeometry, symbol: .coloradoFill)
-    }
-    
-    /// Clips geometries and adds resulting graphics.
-    private func clipGeometries() {
-        // Hides the Colorado graphic.
-        coloradoGraphic.isVisible = false
-        // Clips Colorado's geometry to each envelope.
-        let clippedGraphics = envelopesGraphicsOverlay.graphics.map { clipColoradoGeometry(to: $0.geometry as! Envelope) }
-        // Adds the clipped graphics.
-        clippedGraphicsOverlay.addGraphics(clippedGraphics)
-    }
-    
-    /// Removes all clipped graphics.
-    private func reset() {
-        clippedGraphicsOverlay.removeAllGraphics()
-        coloradoGraphic.isVisible = true
-    }
+    /// The view model for the sample.
+    @StateObject private var model = Model()
     
     var body: some View {
-        MapView(map: map, graphicsOverlays: [coloradoGraphicsOverlay, envelopesGraphicsOverlay, clippedGraphicsOverlay])
+        MapView(map: model.map, graphicsOverlays: [model.coloradoGraphicsOverlay, model.envelopesGraphicsOverlay, model.clippedGraphicsOverlay])
             .toolbar {
                 ToolbarItem(placement: .bottomBar) {
                     Button(geometriesAreClipped ? "Reset" : "Clip") {
                         if geometriesAreClipped {
-                            reset()
+                            model.reset()
                         } else {
-                            clipGeometries()
+                            model.clipGeometries()
                         }
                         geometriesAreClipped.toggle()
                     }
                 }
             }
+    }
+}
+
+private extension ClipGeometryView {
+    private class Model: ObservableObject {
+        /// A map with a topographic basemap style and an initial viewpoint of Colorado.
+        let map: Map = {
+            let map = Map(basemapStyle: .arcGISTopographic)
+            // Sets the initial viewpoint to Colorado and adds additional padding.
+            map.initialViewpoint = Viewpoint(targetExtent: .coloradoEnvelope.expanded(by: 2))
+            return map
+        }()
+        
+        /// The graphics overlay containing an unclipped graphic of Colorado.
+        var coloradoGraphicsOverlay = GraphicsOverlay(
+            graphics: [
+                Graphic(geometry: .coloradoEnvelope, symbol: .coloradoFill)
+            ]
+        )
+        
+        /// The graphics overlay containing graphics of the other envelopes, outlined by a dotted red line.
+        var envelopesGraphicsOverlay = GraphicsOverlay(
+            graphics: Geometry.envelopes.map {
+                Graphic(geometry: $0, symbol: SimpleLineSymbol(style: .dot, color: .red, width: 3))
+            }
+        )
+        
+        /// The graphics overlay containing clipped graphics.
+        var clippedGraphicsOverlay = GraphicsOverlay()
+        
+        /// The unclipped graphic of Colorado.
+        private var coloradoGraphic: Graphic { coloradoGraphicsOverlay.graphics.first! }
+        
+        /// Clips the geometry of Colorado to the given envelope.
+        /// - Parameter envelope: The envelope to clip the geometry of Colorado to.
+        /// - Returns: The clipped graphic.
+        private func clipColoradoGeometry(to envelope: Envelope) -> Graphic {
+            // Uses the geometry engine to create a new geometry for the area of
+            // Colorado that overlaps the given envelope.
+            let clippedGeometry = GeometryEngine.clip(coloradoGraphic.geometry!, to: envelope)
+            // Creates and returns the clipped graphic from the clipped geometry if there is an overlap.
+            return Graphic(geometry: clippedGeometry, symbol: .coloradoFill)
+        }
+        
+        /// Clips geometries and adds resulting graphics.
+        func clipGeometries() {
+            // Hides the Colorado graphic.
+            coloradoGraphic.isVisible = false
+            // Clips Colorado's geometry to each envelope.
+            let clippedGraphics = envelopesGraphicsOverlay.graphics.map { clipColoradoGeometry(to: $0.geometry as! Envelope) }
+            // Adds the clipped graphics.
+            clippedGraphicsOverlay.addGraphics(clippedGraphics)
+        }
+        
+        /// Removes all clipped graphics.
+        func reset() {
+            clippedGraphicsOverlay.removeAllGraphics()
+            coloradoGraphic.isVisible = true
+        }
     }
 }
 

--- a/Shared/Samples/Clip geometry/ClipGeometryView.swift
+++ b/Shared/Samples/Clip geometry/ClipGeometryView.swift
@@ -40,7 +40,7 @@ struct ClipGeometryView: View {
 }
 
 private extension ClipGeometryView {
-    private class Model: ObservableObject {
+    class Model: ObservableObject {
         /// A map with a topographic basemap style and an initial viewpoint of Colorado.
         let map: Map = {
             let map = Map(basemapStyle: .arcGISTopographic)

--- a/Shared/Samples/Create planar and geodetic buffers/CreatePlanarAndGeodeticBuffersView.swift
+++ b/Shared/Samples/Create planar and geodetic buffers/CreatePlanarAndGeodeticBuffersView.swift
@@ -123,6 +123,9 @@ private extension CreatePlanarAndGeodeticBuffersView {
         }
         
         /// Adds a buffer at a given point.
+        /// - Parameters:
+        ///   - point: The center of the new buffer.
+        ///   - bufferDistance: The radius of the new buffer.
         func addBuffer(at point: Point, bufferDistance: Measurement<UnitLength>) {
             // Converts the buffer distance to meters.
             let bufferRadiusInMeters = bufferDistance.converted(to: .meters).value

--- a/Shared/Samples/Create planar and geodetic buffers/CreatePlanarAndGeodeticBuffersView.swift
+++ b/Shared/Samples/Create planar and geodetic buffers/CreatePlanarAndGeodeticBuffersView.swift
@@ -70,6 +70,8 @@ struct CreatePlanarAndGeodeticBuffersView: View {
 }
 
 private extension CreatePlanarAndGeodeticBuffersView {
+    /// The model used to store the geo model and other expensive objects
+    /// used in this view.
     class Model: ObservableObject {
         /// A map with a topographic basemap style.
         let map = Map(basemapStyle: .arcGISTopographic)

--- a/Shared/Samples/Create planar and geodetic buffers/CreatePlanarAndGeodeticBuffersView.swift
+++ b/Shared/Samples/Create planar and geodetic buffers/CreatePlanarAndGeodeticBuffersView.swift
@@ -70,7 +70,7 @@ struct CreatePlanarAndGeodeticBuffersView: View {
 }
 
 private extension CreatePlanarAndGeodeticBuffersView {
-    private class Model: ObservableObject {
+    class Model: ObservableObject {
         /// A map with a topographic basemap style.
         let map = Map(basemapStyle: .arcGISTopographic)
         

--- a/Shared/Samples/Create planar and geodetic buffers/CreatePlanarAndGeodeticBuffersView.swift
+++ b/Shared/Samples/Create planar and geodetic buffers/CreatePlanarAndGeodeticBuffersView.swift
@@ -160,7 +160,6 @@ private extension CreatePlanarAndGeodeticBuffersView {
         func clearGraphics() {
             graphicsOverlays.forEach { $0.removeAllGraphics() }
         }
-        
     }
 }
 

--- a/Shared/Samples/Create planar and geodetic buffers/CreatePlanarAndGeodeticBuffersView.swift
+++ b/Shared/Samples/Create planar and geodetic buffers/CreatePlanarAndGeodeticBuffersView.swift
@@ -60,7 +60,7 @@ struct CreatePlanarAndGeodeticBuffersView: View {
                 .toggleStyle(.button)
                 Spacer()
                 Button("Clear All") {
-                    model.clearGraphics()
+                    model.removeAllBufferGraphics()
                 }
                 Spacer()
             }
@@ -159,7 +159,7 @@ private extension CreatePlanarAndGeodeticBuffersView {
         }
         
         /// Removes all graphics from all graphics overlays.
-        func clearGraphics() {
+        func removeAllBufferGraphics() {
             graphicsOverlays.forEach { $0.removeAllGraphics() }
         }
     }

--- a/Shared/Samples/Cut geometry/CutGeometryView.swift
+++ b/Shared/Samples/Cut geometry/CutGeometryView.swift
@@ -40,7 +40,7 @@ struct CutGeometryView: View {
 }
 
 private extension CutGeometryView {
-    private class Model: ObservableObject {
+    class Model: ObservableObject {
         /// A map with a topographic basemap style and an initial viewpoint of Lake Superior.
         let map: Map = {
             let map = Map(basemapStyle: .arcGISTopographic)

--- a/Shared/Samples/Cut geometry/CutGeometryView.swift
+++ b/Shared/Samples/Cut geometry/CutGeometryView.swift
@@ -19,67 +19,79 @@ struct CutGeometryView: View {
     /// A Boolean value indicating whether the geometry is cut.
     @State private var isGeometryCut = false
     
-    /// A map with a topographic basemap style and an initial viewpoint of Lake Superior.
-    @StateObject private var map: Map = {
-        let map = Map(basemapStyle: .arcGISTopographic)
-        map.initialViewpoint = Viewpoint(targetExtent: Geometry.lakeSuperiorPolygon)
-        return map
-    }()
-    
-    /// A graphics overlay containing the Lake Superior polygon and a border line.
-    @StateObject private var lakeGraphicsOverlay: GraphicsOverlay = {
-        let lakeSuperiorGraphic = Graphic(
-            geometry: .lakeSuperiorPolygon,
-            symbol: SimpleFillSymbol(
-                color: .blue.withAlphaComponent(0.1),
-                outline: SimpleLineSymbol(style: .solid, color: .blue, width: 4)
-            )
-        )
-        let borderGraphic = Graphic(
-            geometry: .borderPolyline,
-            symbol: SimpleLineSymbol(style: .dot, color: .red, width: 5)
-        )
-        return GraphicsOverlay(graphics: [lakeSuperiorGraphic, borderGraphic])
-    }()
-    
-    /// The graphics overlay containing cut graphics.
-    @StateObject private var cutGraphicsOverlay = GraphicsOverlay()
-    
-    /// Cuts geometry and adds resulting graphics.
-    private func cutGeometry() {
-        // Cuts the Lake Superior polygon using the border polyline.
-        guard let parts = GeometryEngine.cut(.lakeSuperiorPolygon, usingCutter: .borderPolyline),
-              parts.count == 2,
-              let firstPart = parts.first,
-              let secondPart = parts.last else {
-            return
-        }
-        // Creates the graphics for the Canadian and USA sides of Lake Superior.
-        let canadaSideGraphic = Graphic(geometry: firstPart, symbol: SimpleFillSymbol(style: .backwardDiagonal, color: .green))
-        let usaSideGraphic = Graphic(geometry: secondPart, symbol: SimpleFillSymbol(style: .forwardDiagonal, color: .yellow))
-        // Adds the graphics to the graphics overlay.
-        cutGraphicsOverlay.addGraphics([canadaSideGraphic, usaSideGraphic])
-    }
-    
-    /// Removes all cut graphics.
-    private func reset() {
-        cutGraphicsOverlay.removeAllGraphics()
-    }
+    /// The view model for the sample.
+    @StateObject private var model = Model()
     
     var body: some View {
-        MapView(map: map, graphicsOverlays: [lakeGraphicsOverlay, cutGraphicsOverlay])
+        MapView(map: model.map, graphicsOverlays: model.graphicsOverlays)
             .toolbar {
                 ToolbarItem(placement: .bottomBar) {
                     Button(isGeometryCut ? "Reset" : "Cut") {
                         if isGeometryCut {
-                            reset()
+                            model.reset()
                         } else {
-                            cutGeometry()
+                            model.cutGeometry()
                         }
                         isGeometryCut.toggle()
                     }
                 }
             }
+    }
+}
+
+private extension CutGeometryView {
+    private class Model: ObservableObject {
+        /// A map with a topographic basemap style and an initial viewpoint of Lake Superior.
+        let map: Map = {
+            let map = Map(basemapStyle: .arcGISTopographic)
+            map.initialViewpoint = Viewpoint(targetExtent: Geometry.lakeSuperiorPolygon)
+            return map
+        }()
+        
+        /// A graphics overlay containing the Lake Superior polygon and a border line.
+        private let lakeGraphicsOverlay: GraphicsOverlay = {
+            let lakeSuperiorGraphic = Graphic(
+                geometry: .lakeSuperiorPolygon,
+                symbol: SimpleFillSymbol(
+                    color: .blue.withAlphaComponent(0.1),
+                    outline: SimpleLineSymbol(style: .solid, color: .blue, width: 4)
+                )
+            )
+            let borderGraphic = Graphic(
+                geometry: .borderPolyline,
+                symbol: SimpleLineSymbol(style: .dot, color: .red, width: 5)
+            )
+            return GraphicsOverlay(graphics: [lakeSuperiorGraphic, borderGraphic])
+        }()
+        
+        /// The graphics overlay containing cut graphics.
+        private let cutGraphicsOverlay = GraphicsOverlay()
+        
+        /// The graphics overlays used in this sample.
+        var graphicsOverlays: [GraphicsOverlay] {
+            return [lakeGraphicsOverlay, cutGraphicsOverlay]
+        }
+        
+        /// Cuts geometry and adds resulting graphics.
+        func cutGeometry() {
+            // Cuts the Lake Superior polygon using the border polyline.
+            guard let parts = GeometryEngine.cut(.lakeSuperiorPolygon, usingCutter: .borderPolyline),
+                  parts.count == 2,
+                  let firstPart = parts.first,
+                  let secondPart = parts.last else {
+                return
+            }
+            // Creates the graphics for the Canadian and USA sides of Lake Superior.
+            let canadaSideGraphic = Graphic(geometry: firstPart, symbol: SimpleFillSymbol(style: .backwardDiagonal, color: .green))
+            let usaSideGraphic = Graphic(geometry: secondPart, symbol: SimpleFillSymbol(style: .forwardDiagonal, color: .yellow))
+            // Adds the graphics to the graphics overlay.
+            cutGraphicsOverlay.addGraphics([canadaSideGraphic, usaSideGraphic])
+        }
+        
+        /// Removes all cut graphics.
+        func reset() {
+            cutGraphicsOverlay.removeAllGraphics()
+        }
     }
 }
 

--- a/Shared/Samples/Cut geometry/CutGeometryView.swift
+++ b/Shared/Samples/Cut geometry/CutGeometryView.swift
@@ -77,8 +77,8 @@ private extension CutGeometryView {
         /// Cuts geometry and adds resulting graphics.
         func cutGeometry() {
             // Cuts the Lake Superior polygon using the border polyline.
-            guard let parts = GeometryEngine.cut(.lakeSuperiorPolygon, usingCutter: .borderPolyline),
-                  parts.count == 2,
+            let parts = GeometryEngine.cut(.lakeSuperiorPolygon, usingCutter: .borderPolyline)
+            guard parts.count == 2,
                   let firstPart = parts.first,
                   let secondPart = parts.last else {
                 return

--- a/Shared/Samples/Cut geometry/CutGeometryView.swift
+++ b/Shared/Samples/Cut geometry/CutGeometryView.swift
@@ -40,6 +40,8 @@ struct CutGeometryView: View {
 }
 
 private extension CutGeometryView {
+    /// The model used to store the geo model and other expensive objects
+    /// used in this view.
     class Model: ObservableObject {
         /// A map with a topographic basemap style and an initial viewpoint of Lake Superior.
         let map: Map = {

--- a/Shared/Samples/Cut geometry/CutGeometryView.swift
+++ b/Shared/Samples/Cut geometry/CutGeometryView.swift
@@ -28,7 +28,7 @@ struct CutGeometryView: View {
                 ToolbarItem(placement: .bottomBar) {
                     Button(isGeometryCut ? "Reset" : "Cut") {
                         if isGeometryCut {
-                            model.reset()
+                            model.removeAllGraphics()
                         } else {
                             model.cutGeometry()
                         }
@@ -91,7 +91,7 @@ private extension CutGeometryView {
         }
         
         /// Removes all cut graphics.
-        func reset() {
+        func removeAllGraphics() {
             cutGraphicsOverlay.removeAllGraphics()
         }
     }

--- a/Shared/Samples/Display map from mobile map package/DisplayMapFromMobileMapPackageView.swift
+++ b/Shared/Samples/Display map from mobile map package/DisplayMapFromMobileMapPackageView.swift
@@ -46,14 +46,11 @@ extension DisplayMapFromMobileMapPackageView {
         /// A map with no specified style.
         var map = Map()
         
-        /// The mobile map package.
-        private var mobileMapPackage: MobileMapPackage!
-        
         /// Loads a local mobile map package.
         func loadMobileMapPackage() async throws {
             // Loads the local mobile map package.
             let yellowstoneURL = Bundle.main.url(forResource: "Yellowstone", withExtension: "mmpk")!
-            mobileMapPackage = MobileMapPackage(fileURL: yellowstoneURL)
+            let mobileMapPackage = MobileMapPackage(fileURL: yellowstoneURL)
             try await mobileMapPackage.load()
             // Gets the first map in the mobile map package.
             guard let map = mobileMapPackage.maps.first else { return }

--- a/Shared/Samples/Display map from mobile map package/DisplayMapFromMobileMapPackageView.swift
+++ b/Shared/Samples/Display map from mobile map package/DisplayMapFromMobileMapPackageView.swift
@@ -16,12 +16,6 @@ import ArcGIS
 import SwiftUI
 
 struct DisplayMapFromMobileMapPackageView: View {
-    /// A map with no specified style.
-    @State private var map = Map()
-    
-    /// The mobile map package.
-    @State private var mobileMapPackage: MobileMapPackage!
-    
     /// A Boolean value indicating whether to show an alert.
     @State private var isShowingAlert = false
     
@@ -30,28 +24,40 @@ struct DisplayMapFromMobileMapPackageView: View {
         didSet { isShowingAlert = error != nil }
     }
     
-    /// Loads a local mobile map package.
-    private func loadMobileMapPackage() async throws {
-        // Loads the local mobile map package.
-        let yellowstoneURL = Bundle.main.url(forResource: "Yellowstone", withExtension: "mmpk")!
-        mobileMapPackage = MobileMapPackage(fileURL: yellowstoneURL)
-        try await mobileMapPackage.load()
-        // Gets the first map in the mobile map package.
-        guard let map = mobileMapPackage.maps.first else { return }
-        self.map = map
-    }
+    /// The view model for the sample.
+    @StateObject private var model = Model()
     
     var body: some View {
-        // Creates a map view to display the map.
-        MapView(map: map)
+        MapView(map: model.map)
             .task {
                 do {
-                    try await loadMobileMapPackage()
+                    try await model.loadMobileMapPackage()
                 } catch {
                     // Presents an error message if the map fails to load.
                     self.error = error
                 }
             }
             .alert(isPresented: $isShowingAlert, presentingError: error)
+    }
+}
+
+extension DisplayMapFromMobileMapPackageView {
+    private class Model: ObservableObject {
+        /// A map with no specified style.
+        var map = Map()
+        
+        /// The mobile map package.
+        private var mobileMapPackage: MobileMapPackage!
+        
+        /// Loads a local mobile map package.
+        func loadMobileMapPackage() async throws {
+            // Loads the local mobile map package.
+            let yellowstoneURL = Bundle.main.url(forResource: "Yellowstone", withExtension: "mmpk")!
+            mobileMapPackage = MobileMapPackage(fileURL: yellowstoneURL)
+            try await mobileMapPackage.load()
+            // Gets the first map in the mobile map package.
+            guard let map = mobileMapPackage.maps.first else { return }
+            self.map = map
+        }
     }
 }

--- a/Shared/Samples/Display map from mobile map package/DisplayMapFromMobileMapPackageView.swift
+++ b/Shared/Samples/Display map from mobile map package/DisplayMapFromMobileMapPackageView.swift
@@ -16,6 +16,12 @@ import ArcGIS
 import SwiftUI
 
 struct DisplayMapFromMobileMapPackageView: View {
+    /// A map with no specified style.
+    @State private var map = Map()
+    
+    /// The mobile map package.
+    @State private var mobileMapPackage: MobileMapPackage!
+    
     /// A Boolean value indicating whether to show an alert.
     @State private var isShowingAlert = false
     
@@ -24,37 +30,28 @@ struct DisplayMapFromMobileMapPackageView: View {
         didSet { isShowingAlert = error != nil }
     }
     
-    /// The view model for the sample.
-    @StateObject private var model = Model()
+    /// Loads a local mobile map package.
+    private func loadMobileMapPackage() async throws {
+        // Loads the local mobile map package.
+        let yellowstoneURL = Bundle.main.url(forResource: "Yellowstone", withExtension: "mmpk")!
+        mobileMapPackage = MobileMapPackage(fileURL: yellowstoneURL)
+        try await mobileMapPackage.load()
+        // Gets the first map in the mobile map package.
+        guard let map = mobileMapPackage.maps.first else { return }
+        self.map = map
+    }
     
     var body: some View {
-        MapView(map: model.map)
+        // Creates a map view to display the map.
+        MapView(map: map)
             .task {
                 do {
-                    try await model.loadMobileMapPackage()
+                    try await loadMobileMapPackage()
                 } catch {
                     // Presents an error message if the map fails to load.
                     self.error = error
                 }
             }
             .alert(isPresented: $isShowingAlert, presentingError: error)
-    }
-}
-
-extension DisplayMapFromMobileMapPackageView {
-    private class Model: ObservableObject {
-        /// A map with no specified style.
-        var map = Map()
-        
-        /// Loads a local mobile map package.
-        func loadMobileMapPackage() async throws {
-            // Loads the local mobile map package.
-            let yellowstoneURL = Bundle.main.url(forResource: "Yellowstone", withExtension: "mmpk")!
-            let mobileMapPackage = MobileMapPackage(fileURL: yellowstoneURL)
-            try await mobileMapPackage.load()
-            // Gets the first map in the mobile map package.
-            guard let map = mobileMapPackage.maps.first else { return }
-            self.map = map
-        }
     }
 }

--- a/Shared/Samples/Display map/DisplayMapView.swift
+++ b/Shared/Samples/Display map/DisplayMapView.swift
@@ -16,6 +16,8 @@ import SwiftUI
 import ArcGIS
 
 struct DisplayMapView: View {
+    /// The model used to store the geo model and other expensive objects
+    /// used in this view.
     private class Model: ObservableObject {
         /// A map with imagery basemap.
         let map = Map(basemapStyle: .arcGISImagery)

--- a/Shared/Samples/Display map/DisplayMapView.swift
+++ b/Shared/Samples/Display map/DisplayMapView.swift
@@ -16,11 +16,16 @@ import SwiftUI
 import ArcGIS
 
 struct DisplayMapView: View {
-    /// A map with imagery basemap.
-    @StateObject private var map = Map(basemapStyle: .arcGISImagery)
+    private class Model: ObservableObject {
+        /// A map with imagery basemap.
+        let map: Map = Map(basemapStyle: .arcGISImagery)
+    }
+    
+    /// The view model for the sample.
+    @StateObject private var model = Model()
     
     var body: some View {
         // Creates a map view to display the map.
-        MapView(map: map)
+        MapView(map: model.map)
     }
 }

--- a/Shared/Samples/Display map/DisplayMapView.swift
+++ b/Shared/Samples/Display map/DisplayMapView.swift
@@ -18,7 +18,7 @@ import ArcGIS
 struct DisplayMapView: View {
     private class Model: ObservableObject {
         /// A map with imagery basemap.
-        let map: Map = Map(basemapStyle: .arcGISImagery)
+        let map = Map(basemapStyle: .arcGISImagery)
     }
     
     /// The view model for the sample.

--- a/Shared/Samples/Display overview map/DisplayOverviewMapView.swift
+++ b/Shared/Samples/Display overview map/DisplayOverviewMapView.swift
@@ -45,6 +45,8 @@ struct DisplayOverviewMapView: View {
 }
 
 private extension DisplayOverviewMapView {
+    /// The model used to store the geo model and other expensive objects
+    /// used in this view.
     class Model: ObservableObject {
         /// A map with imagery basemap and a tourist attraction feature layer.
         let map: Map = {

--- a/Shared/Samples/Display overview map/DisplayOverviewMapView.swift
+++ b/Shared/Samples/Display overview map/DisplayOverviewMapView.swift
@@ -17,8 +17,8 @@ import ArcGIS
 import ArcGISToolkit
 
 struct DisplayOverviewMapView: View {
-    /// A map with imagery basemap and a tourist attraction feature layer.
-    @StateObject private var map = makeMap()
+    /// The view model for the sample.
+    @StateObject private var model = Model()
     
     /// The current viewpoint of the map view.
     @State private var viewpoint = Viewpoint(
@@ -29,21 +29,8 @@ struct DisplayOverviewMapView: View {
     /// The visible area marked with a red rectangle on the overview map.
     @State private var visibleArea: ArcGIS.Polygon?
     
-    /// Creates a map.
-    private static func makeMap() -> Map {
-        let featureLayer = FeatureLayer(
-            item: PortalItem(
-                portal: .arcGISOnline(connection: .anonymous),
-                id: .northAmericaTouristAttractions
-            )
-        )
-        let map = Map(basemapStyle: .arcGISTopographic)
-        map.addOperationalLayer(featureLayer)
-        return map
-    }
-    
     var body: some View {
-        MapView(map: map, viewpoint: viewpoint)
+        MapView(map: model.map, viewpoint: viewpoint)
             .onViewpointChanged(kind: .centerAndScale) { viewpoint = $0 }
             .onVisibleAreaChanged { visibleArea = $0 }
             .overlay(alignment: .topTrailing) {
@@ -54,6 +41,23 @@ struct DisplayOverviewMapView: View {
                 .frame(width: 200, height: 132)
                 .padding()
             }
+    }
+}
+
+private extension DisplayOverviewMapView {
+    private class Model: ObservableObject {
+        /// A map with imagery basemap and a tourist attraction feature layer.
+        let map: Map = {
+            let featureLayer = FeatureLayer(
+                item: PortalItem(
+                    portal: .arcGISOnline(connection: .anonymous),
+                    id: .northAmericaTouristAttractions
+                )
+            )
+            let map = Map(basemapStyle: .arcGISTopographic)
+            map.addOperationalLayer(featureLayer)
+            return map
+        }()
     }
 }
 

--- a/Shared/Samples/Display overview map/DisplayOverviewMapView.swift
+++ b/Shared/Samples/Display overview map/DisplayOverviewMapView.swift
@@ -45,7 +45,7 @@ struct DisplayOverviewMapView: View {
 }
 
 private extension DisplayOverviewMapView {
-    private class Model: ObservableObject {
+    class Model: ObservableObject {
         /// A map with imagery basemap and a tourist attraction feature layer.
         let map: Map = {
             let featureLayer = FeatureLayer(

--- a/Shared/Samples/Display scene/DisplaySceneView.swift
+++ b/Shared/Samples/Display scene/DisplaySceneView.swift
@@ -16,46 +16,48 @@ import SwiftUI
 import ArcGIS
 
 struct DisplaySceneView: View {
-    /// A scene with imagery basemap style and a tiled elevation source.
-    @StateObject private var scene = makeScene()
-    
-    /// Makes a scene.
-    private static func makeScene() -> ArcGIS.Scene {
-        // Creates a scene.
-        let scene = Scene(basemapStyle: .arcGISImageryStandard)
-        
-        // Sets the initial viewpoint of the scene.
-        scene.initialViewpoint = Viewpoint(
-            latitude: 45.74,
-            longitude: 6.88,
-            scale: 4_500,
-            camera: Camera(
+    private class Model: ObservableObject {
+        /// A scene with imagery basemap style and a tiled elevation source.
+        let scene: ArcGIS.Scene = {
+            // Creates a scene.
+            let scene = Scene(basemapStyle: .arcGISImageryStandard)
+            
+            // Sets the initial viewpoint of the scene.
+            scene.initialViewpoint = Viewpoint(
                 latitude: 45.74,
                 longitude: 6.88,
-                altitude: 4500,
-                heading: 10,
-                pitch: 70,
-                roll: 0
+                scale: 4_500,
+                camera: Camera(
+                    latitude: 45.74,
+                    longitude: 6.88,
+                    altitude: 4500,
+                    heading: 10,
+                    pitch: 70,
+                    roll: 0
+                )
             )
-        )
-        
-        // Creates a surface.
-        let surface = Surface()
-        
-        // Creates a tiled elevation source.
-        let worldElevationServiceURL = URL(string: "https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer")!
-        let elevationSource = ArcGISTiledElevationSource(url: worldElevationServiceURL)
-        
-        // Adds the elevation source to the surface.
-        surface.addElevationSource(elevationSource)
-        
-        // Sets the surface to the scene's base surface.
-        scene.baseSurface = surface
-        return scene
+            
+            // Creates a surface.
+            let surface = Surface()
+            
+            // Creates a tiled elevation source.
+            let worldElevationServiceURL = URL(string: "https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer")!
+            let elevationSource = ArcGISTiledElevationSource(url: worldElevationServiceURL)
+            
+            // Adds the elevation source to the surface.
+            surface.addElevationSource(elevationSource)
+            
+            // Sets the surface to the scene's base surface.
+            scene.baseSurface = surface
+            return scene
+        }()
     }
+    
+    /// The view model for the sample.
+    @StateObject private var model = Model()
     
     var body: some View {
         // Creates a scene view with the scene.
-        SceneView(scene: scene)
+        SceneView(scene: model.scene)
     }
 }

--- a/Shared/Samples/Display scene/DisplaySceneView.swift
+++ b/Shared/Samples/Display scene/DisplaySceneView.swift
@@ -16,6 +16,8 @@ import SwiftUI
 import ArcGIS
 
 struct DisplaySceneView: View {
+    /// The model used to store the geo model and other expensive objects
+    /// used in this view.
     private class Model: ObservableObject {
         /// A scene with imagery basemap style and a tiled elevation source.
         let scene: ArcGIS.Scene = {

--- a/Shared/Samples/Download vector tiles to local cache/DownloadVectorTilesToLocalCacheView.swift
+++ b/Shared/Samples/Download vector tiles to local cache/DownloadVectorTilesToLocalCacheView.swift
@@ -25,9 +25,6 @@ struct DownloadVectorTilesToLocalCacheView: View {
     /// A Boolean value indicating whether to show an alert.
     @State private var isShowingAlert = false
     
-    /// A Boolean value indicating whether the download button is enabled.
-    @State private var allowsDownloading = false
-    
     /// A Boolean value indicating whether to show the result map.
     @State private var isShowingResults = false
     
@@ -49,8 +46,6 @@ struct DownloadVectorTilesToLocalCacheView: View {
                     .task {
                         do {
                             try await model.initializeVectorTilesTask()
-                            // Enables the download button.
-                            allowsDownloading = true
                         } catch {
                             self.error = error
                         }
@@ -97,7 +92,7 @@ struct DownloadVectorTilesToLocalCacheView: View {
                             Button("Download Vector Tiles") {
                                 isDownloading = true
                             }
-                            .disabled(!allowsDownloading || isDownloading)
+                            .disabled(model.exportVectorTilesTask == nil || isDownloading)
                             .task(id: isDownloading) {
                                 // Ensures downloading is true.
                                 guard isDownloading else { return }
@@ -165,7 +160,7 @@ private extension DownloadVectorTilesToLocalCacheView {
         @Published var exportVectorTilesJob: ExportVectorTilesJob!
         
         /// The export vector tiles task.
-        private var exportVectorTilesTask: ExportVectorTilesTask!
+        @Published var exportVectorTilesTask: ExportVectorTilesTask!
         
         /// The vector tiled layer from the downloaded result.
         private var vectorTiledLayerResults: ArcGISVectorTiledLayer!

--- a/Shared/Samples/Download vector tiles to local cache/DownloadVectorTilesToLocalCacheView.swift
+++ b/Shared/Samples/Download vector tiles to local cache/DownloadVectorTilesToLocalCacheView.swift
@@ -210,9 +210,10 @@ private extension DownloadVectorTilesToLocalCacheView {
             // Waits for the map to load.
             try await map.load()
             // Gets the map's base layers.
-            guard let vectorTiledLayer = map.basemap?.baseLayers.first as? ArcGISVectorTiledLayer else { return }
+            guard let vectorTiledLayer = map.basemap?.baseLayers.first as? ArcGISVectorTiledLayer,
+                  let url = vectorTiledLayer.url else { return }
             // Creates the export vector tiles task from the base layers' URL.
-            exportVectorTilesTask = ExportVectorTilesTask(url: vectorTiledLayer.url!)
+            exportVectorTilesTask = ExportVectorTilesTask(url: url)
             // Loads the export vector tiles task.
             try await exportVectorTilesTask.load()
         }

--- a/Shared/Samples/Download vector tiles to local cache/DownloadVectorTilesToLocalCacheView.swift
+++ b/Shared/Samples/Download vector tiles to local cache/DownloadVectorTilesToLocalCacheView.swift
@@ -150,7 +150,8 @@ struct DownloadVectorTilesToLocalCacheView: View {
 }
 
 private extension DownloadVectorTilesToLocalCacheView {
-    /// A view model for this sample.
+    /// The model used to store the geo model and other expensive objects
+    /// used in this view.
     @MainActor
     class Model: ObservableObject {
         /// A map with a basemap from the vector tiled layer results.

--- a/Shared/Samples/Download vector tiles to local cache/DownloadVectorTilesToLocalCacheView.swift
+++ b/Shared/Samples/Download vector tiles to local cache/DownloadVectorTilesToLocalCacheView.swift
@@ -25,8 +25,8 @@ struct DownloadVectorTilesToLocalCacheView: View {
     /// A Boolean value indicating whether to show an alert.
     @State private var isShowingAlert = false
     
-    /// A Boolean value indicating whether the download button is disabled.
-    @State private var isDownloadDisabled = true
+    /// A Boolean value indicating whether the download button is enabled.
+    @State private var allowsDownloading = false
     
     /// A Boolean value indicating whether to show the result map.
     @State private var isShowingResults = false
@@ -50,7 +50,7 @@ struct DownloadVectorTilesToLocalCacheView: View {
                         do {
                             try await model.initializeVectorTilesTask()
                             // Enables the download button.
-                            isDownloadDisabled = false
+                            allowsDownloading = true
                         } catch {
                             self.error = error
                         }
@@ -97,7 +97,7 @@ struct DownloadVectorTilesToLocalCacheView: View {
                             Button("Download Vector Tiles") {
                                 isDownloading = true
                             }
-                            .disabled(isDownloadDisabled || isDownloading)
+                            .disabled(!allowsDownloading || isDownloading)
                             .task(id: isDownloading) {
                                 // Ensures downloading is true.
                                 guard isDownloading else { return }

--- a/Shared/Samples/Download vector tiles to local cache/DownloadVectorTilesToLocalCacheView.swift
+++ b/Shared/Samples/Download vector tiles to local cache/DownloadVectorTilesToLocalCacheView.swift
@@ -211,9 +211,10 @@ private extension DownloadVectorTilesToLocalCacheView {
             guard let vectorTiledLayer = map.basemap?.baseLayers.first as? ArcGISVectorTiledLayer,
                   let url = vectorTiledLayer.url else { return }
             // Creates the export vector tiles task from the base layers' URL.
-            exportVectorTilesTask = ExportVectorTilesTask(url: url)
+            let exportVectorTilesTask = ExportVectorTilesTask(url: url)
             // Loads the export vector tiles task.
             try await exportVectorTilesTask.load()
+            self.exportVectorTilesTask = exportVectorTilesTask
         }
         
         /// Downloads the vector tiles within the area of interest.

--- a/Shared/Samples/Download vector tiles to local cache/DownloadVectorTilesToLocalCacheView.swift
+++ b/Shared/Samples/Download vector tiles to local cache/DownloadVectorTilesToLocalCacheView.swift
@@ -205,6 +205,7 @@ private extension DownloadVectorTilesToLocalCacheView {
         
         /// Initializes the vector tiles task.
         func initializeVectorTilesTask() async throws {
+            guard exportVectorTilesTask == nil else { return }
             // Waits for the map to load.
             try await map.load()
             // Gets the map's base layers.

--- a/Shared/Samples/Download vector tiles to local cache/DownloadVectorTilesToLocalCacheView.swift
+++ b/Shared/Samples/Download vector tiles to local cache/DownloadVectorTilesToLocalCacheView.swift
@@ -113,15 +113,17 @@ struct DownloadVectorTilesToLocalCacheView: View {
                                 // Downloads the vector tiles.
                                 do {
                                     try await model.downloadVectorTiles(extent: extent)
-                                    // Sets downloading to false when the download finishes.
-                                    isDownloading = false
                                     // Sets show results to true.
                                     isShowingResults = true
+                                    // Sets downloading to false when the download finishes.
+                                    isDownloading = false
                                 } catch is CancellationError {
                                     // Does nothing if the error is a cancellation error.
                                 } catch {
                                     // Shows an alert if any errors occur.
                                     self.error = error
+                                    // Sets downloading to false when the download finishes.
+                                    isDownloading = false
                                 }
                             }
                             .sheet(isPresented: $isShowingResults) {

--- a/Shared/Samples/Download vector tiles to local cache/DownloadVectorTilesToLocalCacheView.swift
+++ b/Shared/Samples/Download vector tiles to local cache/DownloadVectorTilesToLocalCacheView.swift
@@ -22,6 +22,20 @@ struct DownloadVectorTilesToLocalCacheView: View {
     /// A Boolean value indicating whether to cancel and the job.
     @State private var isCancellingJob = false
     
+    /// A Boolean value indicating whether to show an alert.
+    @State private var isShowingAlert = false
+    
+    /// A Boolean value indicating whether the download button is disabled.
+    @State private var isDownloadDisabled = true
+    
+    /// A Boolean value indicating whether to show the result map.
+    @State private var isShowingResults = false
+    
+    /// The error shown in the alert.
+    @State private var error: Error? {
+        didSet { isShowingAlert = error != nil }
+    }
+    
     /// The view model for this sample.
     @StateObject private var model = Model()
     
@@ -31,9 +45,15 @@ struct DownloadVectorTilesToLocalCacheView: View {
                 MapView(map: model.map)
                     .interactionModes(isDownloading ? [] : [.pan, .zoom])
                     .onScaleChanged { model.maxScale = $0 * 0.1 }
-                    .alert(isPresented: $model.isShowingAlert, presentingError: model.error)
+                    .alert(isPresented: $isShowingAlert, presentingError: error)
                     .task {
-                        await model.initializeVectorTilesTask()
+                        do {
+                            try await model.initializeVectorTilesTask()
+                            // Enables the download button.
+                            isDownloadDisabled = false
+                        } catch {
+                            self.error = error
+                        }
                     }
                     .onDisappear {
                         Task { await model.cancelJob() }
@@ -42,7 +62,7 @@ struct DownloadVectorTilesToLocalCacheView: View {
                         Rectangle()
                             .stroke(.red, lineWidth: 2)
                             .padding(EdgeInsets(top: 20, leading: 20, bottom: 44, trailing: 20))
-                            .opacity(model.isShowingResults ? 0 : 1)
+                            .opacity(isShowingResults ? 0 : 1)
                     }
                     .overlay {
                         if isDownloading,
@@ -77,7 +97,7 @@ struct DownloadVectorTilesToLocalCacheView: View {
                             Button("Download Vector Tiles") {
                                 isDownloading = true
                             }
-                            .disabled(model.isDownloadDisabled || isDownloading)
+                            .disabled(isDownloadDisabled || isDownloading)
                             .task(id: isDownloading) {
                                 // Ensures downloading is true.
                                 guard isDownloading else { return }
@@ -96,11 +116,20 @@ struct DownloadVectorTilesToLocalCacheView: View {
                                 guard let extent = mapView.envelope(fromViewRect: viewRect) else { return }
                                 
                                 // Downloads the vector tiles.
-                                await model.downloadVectorTiles(extent: extent)
-                                // Sets downloading to false when the download finishes.
-                                isDownloading = false
+                                do {
+                                    try await model.downloadVectorTiles(extent: extent)
+                                    // Sets downloading to false when the download finishes.
+                                    isDownloading = false
+                                    // Sets show results to true.
+                                    isShowingResults = true
+                                } catch is CancellationError {
+                                    // Does nothing if the error is a cancellation error.
+                                } catch {
+                                    // Shows an alert if any errors occur.
+                                    self.error = error
+                                }
                             }
-                            .sheet(isPresented: $model.isShowingResults) {
+                            .sheet(isPresented: $isShowingResults) {
                                 // Removes the temporary files when the cover is dismissed.
                                 model.removeTemporaryFiles()
                             } content: {
@@ -111,7 +140,7 @@ struct DownloadVectorTilesToLocalCacheView: View {
                                         .toolbar {
                                             ToolbarItem(placement: .confirmationAction) {
                                                 Button("Done") {
-                                                    model.isShowingResults = false
+                                                    isShowingResults = false
                                                 }
                                             }
                                         }
@@ -127,27 +156,12 @@ struct DownloadVectorTilesToLocalCacheView: View {
 
 private extension DownloadVectorTilesToLocalCacheView {
     /// A view model for this sample.
-    @MainActor
     class Model: ObservableObject {
-        /// A Boolean value indicating whether the download button is disabled.
-        @Published var isDownloadDisabled = true
-        
-        /// A Boolean value indicating whether to show the result map.
-        @Published var isShowingResults = false
-        
-        /// A Boolean value indicating whether to show an alert.
-        @Published var isShowingAlert = false
-        
-        /// The error shown in the alert.
-        @Published var error: Error? {
-            didSet { isShowingAlert = error != nil }
-        }
-        
         /// A map with a basemap from the vector tiled layer results.
-        @Published var downloadedVectorTilesMap: Map!
+        var downloadedVectorTilesMap: Map!
         
         /// The export vector tiles job.
-        @Published var exportVectorTilesJob: ExportVectorTilesJob!
+        var exportVectorTilesJob: ExportVectorTilesJob!
         
         /// The export vector tiles task.
         private var exportVectorTilesTask: ExportVectorTilesTask!
@@ -191,76 +205,60 @@ private extension DownloadVectorTilesToLocalCacheView {
         }
         
         /// Initializes the vector tiles task.
-        func initializeVectorTilesTask() async {
-            do {
-                // Waits for the map to load.
-                try await map.load()
-                // Gets the map's base layers.
-                guard let vectorTiledLayer = map.basemap?.baseLayers.first as? ArcGISVectorTiledLayer else { return }
-                // Creates the export vector tiles task from the base layers' URL.
-                exportVectorTilesTask = ExportVectorTilesTask(url: vectorTiledLayer.url!)
-                // Loads the export vector tiles task.
-                try await exportVectorTilesTask.load()
-                // Enables the download button.
-                isDownloadDisabled = false
-            } catch {
-                self.error = error
-            }
+        func initializeVectorTilesTask() async throws {
+            // Waits for the map to load.
+            try await map.load()
+            // Gets the map's base layers.
+            guard let vectorTiledLayer = map.basemap?.baseLayers.first as? ArcGISVectorTiledLayer else { return }
+            // Creates the export vector tiles task from the base layers' URL.
+            exportVectorTilesTask = ExportVectorTilesTask(url: vectorTiledLayer.url!)
+            // Loads the export vector tiles task.
+            try await exportVectorTilesTask.load()
         }
         
         /// Downloads the vector tiles within the area of interest.
         /// - Parameter extent: The area of interest's envelope to download vector tiles.
-        func downloadVectorTiles(extent: Envelope) async {
+        func downloadVectorTiles(extent: Envelope) async throws {
             // Ensures that exporting vector tiles is allowed.
             if let vectorTileSourceInfo = exportVectorTilesTask.vectorTileSourceInfo,
                vectorTileSourceInfo.allowsExportingTiles,
                let maxScale = maxScale {
-                do {
-                    // Creates the parameters for the export vector tiles job.
-                    let parameters = try await exportVectorTilesTask.makeDefaultExportVectorTilesParameters(
-                        areaOfInterest: extent,
-                        maxScale: maxScale
+                // Creates the parameters for the export vector tiles job.
+                let parameters = try await exportVectorTilesTask.makeDefaultExportVectorTilesParameters(
+                    areaOfInterest: extent,
+                    maxScale: maxScale
+                )
+                
+                // Creates the export vector tiles job based on the parameters
+                // and temporary URLs.
+                exportVectorTilesJob = exportVectorTilesTask.makeExportVectorTilesJob(
+                    parameters: parameters,
+                    vectorTileCacheURL: vtpkTemporaryURL,
+                    itemResourceCacheURL: styleTemporaryURL
+                )
+                
+                // Starts the job.
+                exportVectorTilesJob.start()
+                
+                defer { exportVectorTilesJob = nil }
+                
+                // Awaits the output of the job.
+                let output = try await exportVectorTilesJob.output
+                
+                // Gets the vector tile and item resource cache from the output.
+                if let vectorTileCache = output.vectorTileCache,
+                   let itemResourceCache = output.itemResourceCache {
+                    // Creates a vector tiled layer from the caches.
+                    vectorTiledLayerResults = ArcGISVectorTiledLayer(
+                        vectorTileCache: vectorTileCache,
+                        itemResourceCache: itemResourceCache
                     )
                     
-                    // Creates the export vector tiles job based on the parameters
-                    // and temporary URLs.
-                    exportVectorTilesJob = exportVectorTilesTask.makeExportVectorTilesJob(
-                        parameters: parameters,
-                        vectorTileCacheURL: vtpkTemporaryURL,
-                        itemResourceCacheURL: styleTemporaryURL
-                    )
+                    // Creates a map with a basemap from the vector tiled layer results.
+                    downloadedVectorTilesMap = Map(basemap: Basemap(baseLayer: vectorTiledLayerResults))
                     
-                    // Starts the job.
-                    exportVectorTilesJob.start()
-                    
-                    defer { exportVectorTilesJob = nil }
-                    
-                    // Awaits the output of the job.
-                    let output = try await exportVectorTilesJob.output
-                    
-                    // Gets the vector tile and item resource cache from the output.
-                    if let vectorTileCache = output.vectorTileCache,
-                       let itemResourceCache = output.itemResourceCache {
-                        // Creates a vector tiled layer from the caches.
-                        vectorTiledLayerResults = ArcGISVectorTiledLayer(
-                            vectorTileCache: vectorTileCache,
-                            itemResourceCache: itemResourceCache
-                        )
-                        
-                        // Creates a map with a basemap from the vector tiled layer results.
-                        downloadedVectorTilesMap = Map(basemap: Basemap(baseLayer: vectorTiledLayerResults))
-                        
-                        // Sets the initial viewpoint of the result map.
-                        downloadedVectorTilesMap.initialViewpoint = Viewpoint(targetExtent: extent.expanded(by: 0.9))
-                        
-                        // Shows the downloaded results.
-                        isShowingResults = true
-                    }
-                } catch is CancellationError {
-                    // Does nothing if the error is a cancellation error.
-                } catch {
-                    // Shows an alert if any errors occur.
-                    self.error = error
+                    // Sets the initial viewpoint of the result map.
+                    downloadedVectorTilesMap.initialViewpoint = Viewpoint(targetExtent: extent.expanded(by: 0.9))
                 }
             }
         }

--- a/Shared/Samples/Download vector tiles to local cache/DownloadVectorTilesToLocalCacheView.swift
+++ b/Shared/Samples/Download vector tiles to local cache/DownloadVectorTilesToLocalCacheView.swift
@@ -156,12 +156,13 @@ struct DownloadVectorTilesToLocalCacheView: View {
 
 private extension DownloadVectorTilesToLocalCacheView {
     /// A view model for this sample.
+    @MainActor
     class Model: ObservableObject {
         /// A map with a basemap from the vector tiled layer results.
         var downloadedVectorTilesMap: Map!
         
         /// The export vector tiles job.
-        var exportVectorTilesJob: ExportVectorTilesJob!
+        @Published var exportVectorTilesJob: ExportVectorTilesJob!
         
         /// The export vector tiles task.
         private var exportVectorTilesTask: ExportVectorTilesTask!

--- a/Shared/Samples/Find route/FindRouteView.swift
+++ b/Shared/Samples/Find route/FindRouteView.swift
@@ -71,8 +71,8 @@ struct FindRouteView: View {
                     .disabled(model.directions.isEmpty)
                     .popover(isPresented: $isShowingDirections) {
                         NavigationView {
-                            List(model.directions, id: \.directionText) { directionManeuver in
-                                Text(directionManeuver.directionText)
+                            List(model.directions, id: \.text) { directionManeuver in
+                                Text(directionManeuver.text)
                             }
                             .navigationTitle("Directions")
                             .navigationBarTitleDisplayMode(.inline)

--- a/Shared/Samples/Find route/FindRouteView.swift
+++ b/Shared/Samples/Find route/FindRouteView.swift
@@ -16,6 +16,14 @@ import ArcGIS
 import SwiftUI
 
 struct FindRouteView: View {
+    /// A Boolean value indicating whether to show an alert.
+    @State private var isShowingAlert = false
+    
+    /// The error shown in the alert.
+    @State private var error: Error? {
+        didSet { isShowingAlert = error != nil }
+    }
+    
     /// A Boolean value indicating whether to show the directions.
     @State private var isShowingDirections = false
     
@@ -27,9 +35,13 @@ struct FindRouteView: View {
     
     var body: some View {
         MapView(map: model.map, graphicsOverlays: model.graphicsOverlays)
-            .alert(isPresented: $model.isShowingAlert, presentingError: model.error)
+            .alert(isPresented: $isShowingAlert, presentingError: error)
             .task {
-                await model.initializeRouteParameters()
+                do {
+                    try await model.initializeRouteParameters()
+                } catch {
+                    self.error = error
+                }
             }
             .toolbar {
                 ToolbarItemGroup(placement: .bottomBar) {
@@ -42,7 +54,11 @@ struct FindRouteView: View {
                         // Ensures that solving the route is true.
                         guard isSolvingRoute else { return }
                         // Finds the route.
-                        await model.findRoute()
+                        do {
+                            try await model.findRoute()
+                        } catch {
+                            self.error = error
+                        }
                         // Sets solving the route to false.
                         isSolvingRoute = false
                     }
@@ -85,14 +101,6 @@ private extension FindRouteView {
         
         /// The parameters for the route.
         @Published var routeParameters: RouteParameters!
-        
-        /// A Boolean value indicating whether to show an alert.
-        @Published var isShowingAlert = false
-        
-        /// The error shown in the alert.
-        @Published var error: Error? {
-            didSet { isShowingAlert = error != nil }
-        }
         
         /// A Boolean value indicating whether to disable the route button.
         var isRouteDisabled: Bool { routeParameters == nil }
@@ -158,40 +166,31 @@ private extension FindRouteView {
         }
         
         /// Initializes the route parameters.
-        func initializeRouteParameters() async {
-            do {
-                // Creates the default parameters.
-                let parameters = try await routeTask.makeDefaultParameters()
-                
-                // Sets the return directions on the parameters to true.
-                parameters.returnsDirections = true
-                
-                // Sets the stops for the route.
-                parameters.setStops(stops)
-                
-                // Initializes the route parameters.
-                routeParameters = parameters
-            } catch {
-                self.error = error
-            }
+        func initializeRouteParameters() async throws {
+            // Creates the default parameters.
+            let parameters = try await routeTask.makeDefaultParameters()
+            
+            // Sets the return directions on the parameters to true.
+            parameters.returnsDirections = true
+            
+            // Sets the stops for the route.
+            parameters.setStops(stops)
+            
+            // Initializes the route parameters.
+            routeParameters = parameters
         }
         
         /// Finds the route from stop one to stop two.
-        func findRoute() async {
+        func findRoute() async throws {
             // Resets the route geometry and directions.
             routeGraphic.geometry = nil
             directions.removeAll()
-            
-            do {
-                // Solves the route based on the route parameters.
-                let routeResult = try await routeTask.solveRoute(using: routeParameters)
-                if let firstRoute = routeResult.routes.first {
-                    // Updates the route geometry and directions.
-                    routeGraphic.geometry = firstRoute.geometry
-                    directions = firstRoute.directionManeuvers
-                }
-            } catch {
-                self.error = error
+            // Solves the route based on the route parameters.
+            let routeResult = try await routeTask.solveRoute(using: routeParameters)
+            if let firstRoute = routeResult.routes.first {
+                // Updates the route geometry and directions.
+                routeGraphic.geometry = firstRoute.geometry
+                directions = firstRoute.directionManeuvers
             }
         }
     }

--- a/Shared/Samples/Find route/FindRouteView.swift
+++ b/Shared/Samples/Find route/FindRouteView.swift
@@ -93,7 +93,8 @@ struct FindRouteView: View {
 }
 
 private extension FindRouteView {
-    /// A view model for this sample.
+    /// The model used to store the geo model and other expensive objects
+    /// used in this view.
     @MainActor
     class Model: ObservableObject {
         /// The directions for the route.

--- a/Shared/Samples/Find route/FindRouteView.swift
+++ b/Shared/Samples/Find route/FindRouteView.swift
@@ -168,6 +168,8 @@ private extension FindRouteView {
         
         /// Initializes the route parameters.
         func initializeRouteParameters() async throws {
+            guard routeParameters == nil else { return }
+            
             // Creates the default parameters.
             let parameters = try await routeTask.makeDefaultParameters()
             

--- a/Shared/Samples/Generate offline map/GenerateOfflineMapView.swift
+++ b/Shared/Samples/Generate offline map/GenerateOfflineMapView.swift
@@ -109,7 +109,8 @@ struct GenerateOfflineMapView: View {
 }
 
 private extension GenerateOfflineMapView {
-    /// The view model for this sample.
+    /// The model used to store the geo model and other expensive objects
+    /// used in this view.
     @MainActor
     class Model: ObservableObject {
         /// The offline map that is generated.

--- a/Shared/Samples/Project geometry/ProjectGeometryView.swift
+++ b/Shared/Samples/Project geometry/ProjectGeometryView.swift
@@ -24,7 +24,7 @@ struct ProjectGeometryView: View {
     
     /// The view model for the sample.
     @StateObject private var model = Model()
-
+    
     var body: some View {
         MapView(map: model.map, graphicsOverlays: [model.graphicsOverlay])
             .onSingleTapGesture { _, mapPoint in

--- a/Shared/Samples/Project geometry/ProjectGeometryView.swift
+++ b/Shared/Samples/Project geometry/ProjectGeometryView.swift
@@ -68,7 +68,7 @@ struct ProjectGeometryView: View {
 }
 
 private extension ProjectGeometryView {
-    private class Model: ObservableObject {
+    class Model: ObservableObject {
         /// A map with a topographic basemap style and an initial viewpoint.
         let map: Map = {
             let map = Map(basemapStyle: .arcGISTopographic)

--- a/Shared/Samples/Project geometry/ProjectGeometryView.swift
+++ b/Shared/Samples/Project geometry/ProjectGeometryView.swift
@@ -22,26 +22,11 @@ struct ProjectGeometryView: View {
     /// The point where the map was tapped in its original spatial reference (Web Mercator).
     @State private var originalPoint: Point?
     
-    /// A map with a topographic basemap style and an initial viewpoint.
-    @StateObject private var map: Map = {
-        let map = Map(basemapStyle: .arcGISTopographic)
-        map.initialViewpoint = Viewpoint(
-            center: Point(x: -1.2e7, y: 5e6, spatialReference: .webMercator),
-            scale: 4e7
-        )
-        return map
-    }()
-    
-    /// A graphics overlay containing a graphic with a circular, red marker symbol.
-    @StateObject private var graphicsOverlay = GraphicsOverlay(graphics: [
-        Graphic(symbol: SimpleMarkerSymbol(color: .red, size: 8))
-    ])
-    
-    /// The graphic with a circular, red marker symbol.
-    private var pointGraphic: Graphic { graphicsOverlay.graphics.first! }
-    
+    /// The view model for the sample.
+    @StateObject private var model = Model()
+
     var body: some View {
-        MapView(map: map, graphicsOverlays: [graphicsOverlay])
+        MapView(map: model.map, graphicsOverlays: [model.graphicsOverlay])
             .onSingleTapGesture { _, mapPoint in
                 if calloutPlacement == nil {
                     // Sets the original point to where the map was tapped.
@@ -51,14 +36,14 @@ struct ProjectGeometryView: View {
                     let projectedPoint = GeometryEngine.project(originalPoint!, into: .wgs84)!
                     
                     // Updates the geometry of the point graphic.
-                    pointGraphic.geometry = projectedPoint
+                    model.pointGraphic.geometry = projectedPoint
                     
                     // Updates the location callout placement.
                     calloutPlacement = LocationCalloutPlacement(location: projectedPoint)
                 } else {
                     // Hides the callout and point graphic.
                     calloutPlacement = nil
-                    pointGraphic.geometry = nil
+                    model.pointGraphic.geometry = nil
                 }
             }
             .callout(placement: $calloutPlacement.animation(.default.speed(4))) { callout in
@@ -79,6 +64,28 @@ struct ProjectGeometryView: View {
                     .padding(.vertical, 6)
                     .background(.thinMaterial, ignoresSafeAreaEdges: .horizontal)
             }
+    }
+}
+
+private extension ProjectGeometryView {
+    private class Model: ObservableObject {
+        /// A map with a topographic basemap style and an initial viewpoint.
+        let map: Map = {
+            let map = Map(basemapStyle: .arcGISTopographic)
+            map.initialViewpoint = Viewpoint(
+                center: Point(x: -1.2e7, y: 5e6, spatialReference: .webMercator),
+                scale: 4e7
+            )
+            return map
+        }()
+        
+        /// A graphics overlay containing a graphic with a circular, red marker symbol.
+        let graphicsOverlay = GraphicsOverlay(graphics: [
+            Graphic(symbol: SimpleMarkerSymbol(color: .red, size: 8))
+        ])
+        
+        /// The graphic with a circular, red marker symbol.
+        var pointGraphic: Graphic { graphicsOverlay.graphics.first! }
     }
 }
 

--- a/Shared/Samples/Project geometry/ProjectGeometryView.swift
+++ b/Shared/Samples/Project geometry/ProjectGeometryView.swift
@@ -68,6 +68,8 @@ struct ProjectGeometryView: View {
 }
 
 private extension ProjectGeometryView {
+    /// The model used to store the geo model and other expensive objects
+    /// used in this view.
     class Model: ObservableObject {
         /// A map with a topographic basemap style and an initial viewpoint.
         let map: Map = {

--- a/Shared/Samples/Search with geocode/SearchWithGeocodeView.swift
+++ b/Shared/Samples/Search with geocode/SearchWithGeocodeView.swift
@@ -124,7 +124,7 @@ struct SearchWithGeocodeView: View {
 }
 
 private extension SearchWithGeocodeView {
-    private class Model: ObservableObject {
+    class Model: ObservableObject {
         /// A map with imagery basemap.
         let map = Map(basemapStyle: .arcGISImagery)
         

--- a/Shared/Samples/Search with geocode/SearchWithGeocodeView.swift
+++ b/Shared/Samples/Search with geocode/SearchWithGeocodeView.swift
@@ -124,6 +124,8 @@ struct SearchWithGeocodeView: View {
 }
 
 private extension SearchWithGeocodeView {
+    /// The model used to store the geo model and other expensive objects
+    /// used in this view.
     class Model: ObservableObject {
         /// A map with imagery basemap.
         let map = Map(basemapStyle: .arcGISImagery)

--- a/Shared/Samples/Search with geocode/SearchWithGeocodeView.swift
+++ b/Shared/Samples/Search with geocode/SearchWithGeocodeView.swift
@@ -17,9 +17,6 @@ import ArcGIS
 import ArcGISToolkit
 
 struct SearchWithGeocodeView: View {
-    /// A map with imagery basemap.
-    @StateObject private var map = Map(basemapStyle: .arcGISImagery)
-    
     /// The viewpoint used by the search view to pan/zoom the map to the extent
     /// of the search results.
     @State private var viewpoint: Viewpoint? = Viewpoint(
@@ -58,16 +55,15 @@ struct SearchWithGeocodeView: View {
         maximumSuggestions: 5
     )
     
-    /// The graphics overlay used by the search toolkit component to display
-    /// search results on the map.
-    @StateObject private var searchResultsOverlay = GraphicsOverlay()
+    /// The view model for the sample.
+    @StateObject private var model = Model()
     
     var body: some View {
         MapViewReader { proxy in
             MapView(
-                map: map,
+                map: model.map,
                 viewpoint: viewpoint,
-                graphicsOverlays: [searchResultsOverlay]
+                graphicsOverlays: [model.searchResultsOverlay]
             )
             .onSingleTapGesture { screenPoint, tapLocation in
                 identifyScreenPoint = screenPoint
@@ -92,7 +88,7 @@ struct SearchWithGeocodeView: View {
                 guard let screenPoint = identifyScreenPoint,
                       // Identifies when user taps a graphic.
                       let identifyResult = try? await proxy.identify(
-                        on: searchResultsOverlay,
+                        on: model.searchResultsOverlay,
                         screenPoint: screenPoint,
                         tolerance: 10
                       )
@@ -111,7 +107,7 @@ struct SearchWithGeocodeView: View {
                     sources: [locatorDataSource],
                     viewpoint: $viewpoint
                 )
-                .resultsOverlay(searchResultsOverlay)
+                .resultsOverlay(model.searchResultsOverlay)
                 .queryCenter($queryCenter)
                 .geoViewExtent($geoViewExtent)
                 .isGeoViewNavigating($isGeoViewNavigating)
@@ -124,5 +120,16 @@ struct SearchWithGeocodeView: View {
                 .padding()
             }
         }
+    }
+}
+
+private extension SearchWithGeocodeView {
+    private class Model: ObservableObject {
+        /// A map with imagery basemap.
+        let map = Map(basemapStyle: .arcGISImagery)
+        
+        /// The graphics overlay used by the search toolkit component to display
+        /// search results on the map.
+        let searchResultsOverlay = GraphicsOverlay()
     }
 }

--- a/Shared/Samples/Select features in feature layer/SelectFeaturesInFeatureLayerView.swift
+++ b/Shared/Samples/Select features in feature layer/SelectFeaturesInFeatureLayerView.swift
@@ -25,8 +25,10 @@ struct SelectFeaturesInFeatureLayerView: View {
     /// A Boolean value indicating whether to show an alert.
     @State private var isShowingAlert = false
     
-    /// The error to display in the alert.
-    @State private var error: Error?
+    /// The error shown in the alert.
+    @State private var error: Error? {
+        didSet { isShowingAlert = error != nil }
+    }
     
     /// The view model for the sample.
     @StateObject private var model = Model()
@@ -60,7 +62,6 @@ struct SelectFeaturesInFeatureLayerView: View {
                     } catch {
                         // Updates the error and shows an alert.
                         self.error = error
-                        isShowingAlert = true
                     }
                 }
                 .overlay(alignment: .top) {

--- a/Shared/Samples/Select features in feature layer/SelectFeaturesInFeatureLayerView.swift
+++ b/Shared/Samples/Select features in feature layer/SelectFeaturesInFeatureLayerView.swift
@@ -44,11 +44,11 @@ struct SelectFeaturesInFeatureLayerView: View {
                     
                     do {
                         // Unselects the selected features.
-                        model.featureLayer.unselectFeatures(selectedFeatures)
+                        model.gdpPerCapitaLayer.unselectFeatures(selectedFeatures)
                         
                         // Saves the results from the identify method on the map view proxy.
                         let results = try await mapViewProxy.identify(
-                            on: model.featureLayer,
+                            on: model.gdpPerCapitaLayer,
                             screenPoint: identifyPoint,
                             tolerance: 12,
                             maximumResults: 10
@@ -58,7 +58,7 @@ struct SelectFeaturesInFeatureLayerView: View {
                         selectedFeatures = results.geoElements as! [Feature]
                         
                         // Selects the features from the selected features array.
-                        model.featureLayer.selectFeatures(selectedFeatures)
+                        model.gdpPerCapitaLayer.selectFeatures(selectedFeatures)
                     } catch {
                         // Updates the error and shows an alert.
                         self.error = error

--- a/Shared/Samples/Select features in feature layer/SelectFeaturesInFeatureLayerView.swift
+++ b/Shared/Samples/Select features in feature layer/SelectFeaturesInFeatureLayerView.swift
@@ -76,7 +76,7 @@ struct SelectFeaturesInFeatureLayerView: View {
 }
 
 private extension SelectFeaturesInFeatureLayerView {
-    private class Model: ObservableObject {
+    class Model: ObservableObject {
         /// A map with a topographic basemap style and a feature layer.
         let map: Map = {
             // A feature layer visualizing GDP per capita.

--- a/Shared/Samples/Select features in feature layer/SelectFeaturesInFeatureLayerView.swift
+++ b/Shared/Samples/Select features in feature layer/SelectFeaturesInFeatureLayerView.swift
@@ -77,22 +77,20 @@ struct SelectFeaturesInFeatureLayerView: View {
 
 private extension SelectFeaturesInFeatureLayerView {
     class Model: ObservableObject {
-        /// A map with a topographic basemap style and a feature layer.
-        let map: Map = {
-            // A feature layer visualizing GDP per capita.
-            let featureLayer = FeatureLayer(
-                item: PortalItem(
-                    portal: .arcGISOnline(connection: .anonymous),
-                    id: .gdpPerCapita
-                )
+        /// A feature layer visualizing GDP per capita.
+        let gdpPerCapitaLayer = FeatureLayer(
+            item: PortalItem(
+                portal: .arcGISOnline(connection: .anonymous),
+                id: .gdpPerCapita
             )
-            let map = Map(basemapStyle: .arcGISTopographic)
-            map.addOperationalLayer(featureLayer)
-            return map
-        }()
-        
-        var featureLayer: FeatureLayer {
-            map.operationalLayers.first as! FeatureLayer
+        )
+
+        /// A map with a topographic basemap style and a feature layer.
+        let map: Map
+
+        init() {
+            map = Map(basemapStyle: .arcGISTopographic)
+            map.addOperationalLayer(gdpPerCapitaLayer)
         }
     }
 }

--- a/Shared/Samples/Select features in feature layer/SelectFeaturesInFeatureLayerView.swift
+++ b/Shared/Samples/Select features in feature layer/SelectFeaturesInFeatureLayerView.swift
@@ -76,6 +76,8 @@ struct SelectFeaturesInFeatureLayerView: View {
 }
 
 private extension SelectFeaturesInFeatureLayerView {
+    /// The model used to store the geo model and other expensive objects
+    /// used in this view.
     class Model: ObservableObject {
         /// A feature layer visualizing GDP per capita.
         let gdpPerCapitaLayer = FeatureLayer(

--- a/Shared/Samples/Select features in feature layer/SelectFeaturesInFeatureLayerView.swift
+++ b/Shared/Samples/Select features in feature layer/SelectFeaturesInFeatureLayerView.swift
@@ -84,10 +84,10 @@ private extension SelectFeaturesInFeatureLayerView {
                 id: .gdpPerCapita
             )
         )
-
+        
         /// A map with a topographic basemap style and a feature layer.
         let map: Map
-
+        
         init() {
             map = Map(basemapStyle: .arcGISTopographic)
             map.addOperationalLayer(gdpPerCapitaLayer)

--- a/Shared/Samples/Select features in feature layer/SelectFeaturesInFeatureLayerView.swift
+++ b/Shared/Samples/Select features in feature layer/SelectFeaturesInFeatureLayerView.swift
@@ -28,27 +28,12 @@ struct SelectFeaturesInFeatureLayerView: View {
     /// The error to display in the alert.
     @State private var error: Error?
     
-    /// A map with a topographic basemap style and a feature layer.
-    @StateObject private var map: Map = {
-        // A feature layer visualizing GDP per capita.
-        let featureLayer = FeatureLayer(
-            item: PortalItem(
-                portal: .arcGISOnline(connection: .anonymous),
-                id: .gdpPerCapita
-            )
-        )
-        let map = Map(basemapStyle: .arcGISTopographic)
-        map.addOperationalLayer(featureLayer)
-        return map
-    }()
-    
-    private var featureLayer: FeatureLayer {
-        map.operationalLayers.first as! FeatureLayer
-    }
+    /// The view model for the sample.
+    @StateObject private var model = Model()
     
     var body: some View {
         MapViewReader { mapViewProxy in
-            MapView(map: map)
+            MapView(map: model.map)
                 .onSingleTapGesture { screenPoint, _ in
                     identifyPoint = screenPoint
                 }
@@ -57,11 +42,11 @@ struct SelectFeaturesInFeatureLayerView: View {
                     
                     do {
                         // Unselects the selected features.
-                        featureLayer.unselectFeatures(selectedFeatures)
+                        model.featureLayer.unselectFeatures(selectedFeatures)
                         
                         // Saves the results from the identify method on the map view proxy.
                         let results = try await mapViewProxy.identify(
-                            on: featureLayer,
+                            on: model.featureLayer,
                             screenPoint: identifyPoint,
                             tolerance: 12,
                             maximumResults: 10
@@ -71,7 +56,7 @@ struct SelectFeaturesInFeatureLayerView: View {
                         selectedFeatures = results.geoElements as! [Feature]
                         
                         // Selects the features from the selected features array.
-                        featureLayer.selectFeatures(selectedFeatures)
+                        model.featureLayer.selectFeatures(selectedFeatures)
                     } catch {
                         // Updates the error and shows an alert.
                         self.error = error
@@ -85,6 +70,28 @@ struct SelectFeaturesInFeatureLayerView: View {
                         .background(.thinMaterial, ignoresSafeAreaEdges: .horizontal)
                 }
                 .alert(isPresented: $isShowingAlert, presentingError: error)
+        }
+    }
+}
+
+private extension SelectFeaturesInFeatureLayerView {
+    private class Model: ObservableObject {
+        /// A map with a topographic basemap style and a feature layer.
+        let map: Map = {
+            // A feature layer visualizing GDP per capita.
+            let featureLayer = FeatureLayer(
+                item: PortalItem(
+                    portal: .arcGISOnline(connection: .anonymous),
+                    id: .gdpPerCapita
+                )
+            )
+            let map = Map(basemapStyle: .arcGISTopographic)
+            map.addOperationalLayer(featureLayer)
+            return map
+        }()
+        
+        var featureLayer: FeatureLayer {
+            map.operationalLayers.first as! FeatureLayer
         }
     }
 }

--- a/Shared/Samples/Set basemap/SetBasemapView.swift
+++ b/Shared/Samples/Set basemap/SetBasemapView.swift
@@ -20,6 +20,8 @@ struct SetBasemapView: View {
     /// A Boolean value that indicates whether to show the basemap gallery.
     @State private var isShowingBasemapGallery = false
     
+    /// The model used to store the geo model and other expensive objects
+    /// used in this view.
     private class Model: ObservableObject {
         /// A map with imagery basemap.
         let map: Map = {

--- a/Shared/Samples/Set basemap/SetBasemapView.swift
+++ b/Shared/Samples/Set basemap/SetBasemapView.swift
@@ -17,8 +17,13 @@ import ArcGIS
 import ArcGISToolkit
 
 struct SetBasemapView: View {
-    /// A map with imagery basemap.
-    @StateObject private var map = Map(basemapStyle: .arcGISImagery)
+    private class Model: ObservableObject {
+        /// A map with imagery basemap.
+        let map = Map(basemapStyle: .arcGISImagery)
+    }
+    
+    /// The view model for the sample.
+    @StateObject private var model = Model()
     
     /// The initial viewpoint of the map.
     private let initialViewpoint = Viewpoint(
@@ -30,10 +35,10 @@ struct SetBasemapView: View {
     @State private var isShowingBasemapGallery = false
     
     var body: some View {
-        MapView(map: map, viewpoint: initialViewpoint)
+        MapView(map: model.map, viewpoint: initialViewpoint)
             .overlay(alignment: .topTrailing) {
                 if isShowingBasemapGallery {
-                    BasemapGallery(geoModel: map)
+                    BasemapGallery(geoModel: model.map)
                         .style(.automatic())
                         .esriBorder()
                 }

--- a/Shared/Samples/Set basemap/SetBasemapView.swift
+++ b/Shared/Samples/Set basemap/SetBasemapView.swift
@@ -17,25 +17,27 @@ import ArcGIS
 import ArcGISToolkit
 
 struct SetBasemapView: View {
+    /// A Boolean value that indicates whether to show the basemap gallery.
+    @State private var isShowingBasemapGallery = false
+    
     private class Model: ObservableObject {
         /// A map with imagery basemap.
-        let map = Map(basemapStyle: .arcGISImagery)
+        let map: Map = {
+            let map = Map(basemapStyle: .arcGISImagery)
+            // The initial viewpoint of the map.
+            map.initialViewpoint = Viewpoint(
+                center: Point(x: -118.4, y: 33.7, spatialReference: .wgs84),
+                scale: 1e6
+            )
+            return map
+        }()
     }
     
     /// The view model for the sample.
     @StateObject private var model = Model()
     
-    /// The initial viewpoint of the map.
-    private let initialViewpoint = Viewpoint(
-        center: Point(x: -118.4, y: 33.7, spatialReference: .wgs84),
-        scale: 1e6
-    )
-    
-    /// A Boolean value that indicates whether to show the basemap gallery.
-    @State private var isShowingBasemapGallery = false
-    
     var body: some View {
-        MapView(map: model.map, viewpoint: initialViewpoint)
+        MapView(map: model.map)
             .overlay(alignment: .topTrailing) {
                 if isShowingBasemapGallery {
                     BasemapGallery(geoModel: model.map)

--- a/Shared/Samples/Set surface placement mode/SetSurfacePlacementModeView.swift
+++ b/Shared/Samples/Set surface placement mode/SetSurfacePlacementModeView.swift
@@ -60,7 +60,8 @@ struct SetSurfacePlacementModeView: View {
 }
 
 private extension SetSurfacePlacementModeView {
-    /// A view model for this sample.
+    /// The model used to store the geo model and other expensive objects
+    /// used in this view.
     class Model: ObservableObject {
         /// The range of possible z-values. The z-value range is 0 to 140 meters in this sample.
         let zValueRange = Measurement.zMin...Measurement.zMax

--- a/Shared/Samples/Set viewpoint rotation/SetViewpointRotationView.swift
+++ b/Shared/Samples/Set viewpoint rotation/SetViewpointRotationView.swift
@@ -26,6 +26,8 @@ struct SetViewpointRotationView: View {
     /// The rotation angle for the viewpoint.
     @State private var rotation = Double.zero
     
+    /// The model used to store the geo model and other expensive objects
+    /// used in this view.
     private class Model: ObservableObject {
         /// A map with ArcGIS Streets basemap style.
         let map = Map(basemapStyle: .arcGISStreets)

--- a/Shared/Samples/Set viewpoint rotation/SetViewpointRotationView.swift
+++ b/Shared/Samples/Set viewpoint rotation/SetViewpointRotationView.swift
@@ -17,9 +17,6 @@ import ArcGIS
 import ArcGISToolkit
 
 struct SetViewpointRotationView: View {
-    /// A map with ArcGIS Streets basemap style.
-    @StateObject private var map = Map(basemapStyle: .arcGISStreets)
-    
     /// The center of the viewpoint.
     @State private var center = Point(x: -117.156229, y: 32.713652, spatialReference: .wgs84)
     
@@ -29,9 +26,17 @@ struct SetViewpointRotationView: View {
     /// The rotation angle for the viewpoint.
     @State private var rotation = Double.zero
     
+    private class Model: ObservableObject {
+        /// A map with ArcGIS Streets basemap style.
+        let map: Map = Map(basemapStyle: .arcGISStreets)
+    }
+    
+    /// The view model for the sample.
+    @StateObject private var model = Model()
+    
     var body: some View {
         VStack {
-            MapView(map: map, viewpoint: Viewpoint(center: center, scale: scale, rotation: rotation))
+            MapView(map: model.map, viewpoint: Viewpoint(center: center, scale: scale, rotation: rotation))
                 .onViewpointChanged(kind: .centerAndScale) { viewpoint in
                     center = viewpoint.targetGeometry.extent.center
                     scale = viewpoint.targetScale

--- a/Shared/Samples/Set viewpoint rotation/SetViewpointRotationView.swift
+++ b/Shared/Samples/Set viewpoint rotation/SetViewpointRotationView.swift
@@ -28,7 +28,7 @@ struct SetViewpointRotationView: View {
     
     private class Model: ObservableObject {
         /// A map with ArcGIS Streets basemap style.
-        let map: Map = Map(basemapStyle: .arcGISStreets)
+        let map = Map(basemapStyle: .arcGISStreets)
     }
     
     /// The view model for the sample.

--- a/Shared/Samples/Show callout/ShowCalloutView.swift
+++ b/Shared/Samples/Show callout/ShowCalloutView.swift
@@ -45,8 +45,8 @@ struct ShowCalloutView: View {
                     Text("Location")
                         .font(.headline)
                     Text(
-                        CoordinateFormatter.toLatitudeLongitude(
-                            point: callout.location,
+                        CoordinateFormatter.latitudeLongitudeString(
+                            from: callout.location,
                             format: .decimalDegrees,
                             decimalPlaces: 2
                         )

--- a/Shared/Samples/Show callout/ShowCalloutView.swift
+++ b/Shared/Samples/Show callout/ShowCalloutView.swift
@@ -16,6 +16,8 @@ import SwiftUI
 import ArcGIS
 
 struct ShowCalloutView: View {
+    /// The model used to store the geo model and other expensive objects
+    /// used in this view.
     private class Model: ObservableObject {
         /// A map with a topographic basemap style.
         let map = Map(basemapStyle: .arcGISTopographic)

--- a/Shared/Samples/Show callout/ShowCalloutView.swift
+++ b/Shared/Samples/Show callout/ShowCalloutView.swift
@@ -16,14 +16,19 @@ import SwiftUI
 import ArcGIS
 
 struct ShowCalloutView: View {
-    /// A map with a topographic basemap style.
-    @StateObject private var map = Map(basemapStyle: .arcGISTopographic)
+    private class Model: ObservableObject {
+        /// A map with a topographic basemap style.
+        let map = Map(basemapStyle: .arcGISTopographic)
+    }
+    
+    /// The view model for the sample.
+    @StateObject private var model = Model()
     
     /// A location callout placement.
     @State private var calloutPlacement: LocationCalloutPlacement?
     
     var body: some View {
-        MapView(map: map)
+        MapView(map: model.map)
             .onSingleTapGesture { _, mapPoint in
                 if calloutPlacement == nil {
                     // Projects the point to the WGS 84 spatial reference.

--- a/Shared/Samples/Show device location/ShowDeviceLocationView.swift
+++ b/Shared/Samples/Show device location/ShowDeviceLocationView.swift
@@ -80,7 +80,7 @@ private extension ShowDeviceLocationView {
         /// A Boolean value indicating whether to show the device location.
         @Published var isShowingLocation: Bool {
             didSet {
-                locationDisplay.showLocation = isShowingLocation
+                locationDisplay.showsLocation = isShowingLocation
             }
         }
         

--- a/Shared/Samples/Show device location/ShowDeviceLocationView.swift
+++ b/Shared/Samples/Show device location/ShowDeviceLocationView.swift
@@ -35,6 +35,9 @@ struct ShowDeviceLocationView: View {
         MapView(map: model.map)
             .locationDisplay(model.locationDisplay)
             .task {
+                guard model.locationDisplay.dataSource.status != .started else {
+                    return
+                }
                 do {
                     try await model.startLocationDataSource()
                     settingsButtonIsDisabled = false

--- a/Shared/Samples/Show device location/ShowDeviceLocationView.swift
+++ b/Shared/Samples/Show device location/ShowDeviceLocationView.swift
@@ -37,7 +37,7 @@ struct ShowDeviceLocationView: View {
             .task {
                 do {
                     try await model.startLocationDataSource()
-                    await model.updateAutoPanMode()
+                    model.updateAutoPanMode()
                     areSettingsDisabled = false
                 } catch {
                     // Shows an alert with an error if starting the data source fails.
@@ -116,10 +116,12 @@ private extension ShowDeviceLocationView {
         }
         
         /// Updates the current auto-pan mode if it does not match the location display's auto-pan mode.
-        func updateAutoPanMode() async {
-            for await mode in locationDisplay.$autoPanMode {
-                if autoPanMode != mode {
-                    autoPanMode = mode
+        func updateAutoPanMode() {
+            Task {
+                for await mode in locationDisplay.$autoPanMode {
+                    if autoPanMode != mode {
+                        autoPanMode = mode
+                    }
                 }
             }
         }

--- a/Shared/Samples/Show device location/ShowDeviceLocationView.swift
+++ b/Shared/Samples/Show device location/ShowDeviceLocationView.swift
@@ -106,7 +106,6 @@ private extension ShowDeviceLocationView {
             }
             // Starts the location display data source.
             try await locationDisplay.dataSource.start()
-            
         }
         
         /// Stops the location data source.

--- a/Shared/Samples/Show device location/ShowDeviceLocationView.swift
+++ b/Shared/Samples/Show device location/ShowDeviceLocationView.swift
@@ -100,7 +100,7 @@ private extension ShowDeviceLocationView {
         init() {
             let locationDisplay = LocationDisplay(dataSource: SystemLocationDataSource())
             self.locationDisplay = locationDisplay
-            self.isShowingLocation = locationDisplay.showLocation
+            self.isShowingLocation = locationDisplay.showsLocation
             self.autoPanMode = locationDisplay.autoPanMode
         }
         

--- a/Shared/Samples/Show device location/ShowDeviceLocationView.swift
+++ b/Shared/Samples/Show device location/ShowDeviceLocationView.swift
@@ -26,7 +26,7 @@ struct ShowDeviceLocationView: View {
     }
     
     /// A Boolean value indicating whether the settings button is disabled.
-    @State private var areSettingsDisabled = true
+    @State private var settingsButtonIsDisabled = true
     
     /// The view model for this sample.
     @StateObject private var model = Model()
@@ -37,8 +37,14 @@ struct ShowDeviceLocationView: View {
             .task {
                 do {
                     try await model.startLocationDataSource()
-                    model.updateAutoPanMode()
-                    areSettingsDisabled = false
+                    settingsButtonIsDisabled = false
+                    // Updates the current auto-pan mode if it does not match the
+                    // location display's auto-pan mode.
+                    for await mode in model.locationDisplay.$autoPanMode {
+                        if model.autoPanMode != mode {
+                            model.autoPanMode = mode
+                        }
+                    }
                 } catch {
                     // Shows an alert with an error if starting the data source fails.
                     self.error = error
@@ -59,7 +65,7 @@ struct ShowDeviceLocationView: View {
                             }
                         }
                     }
-                    .disabled(areSettingsDisabled)
+                    .disabled(settingsButtonIsDisabled)
                 }
             }
             .alert(isPresented: $isShowingAlert, presentingError: error)
@@ -112,17 +118,6 @@ private extension ShowDeviceLocationView {
         func stopLocationDataSource() {
             Task {
                 await locationDisplay.dataSource.stop()
-            }
-        }
-        
-        /// Updates the current auto-pan mode if it does not match the location display's auto-pan mode.
-        func updateAutoPanMode() {
-            Task {
-                for await mode in locationDisplay.$autoPanMode {
-                    if autoPanMode != mode {
-                        autoPanMode = mode
-                    }
-                }
             }
         }
     }

--- a/Shared/Samples/Show device location/ShowDeviceLocationView.swift
+++ b/Shared/Samples/Show device location/ShowDeviceLocationView.swift
@@ -73,7 +73,8 @@ struct ShowDeviceLocationView: View {
 }
 
 private extension ShowDeviceLocationView {
-    /// The view model for this sample.
+    /// The model used to store the geo model and other expensive objects
+    /// used in this view.
     @MainActor
     class Model: ObservableObject {
         /// A Boolean value indicating whether to show the device location.

--- a/Shared/Samples/Show result of spatial operations/ShowResultOfSpatialOperationsView.swift
+++ b/Shared/Samples/Show result of spatial operations/ShowResultOfSpatialOperationsView.swift
@@ -56,7 +56,7 @@ struct ShowResultOfSpatialOperationsView: View {
 }
 
 private extension ShowResultOfSpatialOperationsView {
-    private class Model: ObservableObject {
+    class Model: ObservableObject {
         /// A map with a topographic basemap style and initial viewpoint.
         let map: Map = {
             let map = Map(basemapStyle: .arcGISTopographic)

--- a/Shared/Samples/Show result of spatial operations/ShowResultOfSpatialOperationsView.swift
+++ b/Shared/Samples/Show result of spatial operations/ShowResultOfSpatialOperationsView.swift
@@ -91,9 +91,7 @@ private extension ShowResultOfSpatialOperationsView {
         }()
         
         /// A graphic representing the result of the spatial operation.
-        var resultGraphic: Graphic {
-            return graphicsOverlay.graphics.last!
-        }
+        var resultGraphic: Graphic { graphicsOverlay.graphics.last! }
         
         /// Updates the result graphic based on the spatial operation.
         func performOperation(_ spatialOperation: SpatialOperation) {

--- a/Shared/Samples/Show result of spatial operations/ShowResultOfSpatialOperationsView.swift
+++ b/Shared/Samples/Show result of spatial operations/ShowResultOfSpatialOperationsView.swift
@@ -19,16 +19,8 @@ struct ShowResultOfSpatialOperationsView: View {
     /// The current spatial operation performed.
     @State private var spatialOperation = SpatialOperation.none
     
-    /// A map with a topographic basemap style and initial viewpoint.
-    @StateObject private var map = makeMap()
-    
-    /// A graphics overlay for the map view.
-    @StateObject private var graphicsOverlay = makeGraphicsOverlay()
-    
-    /// A graphic representing the result of the spatial operation.
-    private var resultGraphic: Graphic {
-        return graphicsOverlay.graphics.last!
-    }
+    /// The view model for the sample.
+    @StateObject private var model = Model()
     
     /// An enum of spatial operations.
     private enum SpatialOperation: CaseIterable {
@@ -46,61 +38,10 @@ struct ShowResultOfSpatialOperationsView: View {
         }
     }
     
-    /// Creates a map.
-    private static func makeMap() -> Map {
-        let map = Map(basemapStyle: .arcGISTopographic)
-        map.initialViewpoint = Viewpoint(
-            center: Point(x: -13453, y: 6710127, spatialReference: .webMercator),
-            scale: 30_000
-        )
-        return map
-    }
-    
-    /// Creates the graphics overlay.
-    private static func makeGraphicsOverlay() -> GraphicsOverlay {
-        // Creates the graphics for the two polygons and result.
-        let polygonOneGraphic = Graphic(
-            geometry: .polygon1,
-            symbol: SimpleFillSymbol(color: .blue, outline: .simple)
-        )
-        
-        let polygonTwoGraphic = Graphic(
-            geometry: .polygon2,
-            symbol: SimpleFillSymbol(color: .green, outline: .simple)
-        )
-        
-        let resultGraphic = Graphic(
-            symbol: SimpleFillSymbol(color: .red, outline: .simple)
-        )
-        
-        // Adds the graphics to the overlay.
-        return GraphicsOverlay(graphics: [polygonOneGraphic, polygonTwoGraphic, resultGraphic])
-    }
-    
-    /// Updates the result graphic based on the spatial operation.
-    private func performOperation() {
-        let resultGeometry: Geometry?
-        // Updates the geometry based on the selected spatial operation.
-        switch spatialOperation {
-        case .none:
-            resultGeometry = nil
-        case .union:
-            resultGeometry = GeometryEngine.union(.polygon1, .polygon2)
-        case .difference:
-            resultGeometry = GeometryEngine.difference(.polygon1, .polygon2)
-        case .symmetricDifference:
-            resultGeometry = GeometryEngine.symmetricDifference(.polygon1, .polygon2)
-        case .intersection:
-            resultGeometry = GeometryEngine.intersection(.polygon1, .polygon2)
-        }
-        // Updates the result graphic geometry.
-        resultGraphic.geometry = resultGeometry
-    }
-    
     var body: some View {
-        MapView(map: map, graphicsOverlays: [graphicsOverlay])
+        MapView(map: model.map, graphicsOverlays: [model.graphicsOverlay])
             .onChange(of: spatialOperation) { _ in
-                performOperation()
+                model.performOperation(spatialOperation)
             }
             .toolbar {
                 ToolbarItem(placement: .bottomBar) {
@@ -111,6 +52,66 @@ struct ShowResultOfSpatialOperationsView: View {
                     }
                 }
             }
+    }
+}
+
+private extension ShowResultOfSpatialOperationsView {
+    private class Model: ObservableObject {
+        /// A map with a topographic basemap style and initial viewpoint.
+        let map: Map = {
+            let map = Map(basemapStyle: .arcGISTopographic)
+            map.initialViewpoint = Viewpoint(
+                center: Point(x: -13453, y: 6710127, spatialReference: .webMercator),
+                scale: 30_000
+            )
+            return map
+        }()
+        
+        /// A graphics overlay for the map view.
+        let graphicsOverlay: GraphicsOverlay = {
+            // Creates the graphics for the two polygons and result.
+            let polygonOneGraphic = Graphic(
+                geometry: .polygon1,
+                symbol: SimpleFillSymbol(color: .blue, outline: .simple)
+            )
+            
+            let polygonTwoGraphic = Graphic(
+                geometry: .polygon2,
+                symbol: SimpleFillSymbol(color: .green, outline: .simple)
+            )
+            
+            let resultGraphic = Graphic(
+                symbol: SimpleFillSymbol(color: .red, outline: .simple)
+            )
+            
+            // Adds the graphics to the overlay.
+            return GraphicsOverlay(graphics: [polygonOneGraphic, polygonTwoGraphic, resultGraphic])
+        }()
+        
+        /// A graphic representing the result of the spatial operation.
+        var resultGraphic: Graphic {
+            return graphicsOverlay.graphics.last!
+        }
+        
+        /// Updates the result graphic based on the spatial operation.
+        func performOperation(_ spatialOperation: SpatialOperation) {
+            let resultGeometry: Geometry?
+            // Updates the geometry based on the selected spatial operation.
+            switch spatialOperation {
+            case .none:
+                resultGeometry = nil
+            case .union:
+                resultGeometry = GeometryEngine.union(.polygon1, .polygon2)
+            case .difference:
+                resultGeometry = GeometryEngine.difference(.polygon1, .polygon2)
+            case .symmetricDifference:
+                resultGeometry = GeometryEngine.symmetricDifference(.polygon1, .polygon2)
+            case .intersection:
+                resultGeometry = GeometryEngine.intersection(.polygon1, .polygon2)
+            }
+            // Updates the result graphic geometry.
+            resultGraphic.geometry = resultGeometry
+        }
     }
 }
 

--- a/Shared/Samples/Show result of spatial operations/ShowResultOfSpatialOperationsView.swift
+++ b/Shared/Samples/Show result of spatial operations/ShowResultOfSpatialOperationsView.swift
@@ -22,22 +22,6 @@ struct ShowResultOfSpatialOperationsView: View {
     /// The view model for the sample.
     @StateObject private var model = Model()
     
-    /// An enum of spatial operations.
-    private enum SpatialOperation: CaseIterable {
-        case intersection, symmetricDifference, difference, union, none
-        
-        /// A human-readable label for each spatial operation.
-        var label: String {
-            switch self {
-            case .none: return "None"
-            case .union: return "Union"
-            case .difference: return "Difference"
-            case .symmetricDifference: return "Symmetric Difference"
-            case .intersection: return "Intersection"
-            }
-        }
-    }
-    
     var body: some View {
         MapView(map: model.map, graphicsOverlays: [model.graphicsOverlay])
             .onChange(of: spatialOperation) { _ in
@@ -56,6 +40,22 @@ struct ShowResultOfSpatialOperationsView: View {
 }
 
 private extension ShowResultOfSpatialOperationsView {
+    /// An enum of spatial operations.
+    enum SpatialOperation: CaseIterable {
+        case intersection, symmetricDifference, difference, union, none
+        
+        /// A human-readable label for each spatial operation.
+        var label: String {
+            switch self {
+            case .none: return "None"
+            case .union: return "Union"
+            case .difference: return "Difference"
+            case .symmetricDifference: return "Symmetric Difference"
+            case .intersection: return "Intersection"
+            }
+        }
+    }
+    
     class Model: ObservableObject {
         /// A map with a topographic basemap style and initial viewpoint.
         let map: Map = {

--- a/Shared/Samples/Show result of spatial operations/ShowResultOfSpatialOperationsView.swift
+++ b/Shared/Samples/Show result of spatial operations/ShowResultOfSpatialOperationsView.swift
@@ -56,6 +56,8 @@ private extension ShowResultOfSpatialOperationsView {
         }
     }
     
+    /// The model used to store the geo model and other expensive objects
+    /// used in this view.
     class Model: ObservableObject {
         /// A map with a topographic basemap style and initial viewpoint.
         let map: Map = {

--- a/Shared/Samples/Show result of spatial relationships/ShowResultOfSpatialRelationshipsView.swift
+++ b/Shared/Samples/Show result of spatial relationships/ShowResultOfSpatialRelationshipsView.swift
@@ -42,16 +42,16 @@ struct ShowResultOfSpatialRelationshipsView: View {
     /// Shows the relationships for the selected graphic.
     /// - Parameter graphic: The graphic to show all spatial relationships for.
     private func showRelationships(for graphic: Graphic) {
-        guard let selectedGeometry = graphic.geometry,
-              let allRelationships = model.allRelationships(for: selectedGeometry),
-              let mapPoint = mapPoint else {
+        guard let selectedGeometry = graphic.geometry else {
             return
         }
-        
         // Updates the relationships.
-        relationships = allRelationships
+        relationships = model.allRelationships(for: selectedGeometry)
+        guard !relationships.isEmpty else {
+            return
+        }
         // Updates the location callout placement.
-        calloutPlacement = LocationCalloutPlacement(location: mapPoint)
+        calloutPlacement = mapPoint.map { LocationCalloutPlacement(location: $0) }
     }
     
     var body: some View {
@@ -137,12 +137,10 @@ private extension ShowResultOfSpatialRelationshipsView {
         /// Returns the relevant spatial relationships for a given geometry with all other geometries in this sample.
         /// - Parameter geometry: The geometry to find all spatial relationships for.
         /// - Returns: An array of relationships between the given geometry and all other geometries.
-        func allRelationships(for geometry: Geometry) -> [Relationship]? {
-            guard let pointGeometry = pointGraphic.geometry,
-                  let polylineGeometry = polylineGraphic.geometry,
-                  let polygonGeometry = polygonGraphic.geometry else {
-                return nil
-            }
+        func allRelationships(for geometry: Geometry) -> [Relationship] {
+            let pointGeometry = pointGraphic.geometry!
+            let polylineGeometry = polylineGraphic.geometry!
+            let polygonGeometry = polygonGraphic.geometry!
             
             switch geometry {
             case is Point:
@@ -161,7 +159,7 @@ private extension ShowResultOfSpatialRelationshipsView {
                     Relationship(between: polygonGeometry, and: polylineGeometry)
                 ]
             default:
-                return nil
+                return []
             }
         }
     }

--- a/Shared/Samples/Show result of spatial relationships/ShowResultOfSpatialRelationshipsView.swift
+++ b/Shared/Samples/Show result of spatial relationships/ShowResultOfSpatialRelationshipsView.swift
@@ -33,82 +33,34 @@ struct ShowResultOfSpatialRelationshipsView: View {
     /// A location callout placement.
     @State private var calloutPlacement: LocationCalloutPlacement?
     
-    /// The relationships for the selected graphic.
-    @State private var relationships: [Relationship] = []
-    
-    /// A map with a topographic basemap style and an initial viewpoint.
-    @StateObject private var map: Map = {
-        let map = Map(basemapStyle: .arcGISTopographic)
-        map.initialViewpoint = Viewpoint(center: Graphic.point.geometry as! Point, scale: 1e8)
-        return map
-    }()
-    
-    /// A graphics overlay consisting of a polygon, polyline, and point.
-    @StateObject private var graphicsOverlay = GraphicsOverlay(graphics: [.polygon, .polyline, .point])
-    
-    /// The polygon graphic.
-    private var polygonGraphic: Graphic { graphicsOverlay.graphics[0] }
-    /// The polyline graphic.
-    private var polylineGraphic: Graphic { graphicsOverlay.graphics[1] }
-    /// The point graphic.
-    private var pointGraphic: Graphic { graphicsOverlay.graphics[2] }
+    /// The view model for the sample.
+    @StateObject private var model = Model()
     
     /// Shows the relationships for the selected graphic.
     /// - Parameter graphic: The graphic to show all spatial relationships for.
     private func showRelationships(for graphic: Graphic) {
         guard let selectedGeometry = graphic.geometry,
-              let allRelationships = allRelationships(for: selectedGeometry),
+              let allRelationships = model.allRelationships(for: selectedGeometry),
               let mapPoint = mapPoint else {
             return
         }
         
         // Updates the relationships.
-        relationships = allRelationships
+        model.relationships = allRelationships
         // Updates the location callout placement.
         calloutPlacement = LocationCalloutPlacement(location: mapPoint)
     }
     
-    /// Returns the relevant spatial relationships for a given geometry with all other geometries in this sample.
-    /// - Parameter geometry: The geometry to find all spatial relationships for.
-    /// - Returns: An array of relationships between the given geometry and all other geometries.
-    private func allRelationships(for geometry: Geometry) -> [Relationship]? {
-        guard let pointGeometry = pointGraphic.geometry,
-              let polylineGeometry = polylineGraphic.geometry,
-              let polygonGeometry = polygonGraphic.geometry else {
-            return nil
-        }
-        
-        switch geometry {
-        case is Point:
-            return [
-                Relationship(between: pointGeometry, and: polylineGeometry),
-                Relationship(between: pointGeometry, and: polygonGeometry)
-            ]
-        case is Polyline:
-            return [
-                Relationship(between: polylineGeometry, and: pointGeometry),
-                Relationship(between: polylineGeometry, and: polygonGeometry)
-            ]
-        case is ArcGIS.Polygon:
-            return [
-                Relationship(between: polygonGeometry, and: pointGeometry),
-                Relationship(between: polygonGeometry, and: polylineGeometry)
-            ]
-        default:
-            return nil
-        }
-    }
-    
     var body: some View {
         MapViewReader { mapView in
-            MapView(map: map, graphicsOverlays: [graphicsOverlay])
+            MapView(map: model.map, graphicsOverlays: [model.graphicsOverlay])
                 .onSingleTapGesture { screenPoint, mapPoint in
                     identifyPoint = screenPoint
                     self.mapPoint = mapPoint
                 }
                 .callout(placement: $calloutPlacement.animation(.default.speed(4))) { _ in
                     VStack(alignment: .leading) {
-                        ForEach(relationships, id: \.relationshipWithLabel) { relationship in
+                        ForEach(model.relationships, id: \.relationshipWithLabel) { relationship in
                             Text(relationship.relationshipWithLabel)
                                 .font(.headline)
                             VStack(alignment: .leading) {
@@ -124,13 +76,13 @@ struct ShowResultOfSpatialRelationshipsView: View {
                 .task(id: identifyPoint) {
                     guard let identifyPoint = identifyPoint else { return }
                     // Clears the selection.
-                    graphicsOverlay.clearSelection()
+                    model.graphicsOverlay.clearSelection()
                     
                     if calloutPlacement == nil {
                         do {
                             // Identifies the graphic at the given screen point.
                             let results = try await mapView.identify(
-                                on: graphicsOverlay,
+                                on: model.graphicsOverlay,
                                 screenPoint: identifyPoint,
                                 tolerance: 12,
                                 maximumResults: 1
@@ -138,7 +90,7 @@ struct ShowResultOfSpatialRelationshipsView: View {
                             
                             if let identifiedGraphic = results.graphics.first {
                                 // Selects the identified graphic.
-                                graphicsOverlay.selectGraphics([identifiedGraphic])
+                                model.graphicsOverlay.selectGraphics([identifiedGraphic])
                                 // Shows the graphic's relationships.
                                 showRelationships(for: identifiedGraphic)
                             }
@@ -156,6 +108,61 @@ struct ShowResultOfSpatialRelationshipsView: View {
                         .padding(.vertical, 6)
                         .background(.thinMaterial, ignoresSafeAreaEdges: .horizontal)
                 }
+        }
+    }
+}
+
+private extension ShowResultOfSpatialRelationshipsView {
+    private class Model: ObservableObject {
+        /// A map with a topographic basemap style and an initial viewpoint.
+        let map: Map = {
+            let map = Map(basemapStyle: .arcGISTopographic)
+            map.initialViewpoint = Viewpoint(center: Graphic.point.geometry as! Point, scale: 1e8)
+            return map
+        }()
+        
+        /// A graphics overlay consisting of a polygon, polyline, and point.
+        let graphicsOverlay = GraphicsOverlay(graphics: [.polygon, .polyline, .point])
+        
+        /// The polygon graphic.
+        private var polygonGraphic: Graphic { graphicsOverlay.graphics[0] }
+        /// The polyline graphic.
+        private var polylineGraphic: Graphic { graphicsOverlay.graphics[1] }
+        /// The point graphic.
+        private var pointGraphic: Graphic { graphicsOverlay.graphics[2] }
+        
+        /// The relationships for the selected graphic.
+        var relationships: [Relationship] = []
+        
+        /// Returns the relevant spatial relationships for a given geometry with all other geometries in this sample.
+        /// - Parameter geometry: The geometry to find all spatial relationships for.
+        /// - Returns: An array of relationships between the given geometry and all other geometries.
+        func allRelationships(for geometry: Geometry) -> [Relationship]? {
+            guard let pointGeometry = pointGraphic.geometry,
+                  let polylineGeometry = polylineGraphic.geometry,
+                  let polygonGeometry = polygonGraphic.geometry else {
+                return nil
+            }
+            
+            switch geometry {
+            case is Point:
+                return [
+                    Relationship(between: pointGeometry, and: polylineGeometry),
+                    Relationship(between: pointGeometry, and: polygonGeometry)
+                ]
+            case is Polyline:
+                return [
+                    Relationship(between: polylineGeometry, and: pointGeometry),
+                    Relationship(between: polylineGeometry, and: polygonGeometry)
+                ]
+            case is ArcGIS.Polygon:
+                return [
+                    Relationship(between: polygonGeometry, and: pointGeometry),
+                    Relationship(between: polygonGeometry, and: polylineGeometry)
+                ]
+            default:
+                return nil
+            }
         }
     }
 }

--- a/Shared/Samples/Show result of spatial relationships/ShowResultOfSpatialRelationshipsView.swift
+++ b/Shared/Samples/Show result of spatial relationships/ShowResultOfSpatialRelationshipsView.swift
@@ -33,6 +33,9 @@ struct ShowResultOfSpatialRelationshipsView: View {
     /// A location callout placement.
     @State private var calloutPlacement: LocationCalloutPlacement?
     
+    /// The relationships for the selected graphic.
+    @State private var relationships: [Relationship] = []
+    
     /// The view model for the sample.
     @StateObject private var model = Model()
     
@@ -46,7 +49,7 @@ struct ShowResultOfSpatialRelationshipsView: View {
         }
         
         // Updates the relationships.
-        model.relationships = allRelationships
+        relationships = allRelationships
         // Updates the location callout placement.
         calloutPlacement = LocationCalloutPlacement(location: mapPoint)
     }
@@ -60,7 +63,7 @@ struct ShowResultOfSpatialRelationshipsView: View {
                 }
                 .callout(placement: $calloutPlacement.animation(.default.speed(4))) { _ in
                     VStack(alignment: .leading) {
-                        ForEach(model.relationships, id: \.relationshipWithLabel) { relationship in
+                        ForEach(relationships, id: \.relationshipWithLabel) { relationship in
                             Text(relationship.relationshipWithLabel)
                                 .font(.headline)
                             VStack(alignment: .leading) {
@@ -130,9 +133,6 @@ private extension ShowResultOfSpatialRelationshipsView {
         private var polylineGraphic: Graphic { graphicsOverlay.graphics[1] }
         /// The point graphic.
         private var pointGraphic: Graphic { graphicsOverlay.graphics[2] }
-        
-        /// The relationships for the selected graphic.
-        var relationships: [Relationship] = []
         
         /// Returns the relevant spatial relationships for a given geometry with all other geometries in this sample.
         /// - Parameter geometry: The geometry to find all spatial relationships for.

--- a/Shared/Samples/Show result of spatial relationships/ShowResultOfSpatialRelationshipsView.swift
+++ b/Shared/Samples/Show result of spatial relationships/ShowResultOfSpatialRelationshipsView.swift
@@ -116,6 +116,8 @@ struct ShowResultOfSpatialRelationshipsView: View {
 }
 
 private extension ShowResultOfSpatialRelationshipsView {
+    /// The model used to store the geo model and other expensive objects
+    /// used in this view.
     class Model: ObservableObject {
         /// A map with a topographic basemap style and an initial viewpoint.
         let map: Map = {

--- a/Shared/Samples/Show result of spatial relationships/ShowResultOfSpatialRelationshipsView.swift
+++ b/Shared/Samples/Show result of spatial relationships/ShowResultOfSpatialRelationshipsView.swift
@@ -20,7 +20,9 @@ struct ShowResultOfSpatialRelationshipsView: View {
     @State private var isShowingAlert = false
     
     /// The error shown in the alert.
-    @State private var error: Error?
+    @State private var error: Error? {
+        didSet { isShowingAlert = error != nil }
+    }
     
     /// The point indicating where to identify a graphic.
     @State private var identifyPoint: CGPoint?
@@ -142,7 +144,6 @@ struct ShowResultOfSpatialRelationshipsView: View {
                             }
                         } catch {
                             self.error = error
-                            isShowingAlert = true
                         }
                     } else {
                         // Hides the callout.

--- a/Shared/Samples/Show result of spatial relationships/ShowResultOfSpatialRelationshipsView.swift
+++ b/Shared/Samples/Show result of spatial relationships/ShowResultOfSpatialRelationshipsView.swift
@@ -113,7 +113,7 @@ struct ShowResultOfSpatialRelationshipsView: View {
 }
 
 private extension ShowResultOfSpatialRelationshipsView {
-    private class Model: ObservableObject {
+    class Model: ObservableObject {
         /// A map with a topographic basemap style and an initial viewpoint.
         let map: Map = {
             let map = Map(basemapStyle: .arcGISTopographic)

--- a/Shared/Samples/Show viewshed from point in scene/ShowViewshedFromPointInSceneView.Model.swift
+++ b/Shared/Samples/Show viewshed from point in scene/ShowViewshedFromPointInSceneView.Model.swift
@@ -145,7 +145,7 @@ extension ShowViewshedFromPointInSceneView {
                 heading: 20,
                 pitch: 70,
                 roll: 0
-            )
+            )!
             scene.initialViewpoint = Viewpoint(targetExtent: camera.location, camera: camera)
             
             // Creates a surface.

--- a/Shared/Samples/Show viewshed from point in scene/ShowViewshedFromPointInSceneView.Model.swift
+++ b/Shared/Samples/Show viewshed from point in scene/ShowViewshedFromPointInSceneView.Model.swift
@@ -16,6 +16,8 @@ import ArcGIS
 import SwiftUI
 
 extension ShowViewshedFromPointInSceneView {
+    /// The model used to store the geo model and other expensive objects
+    /// used in this view.
     class Model: ObservableObject {
         /// The location viewshed used in the sample.
         let viewshed: LocationViewshed

--- a/Shared/Samples/Style graphics with renderer/StyleGraphicsWithRendererView.swift
+++ b/Shared/Samples/Style graphics with renderer/StyleGraphicsWithRendererView.swift
@@ -20,16 +20,7 @@ struct StyleGraphicsWithRendererView: View {
     @StateObject private var model = Model()
     
     var body: some View {
-        MapView(
-            map: model.map,
-            graphicsOverlays: [
-                model.pointGraphicsOverlay,
-                model.lineGraphicsOverlay,
-                model.squarePolygonGraphicsOverlay,
-                model.ellipseGraphicsOverlay,
-                model.curvedPolygonGraphicsOverlay
-            ]
-        )
+        MapView(map: model.map, graphicsOverlays: model.graphicsOverlays)
     }
 }
 
@@ -42,8 +33,19 @@ private extension StyleGraphicsWithRendererView {
             return map
         }()
         
+        /// The graphics overlays used in this sample.
+        var graphicsOverlays: [GraphicsOverlay] {
+            return [
+                pointGraphicsOverlay,
+                lineGraphicsOverlay,
+                squarePolygonGraphicsOverlay,
+                ellipseGraphicsOverlay,
+                curvedPolygonGraphicsOverlay
+            ]
+        }
+        
         /// The graphics overlay rendering a point.
-        let pointGraphicsOverlay: GraphicsOverlay = {
+        private let pointGraphicsOverlay: GraphicsOverlay = {
             // Creates a simple marker symbol.
             let symbol = SimpleMarkerSymbol(style: .diamond, color: .green, size: 10)
             // Creates the geometry for the point.
@@ -57,7 +59,7 @@ private extension StyleGraphicsWithRendererView {
         }()
         
         /// The graphics overlay rendering a line.
-        let lineGraphicsOverlay: GraphicsOverlay = {
+        private let lineGraphicsOverlay: GraphicsOverlay = {
             // Creates a simple line symbol.
             let symbol = SimpleLineSymbol(style: .solid, color: .blue, width: 5)
             // Creates the geometry for the line.
@@ -77,7 +79,7 @@ private extension StyleGraphicsWithRendererView {
         }()
         
         /// The graphics overlay rendering a square polygon.
-        let squarePolygonGraphicsOverlay: GraphicsOverlay = {
+        private let squarePolygonGraphicsOverlay: GraphicsOverlay = {
             // Creates a simple fill symbol.
             let symbol = SimpleFillSymbol(color: .yellow)
             // Creates the geometry for the square polygon.
@@ -99,7 +101,7 @@ private extension StyleGraphicsWithRendererView {
         }()
         
         /// The graphics overlay rendering an ellipse.
-        let ellipseGraphicsOverlay: GraphicsOverlay = {
+        private let ellipseGraphicsOverlay: GraphicsOverlay = {
             // Creates a simple fill symbol.
             let symbol = SimpleFillSymbol(color: .purple)
             // Defines the center point of the ellipse.
@@ -125,7 +127,7 @@ private extension StyleGraphicsWithRendererView {
         }()
         
         /// The graphics overlay rendering a curved polygon.
-        let curvedPolygonGraphicsOverlay: GraphicsOverlay = {
+        private let curvedPolygonGraphicsOverlay: GraphicsOverlay = {
             // Creates a simple fill symbol with an outline.
             let lineSymbol = SimpleLineSymbol(style: .solid, color: .black, width: 1)
             let fillSymbol = SimpleFillSymbol(color: .red, outline: lineSymbol)
@@ -146,7 +148,7 @@ private extension StyleGraphicsWithRendererView {
         ///   - center: The center of the square that contains the heart shape.
         ///   - sideLength: The side length of the square.
         /// - Returns: A heart-shaped polygon.
-        static func makeHeartPolygon(center: Point, sideLength: Double) -> ArcGIS.Polygon? {
+        private static func makeHeartPolygon(center: Point, sideLength: Double) -> ArcGIS.Polygon? {
             guard sideLength > 0 else { return nil }
             let spatialReference = center.spatialReference
             // Defines the x and y coordinates to simplify the calculation.

--- a/Shared/Samples/Style graphics with renderer/StyleGraphicsWithRendererView.swift
+++ b/Shared/Samples/Style graphics with renderer/StyleGraphicsWithRendererView.swift
@@ -16,188 +16,193 @@ import SwiftUI
 import ArcGIS
 
 struct StyleGraphicsWithRendererView: View {
-    /// A map with a topographic basemap style and an initial viewpoint.
-    @StateObject private var map: Map = {
-        let map = Map(basemapStyle: .arcGISTopographic)
-        map.initialViewpoint = Viewpoint(center: Point(x: 20e5, y: 20e5, spatialReference: .webMercator), scale: 7e7)
-        return map
-    }()
-    
-    /// The graphics overlay rendering a point.
-    @StateObject private var pointGraphicsOverlay: GraphicsOverlay = {
-        // Creates a simple marker symbol.
-        let symbol = SimpleMarkerSymbol(style: .diamond, color: .green, size: 10)
-        // Creates the geometry for the point.
-        let geometry = Point(x: 40e5, y: 40e5, spatialReference: .webMercator)
-        
-        // Creates a graphics overlay containing a graphic with the point geometry.
-        let overlay = GraphicsOverlay(graphics: [Graphic(geometry: geometry)])
-        // Creates and assigns a simple renderer to the graphics overlay.
-        overlay.renderer = SimpleRenderer(symbol: symbol)
-        return overlay
-    }()
-    
-    /// The graphics overlay rendering a line.
-    @StateObject private var lineGraphicsOverlay: GraphicsOverlay = {
-        // Creates a simple line symbol.
-        let symbol = SimpleLineSymbol(style: .solid, color: .blue, width: 5)
-        // Creates the geometry for the line.
-        let geometry = Polyline(
-            points: [
-                Point(x: -10e5, y: 40e5),
-                Point(x: 20e5, y: 50e5)
-            ],
-            spatialReference: .webMercator
-        )
-        
-        // Creates a graphics overlay containing a graphic with the line geometry.
-        let overlay = GraphicsOverlay(graphics: [Graphic(geometry: geometry)])
-        // Creates and assigns a simple renderer to the graphics overlay.
-        overlay.renderer = SimpleRenderer(symbol: symbol)
-        return overlay
-    }()
-    
-    /// The graphics overlay rendering a square polygon.
-    @StateObject private var squarePolygonGraphicsOverlay: GraphicsOverlay = {
-        // Creates a simple fill symbol.
-        let symbol = SimpleFillSymbol(color: .yellow)
-        // Creates the geometry for the square polygon.
-        let geometry = Polygon(
-            points: [
-                Point(x: -20e5, y: 20e5),
-                Point(x: 20e5, y: 20e5),
-                Point(x: 20e5, y: -20e5),
-                Point(x: -20e5, y: -20e5)
-            ],
-            spatialReference: .webMercator
-        )
-        
-        // Creates a graphics overlay containing a graphic with the square geometry.
-        let overlay = GraphicsOverlay(graphics: [Graphic(geometry: geometry)])
-        // Creates and assigns a simple renderer to the graphics overlay.
-        overlay.renderer = SimpleRenderer(symbol: symbol)
-        return overlay
-    }()
-    
-    /// The graphics overlay rendering an ellipse.
-    @StateObject private var ellipseGraphicsOverlay: GraphicsOverlay = {
-        // Creates a simple fill symbol.
-        let symbol = SimpleFillSymbol(color: .purple)
-        // Defines the center point of the ellipse.
-        let center = Point(x: 40e5, y: 25e5, spatialReference: .webMercator)
-        // Creates the parameters for the ellipse.
-        let parameters = GeodesicEllipseParameters(
-            axisDirection: -45,
-            center: center,
-            linearUnit: .kilometers,
-            maxPointCount: 100,
-            maxSegmentLength: 20,
-            semiAxis1Length: 200,
-            semiAxis2Length: 400
-        )
-        // Creates the geometry for the ellipse from the parameters.
-        let geometry = GeometryEngine.geodesicEllipse(parameters: parameters)
-        
-        // Creates a graphics overlay containing a graphic with the ellipse geometry.
-        let overlay = GraphicsOverlay(graphics: [Graphic(geometry: geometry)])
-        // Creates and assigns a simple renderer to the graphics overlay.
-        overlay.renderer = SimpleRenderer(symbol: symbol)
-        return overlay
-    }()
-    
-    /// The graphics overlay rendering a curved polygon.
-    @StateObject private var curvedPolygonGraphicsOverlay: GraphicsOverlay = {
-        // Creates a simple fill symbol with an outline.
-        let lineSymbol = SimpleLineSymbol(style: .solid, color: .black, width: 1)
-        let fillSymbol = SimpleFillSymbol(color: .red, outline: lineSymbol)
-        // Defines the point of origin for the curved polygon.
-        let origin = Point(x: 40e5, y: 5e5, spatialReference: .webMercator)
-        // Creates a heart-shaped polygon.
-        let heartPolygon = makeHeartPolygon(center: origin, sideLength: 10e5)
-        
-        // Creates a graphics overlay containing a graphic with the polygon geometry.
-        let overlay = GraphicsOverlay(graphics: [Graphic(geometry: heartPolygon)])
-        // Creates and assigns a simple renderer to the graphics overlay.
-        overlay.renderer = SimpleRenderer(symbol: fillSymbol)
-        return overlay
-    }()
+    /// The view model for the sample.
+    @StateObject private var model = Model()
     
     var body: some View {
         MapView(
-            map: map,
+            map: model.map,
             graphicsOverlays: [
-                pointGraphicsOverlay,
-                lineGraphicsOverlay,
-                squarePolygonGraphicsOverlay,
-                ellipseGraphicsOverlay,
-                curvedPolygonGraphicsOverlay
+                model.pointGraphicsOverlay,
+                model.lineGraphicsOverlay,
+                model.squarePolygonGraphicsOverlay,
+                model.ellipseGraphicsOverlay,
+                model.curvedPolygonGraphicsOverlay
             ]
         )
     }
 }
 
 private extension StyleGraphicsWithRendererView {
-    /// Creates a heart-shaped polygon with Bezier and elliptic arc segments.
-    /// - Parameters:
-    ///   - center: The center of the square that contains the heart shape.
-    ///   - sideLength: The side length of the square.
-    /// - Returns: A heart-shaped polygon.
-    static func makeHeartPolygon(center: Point, sideLength: Double) -> ArcGIS.Polygon? {
-        guard sideLength > 0 else { return nil }
-        let spatialReference = center.spatialReference
-        // Defines the x and y coordinates to simplify the calculation.
-        let minX = center.x - sideLength * 0.5
-        let minY = center.y - sideLength * 0.5
-        // Defines the radius of the arcs.
-        let arcRadius = sideLength * 0.25
+    private class Model: ObservableObject {
+        /// A map with a topographic basemap style and an initial viewpoint.
+        let map: Map = {
+            let map = Map(basemapStyle: .arcGISTopographic)
+            map.initialViewpoint = Viewpoint(center: Point(x: 20e5, y: 20e5, spatialReference: .webMercator), scale: 7e7)
+            return map
+        }()
         
-        // Creates the bottom left curve segment.
-        let leftCurveStart = Point(x: center.x, y: minY, spatialReference: spatialReference)
-        let leftCurveEnd = Point(x: minX, y: minY + sideLength * 0.75, spatialReference: spatialReference)
-        let leftControlPoint1 = Point(x: center.x, y: minY + sideLength * 0.25, spatialReference: spatialReference)
-        let leftControlPoint2 = Point(x: minX, y: center.y, spatialReference: spatialReference)
-        let leftCurve = CubicBezierSegment(
-            startPoint: leftCurveStart,
-            controlPoint1: leftControlPoint1,
-            controlPoint2: leftControlPoint2,
-            endPoint: leftCurveEnd,
-            spatialReference: spatialReference
-        )!
+        /// The graphics overlay rendering a point.
+        let pointGraphicsOverlay: GraphicsOverlay = {
+            // Creates a simple marker symbol.
+            let symbol = SimpleMarkerSymbol(style: .diamond, color: .green, size: 10)
+            // Creates the geometry for the point.
+            let geometry = Point(x: 40e5, y: 40e5, spatialReference: .webMercator)
+            
+            // Creates a graphics overlay containing a graphic with the point geometry.
+            let overlay = GraphicsOverlay(graphics: [Graphic(geometry: geometry)])
+            // Creates and assigns a simple renderer to the graphics overlay.
+            overlay.renderer = SimpleRenderer(symbol: symbol)
+            return overlay
+        }()
         
-        // Creates the top left arc segment.
-        let leftArcCenter = Point(x: minX + sideLength * 0.25, y: minY + sideLength * 0.75, spatialReference: spatialReference)
-        let leftArc = EllipticArcSegment.circularEllipticArcEllipticArcSegment(
-            centerPoint: leftArcCenter,
-            radius: arcRadius,
-            startAngle: .pi,
-            centralAngle: -.pi,
-            spatialReference: spatialReference
-        )!
+        /// The graphics overlay rendering a line.
+        let lineGraphicsOverlay: GraphicsOverlay = {
+            // Creates a simple line symbol.
+            let symbol = SimpleLineSymbol(style: .solid, color: .blue, width: 5)
+            // Creates the geometry for the line.
+            let geometry = Polyline(
+                points: [
+                    Point(x: -10e5, y: 40e5),
+                    Point(x: 20e5, y: 50e5)
+                ],
+                spatialReference: .webMercator
+            )
+            
+            // Creates a graphics overlay containing a graphic with the line geometry.
+            let overlay = GraphicsOverlay(graphics: [Graphic(geometry: geometry)])
+            // Creates and assigns a simple renderer to the graphics overlay.
+            overlay.renderer = SimpleRenderer(symbol: symbol)
+            return overlay
+        }()
         
-        // Creates the top right arc segment.
-        let rightArcCenter = Point(x: minX + sideLength * 0.75, y: minY + sideLength * 0.75, spatialReference: spatialReference)
-        let rightArc = EllipticArcSegment.circularEllipticArcEllipticArcSegment(
-            centerPoint: rightArcCenter,
-            radius: arcRadius,
-            startAngle: .pi,
-            centralAngle: -.pi,
-            spatialReference: spatialReference
-        )!
+        /// The graphics overlay rendering a square polygon.
+        let squarePolygonGraphicsOverlay: GraphicsOverlay = {
+            // Creates a simple fill symbol.
+            let symbol = SimpleFillSymbol(color: .yellow)
+            // Creates the geometry for the square polygon.
+            let geometry = Polygon(
+                points: [
+                    Point(x: -20e5, y: 20e5),
+                    Point(x: 20e5, y: 20e5),
+                    Point(x: 20e5, y: -20e5),
+                    Point(x: -20e5, y: -20e5)
+                ],
+                spatialReference: .webMercator
+            )
+            
+            // Creates a graphics overlay containing a graphic with the square geometry.
+            let overlay = GraphicsOverlay(graphics: [Graphic(geometry: geometry)])
+            // Creates and assigns a simple renderer to the graphics overlay.
+            overlay.renderer = SimpleRenderer(symbol: symbol)
+            return overlay
+        }()
         
-        // Creates the bottom right curve segment.
-        let rightCurveStart = Point(x: minX + sideLength, y: minY + sideLength * 0.75, spatialReference: spatialReference)
-        let rightCurveEnd = leftCurveStart
-        let rightControlPoint1 = Point(x: minX + sideLength, y: center.y, spatialReference: spatialReference)
-        let rightControlPoint2 = leftControlPoint1
-        let rightCurve = CubicBezierSegment(
-            startPoint: rightCurveStart,
-            controlPoint1: rightControlPoint1,
-            controlPoint2: rightControlPoint2,
-            endPoint: rightCurveEnd,
-            spatialReference: spatialReference
-        )!
+        /// The graphics overlay rendering an ellipse.
+        let ellipseGraphicsOverlay: GraphicsOverlay = {
+            // Creates a simple fill symbol.
+            let symbol = SimpleFillSymbol(color: .purple)
+            // Defines the center point of the ellipse.
+            let center = Point(x: 40e5, y: 25e5, spatialReference: .webMercator)
+            // Creates the parameters for the ellipse.
+            let parameters = GeodesicEllipseParameters(
+                axisDirection: -45,
+                center: center,
+                linearUnit: .kilometers,
+                maxPointCount: 100,
+                maxSegmentLength: 20,
+                semiAxis1Length: 200,
+                semiAxis2Length: 400
+            )
+            // Creates the geometry for the ellipse from the parameters.
+            let geometry = GeometryEngine.geodesicEllipse(parameters: parameters)
+            
+            // Creates a graphics overlay containing a graphic with the ellipse geometry.
+            let overlay = GraphicsOverlay(graphics: [Graphic(geometry: geometry)])
+            // Creates and assigns a simple renderer to the graphics overlay.
+            overlay.renderer = SimpleRenderer(symbol: symbol)
+            return overlay
+        }()
         
-        // Creates and returns the heart polygon.
-        return Polygon(parts: [MutablePart(segments: [leftCurve, leftArc, rightArc, rightCurve], spatialReference: spatialReference)])
+        /// The graphics overlay rendering a curved polygon.
+        let curvedPolygonGraphicsOverlay: GraphicsOverlay = {
+            // Creates a simple fill symbol with an outline.
+            let lineSymbol = SimpleLineSymbol(style: .solid, color: .black, width: 1)
+            let fillSymbol = SimpleFillSymbol(color: .red, outline: lineSymbol)
+            // Defines the point of origin for the curved polygon.
+            let origin = Point(x: 40e5, y: 5e5, spatialReference: .webMercator)
+            // Creates a heart-shaped polygon.
+            let heartPolygon = makeHeartPolygon(center: origin, sideLength: 10e5)
+            
+            // Creates a graphics overlay containing a graphic with the polygon geometry.
+            let overlay = GraphicsOverlay(graphics: [Graphic(geometry: heartPolygon)])
+            // Creates and assigns a simple renderer to the graphics overlay.
+            overlay.renderer = SimpleRenderer(symbol: fillSymbol)
+            return overlay
+        }()
+        
+        /// Creates a heart-shaped polygon with Bezier and elliptic arc segments.
+        /// - Parameters:
+        ///   - center: The center of the square that contains the heart shape.
+        ///   - sideLength: The side length of the square.
+        /// - Returns: A heart-shaped polygon.
+        static func makeHeartPolygon(center: Point, sideLength: Double) -> ArcGIS.Polygon? {
+            guard sideLength > 0 else { return nil }
+            let spatialReference = center.spatialReference
+            // Defines the x and y coordinates to simplify the calculation.
+            let minX = center.x - sideLength * 0.5
+            let minY = center.y - sideLength * 0.5
+            // Defines the radius of the arcs.
+            let arcRadius = sideLength * 0.25
+            
+            // Creates the bottom left curve segment.
+            let leftCurveStart = Point(x: center.x, y: minY, spatialReference: spatialReference)
+            let leftCurveEnd = Point(x: minX, y: minY + sideLength * 0.75, spatialReference: spatialReference)
+            let leftControlPoint1 = Point(x: center.x, y: minY + sideLength * 0.25, spatialReference: spatialReference)
+            let leftControlPoint2 = Point(x: minX, y: center.y, spatialReference: spatialReference)
+            let leftCurve = CubicBezierSegment(
+                startPoint: leftCurveStart,
+                controlPoint1: leftControlPoint1,
+                controlPoint2: leftControlPoint2,
+                endPoint: leftCurveEnd,
+                spatialReference: spatialReference
+            )!
+            
+            // Creates the top left arc segment.
+            let leftArcCenter = Point(x: minX + sideLength * 0.25, y: minY + sideLength * 0.75, spatialReference: spatialReference)
+            let leftArc = EllipticArcSegment.circularEllipticArcEllipticArcSegment(
+                centerPoint: leftArcCenter,
+                radius: arcRadius,
+                startAngle: .pi,
+                centralAngle: -.pi,
+                spatialReference: spatialReference
+            )!
+            
+            // Creates the top right arc segment.
+            let rightArcCenter = Point(x: minX + sideLength * 0.75, y: minY + sideLength * 0.75, spatialReference: spatialReference)
+            let rightArc = EllipticArcSegment.circularEllipticArcEllipticArcSegment(
+                centerPoint: rightArcCenter,
+                radius: arcRadius,
+                startAngle: .pi,
+                centralAngle: -.pi,
+                spatialReference: spatialReference
+            )!
+            
+            // Creates the bottom right curve segment.
+            let rightCurveStart = Point(x: minX + sideLength, y: minY + sideLength * 0.75, spatialReference: spatialReference)
+            let rightCurveEnd = leftCurveStart
+            let rightControlPoint1 = Point(x: minX + sideLength, y: center.y, spatialReference: spatialReference)
+            let rightControlPoint2 = leftControlPoint1
+            let rightCurve = CubicBezierSegment(
+                startPoint: rightCurveStart,
+                controlPoint1: rightControlPoint1,
+                controlPoint2: rightControlPoint2,
+                endPoint: rightCurveEnd,
+                spatialReference: spatialReference
+            )!
+            
+            // Creates and returns the heart polygon.
+            return Polygon(parts: [MutablePart(segments: [leftCurve, leftArc, rightArc, rightCurve], spatialReference: spatialReference)])
+        }
     }
 }

--- a/Shared/Samples/Style graphics with renderer/StyleGraphicsWithRendererView.swift
+++ b/Shared/Samples/Style graphics with renderer/StyleGraphicsWithRendererView.swift
@@ -25,6 +25,8 @@ struct StyleGraphicsWithRendererView: View {
 }
 
 private extension StyleGraphicsWithRendererView {
+    /// The model used to store the geo model and other expensive objects
+    /// used in this view.
     class Model: ObservableObject {
         /// A map with a topographic basemap style and an initial viewpoint.
         let map: Map = {

--- a/Shared/Samples/Style graphics with renderer/StyleGraphicsWithRendererView.swift
+++ b/Shared/Samples/Style graphics with renderer/StyleGraphicsWithRendererView.swift
@@ -107,7 +107,7 @@ private extension StyleGraphicsWithRendererView {
             // Defines the center point of the ellipse.
             let center = Point(x: 40e5, y: 25e5, spatialReference: .webMercator)
             // Creates the parameters for the ellipse.
-            let parameters = GeodesicEllipseParameters(
+            let parameters = GeodesicEllipseParameters<Polygon>(
                 axisDirection: -45,
                 center: center,
                 linearUnit: .kilometers,

--- a/Shared/Samples/Style graphics with renderer/StyleGraphicsWithRendererView.swift
+++ b/Shared/Samples/Style graphics with renderer/StyleGraphicsWithRendererView.swift
@@ -107,7 +107,7 @@ private extension StyleGraphicsWithRendererView {
             // Defines the center point of the ellipse.
             let center = Point(x: 40e5, y: 25e5, spatialReference: .webMercator)
             // Creates the parameters for the ellipse.
-            let parameters = GeodesicEllipseParameters<Polygon>(
+            let parameters = GeodesicEllipseParameters<ArcGIS.Polygon>(
                 axisDirection: -45,
                 center: center,
                 linearUnit: .kilometers,

--- a/Shared/Samples/Style graphics with renderer/StyleGraphicsWithRendererView.swift
+++ b/Shared/Samples/Style graphics with renderer/StyleGraphicsWithRendererView.swift
@@ -25,7 +25,7 @@ struct StyleGraphicsWithRendererView: View {
 }
 
 private extension StyleGraphicsWithRendererView {
-    private class Model: ObservableObject {
+    class Model: ObservableObject {
         /// A map with a topographic basemap style and an initial viewpoint.
         let map: Map = {
             let map = Map(basemapStyle: .arcGISTopographic)

--- a/Shared/Samples/Style graphics with symbols/StyleGraphicsWithSymbolsView.swift
+++ b/Shared/Samples/Style graphics with symbols/StyleGraphicsWithSymbolsView.swift
@@ -26,7 +26,7 @@ struct StyleGraphicsWithSymbolsView: View {
 }
 
 private extension StyleGraphicsWithSymbolsView {
-    private class Model: ObservableObject {
+    class Model: ObservableObject {
         /// A map with ArcGIS Oceans basemap style.
         let map: Map = {
             let map = Map(basemapStyle: .arcGISOceans)

--- a/Shared/Samples/Style graphics with symbols/StyleGraphicsWithSymbolsView.swift
+++ b/Shared/Samples/Style graphics with symbols/StyleGraphicsWithSymbolsView.swift
@@ -26,6 +26,8 @@ struct StyleGraphicsWithSymbolsView: View {
 }
 
 private extension StyleGraphicsWithSymbolsView {
+    /// The model used to store the geo model and other expensive objects
+    /// used in this view.
     class Model: ObservableObject {
         /// A map with ArcGIS Oceans basemap style.
         let map: Map = {

--- a/Shared/Samples/Style graphics with symbols/StyleGraphicsWithSymbolsView.swift
+++ b/Shared/Samples/Style graphics with symbols/StyleGraphicsWithSymbolsView.swift
@@ -16,83 +16,92 @@ import SwiftUI
 import ArcGIS
 
 struct StyleGraphicsWithSymbolsView: View {
-    /// A map with ArcGIS Oceans basemap style.
-    @StateObject private var map = Map(basemapStyle: .arcGISOceans)
-    
-    /// A graphics overlay for the map view.
-    @StateObject private var graphicsOverlay = makeGraphicsOverlay()
-    
-    /// The starting viewpoint of the map view.
-    private let viewpoint = Viewpoint(latitude: 56.075844, longitude: -2.681572, scale: 288895.277144)
-    
-    /// Creates a graphics overlay.
-    private static func makeGraphicsOverlay() -> GraphicsOverlay {
-        let graphicsOverlay = GraphicsOverlay()
-        // Adds the graphics.
-        graphicsOverlay.addGraphics(makeBuoyPoints())
-        graphicsOverlay.addGraphics(makeText())
-        graphicsOverlay.addGraphic(makeBoatTripGraphic())
-        graphicsOverlay.addGraphic(makeNestingGroundGraphic())
-        return graphicsOverlay
-    }
-    
-    /// Creates an array of graphics for buoy points.
-    private static func makeBuoyPoints() -> [Graphic] {
-        // Defines an array of points where buoys are located.
-        let buoyLocations = [
-            Point(x: -2.712642647560347, y: 56.062812566811544, spatialReference: .wgs84),
-            Point(x: -2.6908416959572303, y: 56.06444173689877, spatialReference: .wgs84),
-            Point(x: -2.6697273884990937, y: 56.064250073402874, spatialReference: .wgs84),
-            Point(x: -2.6395150461199726, y: 56.06127916736989, spatialReference: .wgs84)
-        ]
-        
-        // Creates a marker symbol.
-        let buoyMarker = SimpleMarkerSymbol(style: .circle, color: .red, size: 10)
-        
-        // Returns an array of graphics for the buoy locations.
-        return buoyLocations.map { Graphic(geometry: $0, symbol: buoyMarker) }
-    }
-    
-    /// Creates an array of graphics for text.
-    private static func makeText() -> [Graphic] {
-        // Creates the Bass Rock graphic.
-        let bassRockGraphic = Graphic(
-            geometry: Point(x: -2.640631, y: 56.078083, spatialReference: .wgs84),
-            symbol: TextSymbol(text: "Bass Rock", color: .blue, size: 10, horizontalAlignment: .left, verticalAlignment: .bottom)
-        )
-        
-        // Creates the Craigleith graphic.
-        let craigleithGraphic = Graphic(
-            geometry: Point(x: -2.720324, y: 56.073569, spatialReference: .wgs84),
-            symbol: TextSymbol(text: "Craigleith", color: .blue, size: 10, horizontalAlignment: .right, verticalAlignment: .top)
-        )
-        
-        // Returns an array of graphics for the text.
-        return [bassRockGraphic, craigleithGraphic]
-    }
-    
-    /// Creates a graphic for the boat trip.
-    private static func makeBoatTripGraphic() -> Graphic {
-        // Creates a line symbol.
-        let lineSymbol = SimpleLineSymbol(style: .dash, color: .purple, width: 4)
-        
-        // Returns the boat trip graphic.
-        return Graphic(geometry: .boatTrip, symbol: lineSymbol)
-    }
-    
-    /// Creates a graphic for the nesting ground.
-    private static func makeNestingGroundGraphic() -> Graphic {
-        // Creates the outline and fill symbols.
-        let outlineSymbol = SimpleLineSymbol(style: .dash, color: .blue, width: 1)
-        let fillSymbol = SimpleFillSymbol(style: .diagonalCross, color: .green, outline: outlineSymbol)
-        
-        // Returns the nesting graphic.
-        return Graphic(geometry: .nestingGround, symbol: fillSymbol)
-    }
+    /// The view model for the sample.
+    @StateObject private var model = Model()
     
     var body: some View {
-        // Creates a map view with the graphic overlay.
-        MapView(map: map, viewpoint: viewpoint, graphicsOverlays: [graphicsOverlay])
+        // Creates a map view with a graphics overlay.
+        MapView(map: model.map, graphicsOverlays: [model.graphicsOverlay])
+    }
+}
+
+private extension StyleGraphicsWithSymbolsView {
+    private class Model: ObservableObject {
+        /// A map with ArcGIS Oceans basemap style.
+        let map: Map = {
+            let map = Map(basemapStyle: .arcGISOceans)
+            // The initial viewpoint of the map view.
+            map.initialViewpoint = Viewpoint(latitude: 56.075844, longitude: -2.681572, scale: 288895.277144)
+            return map
+        }()
+        
+        /// A graphics overlay for the map view.
+        let graphicsOverlay = makeGraphicsOverlay()
+        
+        /// Creates a graphics overlay.
+        private static func makeGraphicsOverlay() -> GraphicsOverlay {
+            let graphicsOverlay = GraphicsOverlay()
+            // Adds the graphics.
+            graphicsOverlay.addGraphics(makeBuoyPoints())
+            graphicsOverlay.addGraphics(makeText())
+            graphicsOverlay.addGraphic(makeBoatTripGraphic())
+            graphicsOverlay.addGraphic(makeNestingGroundGraphic())
+            return graphicsOverlay
+        }
+        
+        /// Creates an array of graphics for buoy points.
+        private static func makeBuoyPoints() -> [Graphic] {
+            // Defines an array of points where buoys are located.
+            let buoyLocations = [
+                Point(x: -2.712642647560347, y: 56.062812566811544, spatialReference: .wgs84),
+                Point(x: -2.6908416959572303, y: 56.06444173689877, spatialReference: .wgs84),
+                Point(x: -2.6697273884990937, y: 56.064250073402874, spatialReference: .wgs84),
+                Point(x: -2.6395150461199726, y: 56.06127916736989, spatialReference: .wgs84)
+            ]
+            
+            // Creates a marker symbol.
+            let buoyMarker = SimpleMarkerSymbol(style: .circle, color: .red, size: 10)
+            
+            // Returns an array of graphics for the buoy locations.
+            return buoyLocations.map { Graphic(geometry: $0, symbol: buoyMarker) }
+        }
+        
+        /// Creates an array of graphics for text.
+        private static func makeText() -> [Graphic] {
+            // Creates the Bass Rock graphic.
+            let bassRockGraphic = Graphic(
+                geometry: Point(x: -2.640631, y: 56.078083, spatialReference: .wgs84),
+                symbol: TextSymbol(text: "Bass Rock", color: .blue, size: 10, horizontalAlignment: .left, verticalAlignment: .bottom)
+            )
+            
+            // Creates the Craigleith graphic.
+            let craigleithGraphic = Graphic(
+                geometry: Point(x: -2.720324, y: 56.073569, spatialReference: .wgs84),
+                symbol: TextSymbol(text: "Craigleith", color: .blue, size: 10, horizontalAlignment: .right, verticalAlignment: .top)
+            )
+            
+            // Returns an array of graphics for the text.
+            return [bassRockGraphic, craigleithGraphic]
+        }
+        
+        /// Creates a graphic for the boat trip.
+        private static func makeBoatTripGraphic() -> Graphic {
+            // Creates a line symbol.
+            let lineSymbol = SimpleLineSymbol(style: .dash, color: .purple, width: 4)
+            
+            // Returns the boat trip graphic.
+            return Graphic(geometry: .boatTrip, symbol: lineSymbol)
+        }
+        
+        /// Creates a graphic for the nesting ground.
+        private static func makeNestingGroundGraphic() -> Graphic {
+            // Creates the outline and fill symbols.
+            let outlineSymbol = SimpleLineSymbol(style: .dash, color: .blue, width: 1)
+            let fillSymbol = SimpleFillSymbol(style: .diagonalCross, color: .green, outline: outlineSymbol)
+            
+            // Returns the nesting graphic.
+            return Graphic(geometry: .nestingGround, symbol: fillSymbol)
+        }
     }
 }
 


### PR DESCRIPTION
## Description

This PR changes the `@StateObject` pattern in most of the samples, to use an observable model object to manage the data.

## Linked Issue(s)

- `swift/issues/3271`
- `swift/issues/3250`
- https://github.com/ArcGIS/arcgis-maps-sdk-swift-toolkit/issues/200
- Potentially #48 and #89 

## How To Test

To run the app, you'll need to

1. replace the toolkit dependency line in Package.swift locally with `.package(name: "arcgis-maps-sdk-swift", path: "../swift/ArcGIS")`.
2. drag the toolkit into the samples project, so it overrides the remote resolved packages and uses the local toolkit repo instead.

No behavioral change should present. Verify all changed sample to work as expected.

## To Discuss

- What should be a good generic docstring for the view model objects?