### PR TITLE
[Fix] Deletion precondition in Sketch on map

### DIFF
--- a/Shared/Samples/Sketch on map/SketchOnMapView.swift
+++ b/Shared/Samples/Sketch on map/SketchOnMapView.swift
@@ -144,7 +144,7 @@ extension GeometryEditorMenu {
             } label: {
                 Label("Delete Selected Element", systemImage: "xmark.square.fill")
             }
-            .disabled(model.selection == nil || !(model.selection?.canBeDeleted ?? false))
+            .disabled(deleteButtonIsDisabled)
             
             Button(role: .destructive) {
                 model.geometryEditor.clearGeometry()
@@ -168,6 +168,17 @@ extension GeometryEditorMenu {
                 Label("Cancel Sketch", systemImage: "xmark")
             }
         }
+    }
+}
+
+extension GeometryEditorMenu {
+    /// A Boolean value indicating whether the selection can be deleted.
+    ///
+    /// In some instances deleting the selection may be invalid. One example would be the mid vertex
+    /// of a line.
+    var deleteButtonIsDisabled: Bool {
+        guard let selection = model.selection else { return true }
+        return !selection.canBeDeleted
     }
 }
 

--- a/Shared/Samples/Sketch on map/SketchOnMapView.swift
+++ b/Shared/Samples/Sketch on map/SketchOnMapView.swift
@@ -144,7 +144,7 @@ extension GeometryEditorMenu {
             } label: {
                 Label("Delete Selected Element", systemImage: "xmark.square.fill")
             }
-            .disabled(model.selection == nil)
+            .disabled(model.selection == nil || !(model.selection?.canBeDeleted ?? false))
             
             Button(role: .destructive) {
                 model.geometryEditor.clearGeometry()


### PR DESCRIPTION
Closes #158 

- Disables "Delete selected element" when the selected element cannot be deleted.

<img src="https://user-images.githubusercontent.com/16397058/230506909-3e43adf4-ebd1-4226-a071-201ea1852e8b.png" width="300"/>