### PR TITLE
[Update] Get rid of iCloud SF Symbols usage

### DIFF
--- a/Shared/Samples/Download preplanned map area/DownloadPreplannedMapAreaView.MapPicker.swift
+++ b/Shared/Samples/Download preplanned map area/DownloadPreplannedMapAreaView.MapPicker.swift
@@ -91,10 +91,10 @@ extension DownloadPreplannedMapAreaView {
                         case .success:
                             EmptyView()
                         case .failure:
-                            Image(systemName: "exclamationmark.icloud")
+                            Image(systemName: "exclamationmark.circle")
                                 .foregroundColor(.red)
                         case .none:
-                            Image(systemName: "icloud.and.arrow.down")
+                            Image(systemName: "tray.and.arrow.down")
                                 .foregroundColor(.accentColor)
                         }
                     


### PR DESCRIPTION
## Description

This PR replaces 2 iCloud SF Symbols. Per Apple Use Restrictions

> This symbol may not be modified and may only be used to refer to Apple’s iCloud service.
