### PR TITLE
[Setup] Fix local bundle ID caused crash

### DIFF
--- a/Shared/Supporting Files/Views/AboutView.swift
+++ b/Shared/Supporting Files/Views/AboutView.swift
@@ -58,7 +58,10 @@ private struct VersionRow: View {
 }
 
 private extension Bundle {
-    static let arcGIS = Bundle(identifier: "com.esri.ArcGIS")!
+    // The local package bundle ID is "ArcGIS"; the binary is "com.esri.ArcGIS".
+    // By default, the project assumes the dependencies come from GitHub. If they
+    // are not found, then for sure we are developing using local packages.
+    static let arcGIS = Bundle(identifier: "com.esri.ArcGIS") ?? Bundle(identifier: "ArcGIS")!
     
     var name: String { object(forInfoDictionaryKey: "CFBundleName") as? String ?? "" }
     var shortVersion: String { object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "" }


### PR DESCRIPTION
## Description

This PR fixes the info button crash when developing using a local source code package. 

## Linked Issue(s)

- #157 

## How To Test

1. Build without changing the project file. It resolves to the 200.1 released binary package
2. Build after changing the project file to use the local source package.
3. Tap on info button and no crash.
4. You can also test build with swift-daily.
