### PR TITLE
[Update] Simplify view model pattern when it is not needed

### DIFF
--- a/Shared/Samples/Add raster from file/AddRasterFromFileView.swift
+++ b/Shared/Samples/Add raster from file/AddRasterFromFileView.swift
@@ -16,15 +16,8 @@ import ArcGIS
 import SwiftUI
 
 struct AddRasterFromFileView: View {
-    /// The model used to store the geo model and other expensive objects
-    /// used in this view.
-    private class Model: ObservableObject {
-        /// A map with imagery basemap and a raster layer.
-        let map = Map(basemapStyle: .arcGISImageryStandard)
-    }
-    
-    /// The view model for the sample.
-    @StateObject private var model = Model()
+    /// A map with imagery basemap and a raster layer.
+    @State private var map = Map(basemapStyle: .arcGISImageryStandard)
     
     /// A Boolean value indicating whether to show an alert.
     @State private var isShowingAlert = false
@@ -39,11 +32,11 @@ struct AddRasterFromFileView: View {
     
     var body: some View {
         // Creates a map view with a viewpoint to display the map.
-        MapView(map: model.map, viewpoint: viewpoint)
+        MapView(map: map, viewpoint: viewpoint)
             .onViewpointChanged(kind: .centerAndScale) { viewpoint = $0 }
             .alert(isPresented: $isShowingAlert, presentingError: error)
             .task {
-                guard model.map.operationalLayers.isEmpty else { return }
+                guard map.operationalLayers.isEmpty else { return }
                 do {
                     // Gets the Shasta.tif file URL.
                     let shastaURL = Bundle.main.url(forResource: "Shasta", withExtension: "tif", subdirectory: "raster-file/raster-file")!
@@ -53,7 +46,7 @@ struct AddRasterFromFileView: View {
                     let rasterLayer = RasterLayer(raster: raster)
                     try await rasterLayer.load()
                     // Adds the raster layer to the map's operational layer.
-                    model.map.addOperationalLayer(rasterLayer)
+                    map.addOperationalLayer(rasterLayer)
                     viewpoint = Viewpoint(center: rasterLayer.fullExtent!.center, scale: 8e4)
                 } catch {
                     // Presents an error message if the raster fails to load.

--- a/Shared/Samples/Add scene layer from service/AddSceneLayerFromServiceView.swift
+++ b/Shared/Samples/Add scene layer from service/AddSceneLayerFromServiceView.swift
@@ -16,36 +16,28 @@ import SwiftUI
 import ArcGIS
 
 struct AddSceneLayerFromServiceView: View {
-    /// The view model for the sample.
-    @StateObject private var model = Model()
+    /// A scene with topographic basemap and a 3D buildings layer.
+    @State private var scene: ArcGIS.Scene = {
+        // Creates a scene and sets an initial viewpoint.
+        let scene = Scene(basemapStyle: .arcGISTopographic)
+        let point = Point(x: -4.4978, y: 48.3828, z: 62.0133, spatialReference: .wgs84)
+        let camera = Camera(location: point, heading: 41.65, pitch: 71.2, roll: 0)
+        scene.initialViewpoint = Viewpoint(boundingGeometry: point, camera: camera)
+        
+        // Creates a surface and adds an elevation source.
+        let surface = Surface()
+        surface.addElevationSource(ArcGISTiledElevationSource(url: .worldElevationService))
+        
+        // Sets the surface to the scene's base surface.
+        scene.baseSurface = surface
+        
+        // Adds a scene layer from a URL to the scene's operational layers.
+        scene.addOperationalLayer(ArcGISSceneLayer(url: .brestBuildingService))
+        return scene
+    }()
     
     var body: some View {
-        SceneView(scene: model.scene)
-    }
-}
-
-private extension AddSceneLayerFromServiceView {
-    /// The model used to store the geo model and other expensive objects
-    /// used in this view.
-    class Model: ObservableObject {
-        let scene: ArcGIS.Scene = {
-            // Creates a scene and sets an initial viewpoint.
-            let scene = Scene(basemapStyle: .arcGISTopographic)
-            let point = Point(x: -4.4978, y: 48.3828, z: 62.0133, spatialReference: .wgs84)
-            let camera = Camera(location: point, heading: 41.65, pitch: 71.2, roll: 0)
-            scene.initialViewpoint = Viewpoint(boundingGeometry: point, camera: camera)
-            
-            // Creates a surface and adds an elevation source.
-            let surface = Surface()
-            surface.addElevationSource(ArcGISTiledElevationSource(url: .worldElevationService))
-            
-            // Sets the surface to the scene's base surface.
-            scene.baseSurface = surface
-            
-            // Adds a scene layer from a URL to the scene's operational layers.
-            scene.addOperationalLayer(ArcGISSceneLayer(url: .brestBuildingService))
-            return scene
-        }()
+        SceneView(scene: scene)
     }
 }
 

--- a/Shared/Samples/Browse building floors/BrowseBuildingFloorsView.swift
+++ b/Shared/Samples/Browse building floors/BrowseBuildingFloorsView.swift
@@ -34,30 +34,23 @@ struct BrowseBuildingFloorsView: View {
     /// A Boolean value indicating whether the map is loaded.
     @State private var isMapLoaded = false
     
-    /// The model used to store the geo model and other expensive objects
-    /// used in this view.
-    private class Model: ObservableObject {
-        /// A floor-aware web map of Building L on the Esri Redlands campus.
-        let map = Map(
-            item: PortalItem(
-                portal: .arcGISOnline(connection: .anonymous),
-                id: .esriBuildingL
-            )
+    /// A floor-aware web map of Building L on the Esri Redlands campus.
+    @State private var map = Map(
+        item: PortalItem(
+            portal: .arcGISOnline(connection: .anonymous),
+            id: .esriBuildingL
         )
-    }
-    
-    /// The view model for the sample.
-    @StateObject private var model = Model()
+    )
     
     var body: some View {
-        MapView(map: model.map)
+        MapView(map: map)
             .onViewpointChanged(kind: .centerAndScale) { viewpoint = $0 }
             .onNavigatingChanged { isMapNavigating = $0 }
             .alert(isPresented: $isShowingAlert, presentingError: error)
             .ignoresSafeArea(.keyboard, edges: .bottom)
             .overlay(alignment: .bottomTrailing) {
                 if isMapLoaded,
-                   let floorManager = model.map.floorManager {
+                   let floorManager = map.floorManager {
                     FloorFilter(
                         floorManager: floorManager,
                         alignment: .bottomTrailing,
@@ -74,7 +67,7 @@ struct BrowseBuildingFloorsView: View {
             }
             .task {
                 do {
-                    try await model.map.load()
+                    try await map.load()
                     isMapLoaded = true
                 } catch {
                     self.error = error

--- a/Shared/Samples/Display map/DisplayMapView.swift
+++ b/Shared/Samples/Display map/DisplayMapView.swift
@@ -16,18 +16,11 @@ import SwiftUI
 import ArcGIS
 
 struct DisplayMapView: View {
-    /// The model used to store the geo model and other expensive objects
-    /// used in this view.
-    private class Model: ObservableObject {
-        /// A map with imagery basemap.
-        let map = Map(basemapStyle: .arcGISImagery)
-    }
-    
-    /// The view model for the sample.
-    @StateObject private var model = Model()
+    /// A map with imagery basemap.
+    @State private var map = Map(basemapStyle: .arcGISImagery)
     
     var body: some View {
         // Creates a map view to display the map.
-        MapView(map: model.map)
+        MapView(map: map)
     }
 }

--- a/Shared/Samples/Display overview map/DisplayOverviewMapView.swift
+++ b/Shared/Samples/Display overview map/DisplayOverviewMapView.swift
@@ -17,8 +17,18 @@ import ArcGIS
 import ArcGISToolkit
 
 struct DisplayOverviewMapView: View {
-    /// The view model for the sample.
-    @StateObject private var model = Model()
+    /// A map with imagery basemap and a tourist attraction feature layer.
+    @State private var map: Map = {
+        let featureLayer = FeatureLayer(
+            item: PortalItem(
+                portal: .arcGISOnline(connection: .anonymous),
+                id: .northAmericaTouristAttractions
+            )
+        )
+        let map = Map(basemapStyle: .arcGISTopographic)
+        map.addOperationalLayer(featureLayer)
+        return map
+    }()
     
     /// The current viewpoint of the map view.
     @State private var viewpoint = Viewpoint(
@@ -30,7 +40,7 @@ struct DisplayOverviewMapView: View {
     @State private var visibleArea: ArcGIS.Polygon?
     
     var body: some View {
-        MapView(map: model.map, viewpoint: viewpoint)
+        MapView(map: map, viewpoint: viewpoint)
             .onViewpointChanged(kind: .centerAndScale) { viewpoint = $0 }
             .onVisibleAreaChanged { visibleArea = $0 }
             .overlay(alignment: .topTrailing) {
@@ -41,25 +51,6 @@ struct DisplayOverviewMapView: View {
                 .frame(width: 200, height: 132)
                 .padding()
             }
-    }
-}
-
-private extension DisplayOverviewMapView {
-    /// The model used to store the geo model and other expensive objects
-    /// used in this view.
-    class Model: ObservableObject {
-        /// A map with imagery basemap and a tourist attraction feature layer.
-        let map: Map = {
-            let featureLayer = FeatureLayer(
-                item: PortalItem(
-                    portal: .arcGISOnline(connection: .anonymous),
-                    id: .northAmericaTouristAttractions
-                )
-            )
-            let map = Map(basemapStyle: .arcGISTopographic)
-            map.addOperationalLayer(featureLayer)
-            return map
-        }()
     }
 }
 

--- a/Shared/Samples/Display scene/DisplaySceneView.swift
+++ b/Shared/Samples/Display scene/DisplaySceneView.swift
@@ -16,50 +16,43 @@ import SwiftUI
 import ArcGIS
 
 struct DisplaySceneView: View {
-    /// The model used to store the geo model and other expensive objects
-    /// used in this view.
-    private class Model: ObservableObject {
-        /// A scene with imagery basemap style and a tiled elevation source.
-        let scene: ArcGIS.Scene = {
-            // Creates a scene.
-            let scene = Scene(basemapStyle: .arcGISImageryStandard)
-            
-            // Sets the initial viewpoint of the scene.
-            scene.initialViewpoint = Viewpoint(
+    /// A scene with imagery basemap style and a tiled elevation source.
+    @State private var scene: ArcGIS.Scene = {
+        // Creates a scene.
+        let scene = Scene(basemapStyle: .arcGISImageryStandard)
+        
+        // Sets the initial viewpoint of the scene.
+        scene.initialViewpoint = Viewpoint(
+            latitude: .nan,
+            longitude: .nan,
+            scale: .nan,
+            camera: Camera(
                 latitude: 45.74,
                 longitude: 6.88,
-                scale: 4_500,
-                camera: Camera(
-                    latitude: 45.74,
-                    longitude: 6.88,
-                    altitude: 4500,
-                    heading: 10,
-                    pitch: 70,
-                    roll: 0
-                )
+                altitude: 4500,
+                heading: 10,
+                pitch: 70,
+                roll: 0
             )
-            
-            // Creates a surface.
-            let surface = Surface()
-            
-            // Creates a tiled elevation source.
-            let worldElevationServiceURL = URL(string: "https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer")!
-            let elevationSource = ArcGISTiledElevationSource(url: worldElevationServiceURL)
-            
-            // Adds the elevation source to the surface.
-            surface.addElevationSource(elevationSource)
-            
-            // Sets the surface to the scene's base surface.
-            scene.baseSurface = surface
-            return scene
-        }()
-    }
-    
-    /// The view model for the sample.
-    @StateObject private var model = Model()
+        )
+        
+        // Creates a surface.
+        let surface = Surface()
+        
+        // Creates a tiled elevation source.
+        let worldElevationServiceURL = URL(string: "https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer")!
+        let elevationSource = ArcGISTiledElevationSource(url: worldElevationServiceURL)
+        
+        // Adds the elevation source to the surface.
+        surface.addElevationSource(elevationSource)
+        
+        // Sets the surface to the scene's base surface.
+        scene.baseSurface = surface
+        return scene
+    }()
     
     var body: some View {
         // Creates a scene view with the scene.
-        SceneView(scene: model.scene)
+        SceneView(scene: scene)
     }
 }

--- a/Shared/Samples/Set basemap/SetBasemapView.swift
+++ b/Shared/Samples/Set basemap/SetBasemapView.swift
@@ -20,29 +20,22 @@ struct SetBasemapView: View {
     /// A Boolean value that indicates whether to show the basemap gallery.
     @State private var isShowingBasemapGallery = false
     
-    /// The model used to store the geo model and other expensive objects
-    /// used in this view.
-    private class Model: ObservableObject {
-        /// A map with imagery basemap.
-        let map: Map = {
-            let map = Map(basemapStyle: .arcGISImagery)
-            // The initial viewpoint of the map.
-            map.initialViewpoint = Viewpoint(
-                center: Point(x: -118.4, y: 33.7, spatialReference: .wgs84),
-                scale: 1e6
-            )
-            return map
-        }()
-    }
-    
-    /// The view model for the sample.
-    @StateObject private var model = Model()
+    /// A map with imagery basemap.
+    @State private var map: Map = {
+        let map = Map(basemapStyle: .arcGISImagery)
+        // The initial viewpoint of the map.
+        map.initialViewpoint = Viewpoint(
+            center: Point(x: -118.4, y: 33.7, spatialReference: .wgs84),
+            scale: 1e6
+        )
+        return map
+    }()
     
     var body: some View {
-        MapView(map: model.map)
+        MapView(map: map)
             .overlay(alignment: .topTrailing) {
                 if isShowingBasemapGallery {
-                    BasemapGallery(geoModel: model.map)
+                    BasemapGallery(geoModel: map)
                         .style(.automatic())
                 }
             }

--- a/Shared/Samples/Set viewpoint rotation/SetViewpointRotationView.swift
+++ b/Shared/Samples/Set viewpoint rotation/SetViewpointRotationView.swift
@@ -26,19 +26,12 @@ struct SetViewpointRotationView: View {
     /// The rotation angle for the viewpoint.
     @State private var rotation = Double.zero
     
-    /// The model used to store the geo model and other expensive objects
-    /// used in this view.
-    private class Model: ObservableObject {
-        /// A map with ArcGIS Streets basemap style.
-        let map = Map(basemapStyle: .arcGISStreets)
-    }
-    
-    /// The view model for the sample.
-    @StateObject private var model = Model()
+    /// A map with ArcGIS Streets basemap style.
+    @State private var map = Map(basemapStyle: .arcGISStreets)
     
     var body: some View {
         VStack {
-            MapView(map: model.map, viewpoint: Viewpoint(center: center, scale: scale, rotation: rotation))
+            MapView(map: map, viewpoint: Viewpoint(center: center, scale: scale, rotation: rotation))
                 .onViewpointChanged(kind: .centerAndScale) { viewpoint in
                     center = viewpoint.targetGeometry.extent.center
                     scale = viewpoint.targetScale

--- a/Shared/Samples/Show callout/ShowCalloutView.swift
+++ b/Shared/Samples/Show callout/ShowCalloutView.swift
@@ -16,15 +16,8 @@ import SwiftUI
 import ArcGIS
 
 struct ShowCalloutView: View {
-    /// The model used to store the geo model and other expensive objects
-    /// used in this view.
-    private class Model: ObservableObject {
-        /// A map with a topographic basemap style.
-        let map = Map(basemapStyle: .arcGISTopographic)
-    }
-    
-    /// The view model for the sample.
-    @StateObject private var model = Model()
+    /// A map with a topographic basemap style.
+    @State private var map = Map(basemapStyle: .arcGISTopographic)
     
     /// A location callout placement.
     @State private var calloutPlacement: CalloutPlacement?
@@ -33,7 +26,7 @@ struct ShowCalloutView: View {
     @State private var tapLocation: Point!
     
     var body: some View {
-        MapView(map: model.map)
+        MapView(map: map)
             .onSingleTapGesture { _, mapPoint in
                 tapLocation = mapPoint
                 if calloutPlacement == nil {


### PR DESCRIPTION
## Description

Close #123 .

In the swift repo there was a discussion on whether to use `StateObject` and view model pattern , or simply `State`, for a geo model (map and scene). In the end we concluded for the simpler samples that don't have extra data flow, `State` is preferred.

This PR changed all the samples which the view model only holds 1 property which is the geo model.

## Linked Issue(s)

- `swift/pull/3698`
- `native-apis-doc/issues/3636`

## How To Test

Run all changed samples and see if they behave the same.

cc @sbaskaran 