### PR TITLE
[Fix] Settings sheet in some samples

### DIFF
--- a/Shared/Samples/Add dynamic entity layer/AddDynamicEntityLayerView.swift
+++ b/Shared/Samples/Add dynamic entity layer/AddDynamicEntityLayerView.swift
@@ -51,6 +51,10 @@ struct AddDynamicEntityLayerView: View {
                     Button("Dynamic Entity Settings") {
                         isShowingSettings = true
                     }
+                    .sheet(isPresented: $isShowingSettings, detents: [.medium], dragIndicatorVisibility: .visible) {
+                        SettingsView()
+                            .environmentObject(model)
+                    }
                 }
             }
             .overlay(alignment: .top) {
@@ -62,10 +66,6 @@ struct AddDynamicEntityLayerView: View {
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, 6)
                 .background(.thinMaterial, ignoresSafeAreaEdges: .horizontal)
-            }
-            .sheet(isPresented: $isShowingSettings, detents: [.medium], dragIndicatorVisibility: .visible) {
-                SettingsView()
-                    .environmentObject(model)
             }
             .task {
                 // This will update `connectionStatus` when the stream service

--- a/Shared/Samples/Change map view background/ChangeMapViewBackgroundView.swift
+++ b/Shared/Samples/Change map view background/ChangeMapViewBackgroundView.swift
@@ -32,11 +32,11 @@ struct ChangeMapViewBackgroundView: View {
                     Button("Background Grid Settings") {
                         isShowingSettings = true
                     }
+                    .sheet(isPresented: $isShowingSettings, detents: [.medium], dragIndicatorVisibility: .visible) {
+                        SettingsView()
+                            .environmentObject(model)
+                    }
                 }
-            }
-            .sheet(isPresented: $isShowingSettings, detents: [.medium], dragIndicatorVisibility: .visible) {
-                SettingsView()
-                    .environmentObject(model)
             }
     }
 }


### PR DESCRIPTION
## Description

This PR fixes the bug where the settings sheet in some samples is getting anchored in the wrong position. Before, the sheet modifier was called on the geo view and SwiftUI defaulted to having the popover attachment anchor below the geo view. With these changes that call the view modifier on the settings button itself, SwiftUI defaults to the expected behavior which anchors the popover above the settings button.

## Linked Issue(s)

- `swift/issues/3879`