### PR TITLE
[Fix] Change on-demand resources downloaded state criteria

### DIFF
--- a/Shared/Supporting Files/Models/OnDemandResource.swift
+++ b/Shared/Supporting Files/Models/OnDemandResource.swift
@@ -54,7 +54,7 @@ final class OnDemandResource: ObservableObject {
         request.progress
             .publisher(for: \.fractionCompleted, options: .new)
             .receive(on: DispatchQueue.main)
-            .map { $0 < 1 ? .inProgress($0) : .downloaded }
+            .map { .inProgress($0) }
             .sink { [weak self] in self?.requestState = $0 }
             .store(in: &cancellables)
     }
@@ -77,6 +77,7 @@ final class OnDemandResource: ObservableObject {
         } else {
             do {
                 try await request.beginAccessingResources()
+                requestState = .downloaded
             } catch {
                 if (error as NSError).code != NSUserCancelledError {
                     self.error = error


### PR DESCRIPTION
## Description

This PR fixes the ODR resource force unwrap not found problem described in #48 

## Linked Issue(s)

- `swift/issues/4199`

## How To Test

1. Do a fresh install and fresh build
2. When the samples app first open, check an arbitrary sample that has ODR, e.g. 
    - [Add raster from file](https://github.com/Esri/arcgis-maps-sdk-swift-samples/tree/main/Shared/Samples/Add%20raster%20from%20file)
    - [Add feature layers](https://github.com/Esri/arcgis-maps-sdk-swift-samples/tree/main/Shared/Samples/Add%20feature%20layers)
    - Change camera controller
    - [Display map from mobile map package](https://github.com/Esri/arcgis-maps-sdk-swift-samples/tree/main/Shared/Samples/Display%20map%20from%20mobile%20map%20package)
3. Make sure none of them crashes

## To Discuss

I haven't been able to reproduce a crash with this fix. My gut says the root cause was that when `NSBundleResourceRequest` sets its progress to 100%, it is not immediately setting the `isResourceAvailable` to `true`, or it is dispatched onto the main serial queue whereas the state change is propagated to the view earlier than that. 🧐 

- One way to fix is to move the `requestState = .downloaded` to a later point.

According to the doc for [beginAccessingResources(completionHandler:)](https://developer.apple.com/documentation/foundation/nsbundleresourcerequest/1614840-beginaccessingresources), 

> The resources are not available until the completion handler is called with error set to nil.

So when the `try await request.beginAccessingResources()` call returns, the resource must be available.

- Another potential way to fix is to call the `download()` method again after the progress reported 100%, so it conditionally checks for the resource again.