### PR TITLE
[Fix] Bump requirement to Xcode 14.1.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository contains Swift sample code demonstrating the capabilities of [Ar
 
 * [ArcGIS Maps SDK for Swift](https://developers.arcgis.com/swift/) 200.1 (or newer)
 * [ArcGIS Maps SDK for Swift Toolkit](https://github.com/Esri/arcgis-maps-sdk-swift-toolkit) 200.1 (or newer)
-* Xcode 14.0 (or newer)
+* Xcode 14.1 (or newer)
 
 The *ArcGIS Maps SDK for Swift Samples app* has a *Target SDK* version of *15.0*, meaning that it can run on devices with *iOS 15.0* or newer.
 


### PR DESCRIPTION
## Description

See https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/issues/318

> It might be best if both the toolkit and the samples app update their minimum Xcode version to 14.1, the first version to include the macOS 13 SDK.

Another PR will fix this on v.next #197 