### PR TITLE
[Fix] Compile error related to `Item.id`

### DIFF
--- a/Shared/Samples/Download preplanned map area/DownloadPreplannedMapAreaView.Model.swift
+++ b/Shared/Samples/Download preplanned map area/DownloadPreplannedMapAreaView.Model.swift
@@ -223,7 +223,7 @@ private extension OfflineMapModel {
     /// - Precondition: `canDownload`
     func download() async {
         precondition(canDownload)
-                
+        
         let parameters: DownloadPreplannedOfflineMapParameters
         
         do {


### PR DESCRIPTION
## Description

ting: See Swift 3906 - it involves a bug in Item.ID's optionality, and the final solution is hard to explain in a few words.