### PR TITLE
[Fix] Accessory button and help text is not clearly visible with selected sample

### DIFF
--- a/Shared/Supporting Files/Views/SampleList.swift
+++ b/Shared/Supporting Files/Views/SampleList.swift
@@ -90,7 +90,6 @@ private extension SampleList {
                                 Text(sample.description)
                                     .foregroundColor(selection == sample.name ? .white.opacity(0.8) : .secondary)
                                     .font(.caption)
-                                    .foregroundColor(.secondary)
                                     .transition(.move(edge: .top).combined(with: .opacity))
                             } else {
                                 Text(sample.description)

--- a/Shared/Supporting Files/Views/SampleList.swift
+++ b/Shared/Supporting Files/Views/SampleList.swift
@@ -19,6 +19,12 @@ struct SampleList: View {
     /// A Boolean value that indicates whether the user is searching.
     @Environment(\.isSearching) private var isSearching
     
+    /// The horizontal size class of the enviroment.
+    @Environment(\.horizontalSizeClass) var horizontalSizeClass
+    
+    /// The vertical size class of the enviroment.
+    @Environment(\.verticalSizeClass) var verticalSizeClass
+    
     /// All samples that will be displayed in the list.
     let samples: [Sample]
     
@@ -46,7 +52,7 @@ struct SampleList: View {
     
     var body: some View {
         List(displayedSamples, id: \.name, selection: $selection) { sample in
-            SampleRow(sample: sample, selection: selection)
+            SampleRow(sample: sample, selection: selection, horizontalSizeClass: horizontalSizeClass, verticalSizeClass: verticalSizeClass)
         }
         .navigationTitle("Samples")
         .toolbar {
@@ -75,6 +81,12 @@ private extension SampleList {
         /// The current device type.
         let deviceType = UIDevice.current.userInterfaceIdiom
         
+        /// The horizontal size class of the device.
+        let horizontalSizeClass: UserInterfaceSizeClass?
+        
+        /// The vertical size class of the device.
+        let verticalSizeClass: UserInterfaceSizeClass?
+        
         /// A Boolean value indicating whether to show the sample's description
         @State private var isShowingDescription = false
         
@@ -88,6 +100,8 @@ private extension SampleList {
         
         var selectionColorIsAccentColor: Bool {
             if #available(iOS 16, *), deviceType != .phone {
+                return true
+            } else if #available(iOS 16, *), horizontalSizeClass == .compact, verticalSizeClass == .compact {
                 return true
             } else {
                 return false

--- a/Shared/Supporting Files/Views/SampleList.swift
+++ b/Shared/Supporting Files/Views/SampleList.swift
@@ -19,12 +19,6 @@ struct SampleList: View {
     /// A Boolean value that indicates whether the user is searching.
     @Environment(\.isSearching) private var isSearching
     
-    /// The horizontal size class of the enviroment.
-    @Environment(\.horizontalSizeClass) var horizontalSizeClass
-    
-    /// The vertical size class of the enviroment.
-    @Environment(\.verticalSizeClass) var verticalSizeClass
-    
     /// All samples that will be displayed in the list.
     let samples: [Sample]
     
@@ -52,7 +46,7 @@ struct SampleList: View {
     
     var body: some View {
         List(displayedSamples, id: \.name, selection: $selection) { sample in
-            SampleRow(sample: sample, selection: selection, horizontalSizeClass: horizontalSizeClass, verticalSizeClass: verticalSizeClass)
+            SampleRow(sample: sample, selection: selection)
         }
         .navigationTitle("Samples")
         .toolbar {
@@ -72,6 +66,12 @@ struct SampleList: View {
 
 private extension SampleList {
     struct SampleRow: View {
+        /// The horizontal size class of the enviroment.
+        @Environment(\.horizontalSizeClass) var horizontalSizeClass
+        
+        /// The vertical size class of the enviroment.
+        @Environment(\.verticalSizeClass) var verticalSizeClass
+        
         /// The sample displayed in the row.
         let sample: Sample
         
@@ -80,12 +80,6 @@ private extension SampleList {
         
         /// The current device type.
         let deviceType = UIDevice.current.userInterfaceIdiom
-        
-        /// The horizontal size class of the device.
-        let horizontalSizeClass: UserInterfaceSizeClass?
-        
-        /// The vertical size class of the device.
-        let verticalSizeClass: UserInterfaceSizeClass?
         
         /// A Boolean value indicating whether to show the sample's description
         @State private var isShowingDescription = false

--- a/Shared/Supporting Files/Views/SampleList.swift
+++ b/Shared/Supporting Files/Views/SampleList.swift
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import SwiftUI
+import UIKit.UIDevice
 
 struct SampleList: View {
     /// A Boolean value that indicates whether the user is searching.
@@ -71,6 +72,9 @@ private extension SampleList {
         /// A string representation of the selected sample.
         let selection: String?
         
+        /// The current device type.
+        let deviceType = UIDevice.current.userInterfaceIdiom
+        
         /// A Boolean value indicating whether to show the sample's description
         @State private var isShowingDescription = false
         
@@ -82,7 +86,7 @@ private extension SampleList {
                     VStack(alignment: .leading, spacing: 5) {
                         Text(sample.name)
                         if isShowingDescription {
-                            if #available(iOS 16, *) {
+                            if #available(iOS 16, *), deviceType != .phone {
                                 Text(sample.description)
                                     .foregroundColor(selection == sample.name ? .white.opacity(0.8) : .secondary)
                                     .font(.caption)
@@ -100,11 +104,14 @@ private extension SampleList {
                     Button {
                         isShowingDescription.toggle()
                     } label: {
-                        Image(systemName: isShowingDescription ? "info.circle.fill" : "info.circle")
-                            .foregroundColor(selection == sample.name ? .white : .accentColor)
+                        if #available(iOS 16, *), deviceType != .phone {
+                            Image(systemName: isShowingDescription ? "info.circle.fill" : "info.circle")
+                                .foregroundColor(selection == sample.name ? .white : .accentColor)
+                        } else {
+                            Image(systemName: isShowingDescription ? "info.circle.fill" : "info.circle")
+                        }
                     }
                     .buttonStyle(.borderless)
-                    .foregroundColor(selection == sample.name ? .white : .accentColor)
                 }
                 .animation(.easeOut(duration: 0.2), value: isShowingDescription)
             }

--- a/Shared/Supporting Files/Views/SampleList.swift
+++ b/Shared/Supporting Files/Views/SampleList.swift
@@ -78,6 +78,22 @@ private extension SampleList {
         /// A Boolean value indicating whether to show the sample's description
         @State private var isShowingDescription = false
         
+        var sampleForegroundColor: Color {
+            selection == sample.name ? .white.opacity(0.8) : .secondary
+        }
+        
+        var descriptionTextColor: Color {
+            selection == sample.name ? .white : .accentColor
+        }
+        
+        var selectionColorIsAccentColor: Bool {
+            if #available(iOS 16, *), deviceType != .phone {
+                return true
+            } else {
+                return false
+            }
+        }
+        
         var body: some View {
             NavigationLink {
                 SampleDetailView(sample: sample)
@@ -86,29 +102,19 @@ private extension SampleList {
                     VStack(alignment: .leading, spacing: 5) {
                         Text(sample.name)
                         if isShowingDescription {
-                            if #available(iOS 16, *), deviceType != .phone {
-                                Text(sample.description)
-                                    .foregroundColor(selection == sample.name ? .white.opacity(0.8) : .secondary)
-                                    .font(.caption)
-                                    .transition(.move(edge: .top).combined(with: .opacity))
-                            } else {
-                                Text(sample.description)
-                                    .font(.caption)
-                                    .foregroundColor(.secondary)
-                                    .transition(.move(edge: .top).combined(with: .opacity))
-                            }
+                            Text(sample.description)
+                                .font(.caption)
+                                .foregroundColor(selectionColorIsAccentColor ? sampleForegroundColor : .secondary)
+                                .transition(.move(edge: .top).combined(with: .opacity))
                         }
                     }
                     Spacer()
                     Button {
                         isShowingDescription.toggle()
                     } label: {
-                        if #available(iOS 16, *), deviceType != .phone {
-                            Image(systemName: isShowingDescription ? "info.circle.fill" : "info.circle")
-                                .foregroundColor(selection == sample.name ? .white : .accentColor)
-                        } else {
-                            Image(systemName: isShowingDescription ? "info.circle.fill" : "info.circle")
-                        }
+                        Image(systemName: "info.circle")
+                            .symbolVariant(isShowingDescription ? .fill : .none)
+                            .foregroundColor(selectionColorIsAccentColor ? descriptionTextColor : .accentColor)
                     }
                     .buttonStyle(.borderless)
                 }

--- a/Shared/Supporting Files/Views/SampleList.swift
+++ b/Shared/Supporting Files/Views/SampleList.swift
@@ -27,6 +27,9 @@ struct SampleList: View {
     /// A Boolean value that indicates whether to present the about view.
     @State private var isAboutViewPresented = false
     
+    /// A string representation of the selected sample.
+    @State var selection: String?
+    
     /// The samples to display in the list. Searching adjusts this value.
     private var displayedSamples: [Sample] {
         if !isSearching {
@@ -41,8 +44,8 @@ struct SampleList: View {
     }
     
     var body: some View {
-        List(displayedSamples, id: \.name) { sample in
-            SampleRow(sample: sample)
+        List(displayedSamples, id: \.name, selection: $selection) { sample in
+            SampleRow(sample: sample, selection: selection)
         }
         .navigationTitle("Samples")
         .toolbar {
@@ -65,6 +68,9 @@ private extension SampleList {
         /// The sample displayed in the row.
         let sample: Sample
         
+        /// A string representation of the selected sample.
+        let selection: String?
+        
         /// A Boolean value indicating whether to show the sample's description
         @State private var isShowingDescription = false
         
@@ -76,10 +82,18 @@ private extension SampleList {
                     VStack(alignment: .leading, spacing: 5) {
                         Text(sample.name)
                         if isShowingDescription {
-                            Text(sample.description)
-                                .font(.caption)
-                                .foregroundColor(.secondary)
-                                .transition(.move(edge: .top).combined(with: .opacity))
+                            if #available(iOS 16, *) {
+                                Text(sample.description)
+                                    .foregroundColor(selection == sample.name ? .white.opacity(0.8) : .secondary)
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                                    .transition(.move(edge: .top).combined(with: .opacity))
+                            } else {
+                                Text(sample.description)
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                                    .transition(.move(edge: .top).combined(with: .opacity))
+                            }
                         }
                     }
                     Spacer()
@@ -87,8 +101,10 @@ private extension SampleList {
                         isShowingDescription.toggle()
                     } label: {
                         Image(systemName: isShowingDescription ? "info.circle.fill" : "info.circle")
+                            .foregroundColor(selection == sample.name ? .white : .accentColor)
                     }
                     .buttonStyle(.borderless)
+                    .foregroundColor(selection == sample.name ? .white : .accentColor)
                 }
                 .animation(.easeOut(duration: 0.2), value: isShowingDescription)
             }


### PR DESCRIPTION
## Description

This PR fixes the issue described [here](https://devtopia.esri.com/runtime/swift/issues/3878) where in iOS 16+ a selected list item's help text color does not contrast well with the purple background color, and the button is no longer visible since it's tint color is purple.

Now the help text and button are white when the list item is selected and the background color is purple. If the list item's background is not purple the color of the help text and button is not modified.

## Linked Issue(s)

- `swift/issues/3878`

## How To Test
Test with iOS 16+

## Screenshots

Before
<img width="600" alt="" src="https://user-images.githubusercontent.com/117859673/231854541-4368cec1-524c-4d78-a9f0-8680433740ca.png">

After (dark mode)
<img width="600" alt="" src="https://user-images.githubusercontent.com/117859673/231854419-0d9c4f7a-32df-4aed-8126-ca221e15b93d.png">

After (light mode)
<img width="600" alt="" src="https://user-images.githubusercontent.com/117859673/231857515-c06ea53d-6fa8-4d08-aab8-70f8d26fd2cd.png">

Question - Is the help text contrast in dark mode still too light? The accent color for dark mode may need to be changed to one with less brightness. Perhaps a lighter shade of the accessory color for light mode.
