### PR TITLE
[Update] Adjust `Compass` API signature

### DIFF
--- a/Shared/Samples/Set viewpoint rotation/SetViewpointRotationView.swift
+++ b/Shared/Samples/Set viewpoint rotation/SetViewpointRotationView.swift
@@ -39,9 +39,9 @@ struct SetViewpointRotationView: View {
                 }
                 .overlay(alignment: .topTrailing) {
                     Compass(
-                        viewpointRotation: $rotation,
-                        autoHide: false
+                        viewpointRotation: $rotation
                     )
+                    .autoHideDisabled(true)
                     .padding()
                 }
             

--- a/Shared/Samples/Set viewpoint rotation/SetViewpointRotationView.swift
+++ b/Shared/Samples/Set viewpoint rotation/SetViewpointRotationView.swift
@@ -38,11 +38,9 @@ struct SetViewpointRotationView: View {
                     rotation = viewpoint.rotation
                 }
                 .overlay(alignment: .topTrailing) {
-                    Compass(
-                        viewpointRotation: $rotation
-                    )
-                    .autoHideDisabled()
-                    .padding()
+                    Compass(viewpointRotation: $rotation)
+                        .autoHideDisabled()
+                        .padding()
                 }
             
             HStack {

--- a/Shared/Samples/Set viewpoint rotation/SetViewpointRotationView.swift
+++ b/Shared/Samples/Set viewpoint rotation/SetViewpointRotationView.swift
@@ -41,7 +41,7 @@ struct SetViewpointRotationView: View {
                     Compass(
                         viewpointRotation: $rotation
                     )
-                    .autoHideDisabled(true)
+                    .autoHideDisabled()
                     .padding()
                 }
             


### PR DESCRIPTION


## Description

This PR updates `Set viewpoint rotation`.

The autohide setting is now a view modifier.

## Linked Issue(s)

- https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/pull/291

## How To Test

The sample behaves exactly the same as before.

## To Discuss

To match the old code, should we explicitly write `.autoHideDisabled(true)`? I don't think so because…
1. its default value is true (which means the compass doesn't autohide)
2. there are other view modifiers on the compass. A user can explore them with other methods, while the sample can keep simple.