### PR TITLE
[Fix] Version variable in Info.plist

### DIFF
--- a/iOS/Info.plist
+++ b/iOS/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSLocationWhenInUseUsageDescription</key>


### PR DESCRIPTION
## Description

This PR fixes an issue in the `Info.plist`. In beta the version was hardcoded for unknown reason. With this change, the bundle version will be the build number, which shows such as 200.0.0 (3456) instead of 200.0.0 (1).
