### PR TITLE
[Setup] Add back PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,27 @@
+## Description
+
+This PR implements `SAMPLE_NAME` in `SAMPLE_CATEGORY` category.
+URL to README: 
+
+## Linked Issue(s)
+
+- `swift/issues/`
+
+## How To Test
+
+
+## Screenshots
+
+|Before|After|
+|:-:|:-:|
+|||
+
+## To Discuss
+
+<details><summary>Code Snippet</summary>
+
+```swift
+Swift repro code goes here
+```
+
+</details>


### PR DESCRIPTION
Please see the discussion here: https://github.com/Esri/arcgis-maps-sdk-swift-samples/pull/172#discussion_r1170549693 

The template was accidentally removed in a new sample PR. This PR adds it back to `main`.

Ref: #9 