### PR TITLE
[Setup] Improve error handling and add category to metadata script 

### DIFF
--- a/Scripts/GenerateSampleViewSourceCode.swift
+++ b/Scripts/GenerateSampleViewSourceCode.swift
@@ -73,7 +73,6 @@ let templateURL = URL(fileURLWithPath: arguments[2], isDirectory: false)
 let outputFileURL = URL(fileURLWithPath: arguments[3], isDirectory: false)
 
 private let sampleMetadata: [SampleMetadata] = {
-    // Finds all subdirectories under the root samples directory.
     let decoder = JSONDecoder()
     // Converts snake-case key "offline_data" to camel-case "offlineData".
     decoder.keyDecodingStrategy = .convertFromSnakeCase
@@ -83,7 +82,7 @@ private let sampleMetadata: [SampleMetadata] = {
         return try FileManager.default.contentsOfDirectory(at: samplesDirectoryURL, includingPropertiesForKeys: nil, options: [.skipsHiddenFiles])
             .filter(\.hasDirectoryPath)
             .map { url in
-                // Try to access the metadata file under a subdirectory.
+                // Gets the metadata JSON under each subdirectory.
                 do {
                     let data = try Data(contentsOf: url.appendingPathComponent("README.metadata.json"))
                     return try decoder.decode(SampleMetadata.self, from: data)

--- a/Scripts/GenerateSampleViewSourceCode.swift
+++ b/Scripts/GenerateSampleViewSourceCode.swift
@@ -31,6 +31,8 @@ import Foundation
 private struct SampleMetadata: Decodable {
     /// The title of the sample.
     let title: String
+    /// The category of the sample.
+    let category: String
     /// The description of the sample.
     let description: String
     /// The relative paths to the code snippets.
@@ -103,6 +105,7 @@ private let sampleStructs = sampleMetadata
         return """
         struct \(sample.structName): Sample {
             var name: String { \"\(sample.title)\" }
+            var category: String { \"\(sample.category)\" }
             var description: String { \"\(sample.description)\" }
             var snippets: [String] { \(sample.snippets) }
             var tags: Set<String> { \(sample.keywords) }

--- a/Scripts/GenerateSampleViewSourceCode.swift
+++ b/Scripts/GenerateSampleViewSourceCode.swift
@@ -77,8 +77,9 @@ private let sampleMetadata: [SampleMetadata] = {
     let decoder = JSONDecoder()
     // Converts snake-case key "offline_data" to camel-case "offlineData".
     decoder.keyDecodingStrategy = .convertFromSnakeCase
-    // Does a shallow traverse of the top level of samples directory.
+    
     do {
+        // Does a shallow traverse of the top level of samples directory.
         return try FileManager.default.contentsOfDirectory(at: samplesDirectoryURL, includingPropertiesForKeys: nil, options: [.skipsHiddenFiles])
             .filter(\.hasDirectoryPath)
             .map { url in

--- a/Scripts/GenerateSampleViewSourceCode.swift
+++ b/Scripts/GenerateSampleViewSourceCode.swift
@@ -88,13 +88,13 @@ private let sampleMetadata: [SampleMetadata] = {
                     let data = try Data(contentsOf: url.appendingPathComponent("README.metadata.json"))
                     return try decoder.decode(SampleMetadata.self, from: data)
                 } catch {
-                    print("Error '\(url.lastPathComponent)' sample couldn’t be decoded.")
+                    print("error: '\(url.lastPathComponent)' sample couldn’t be decoded.")
                     exit(1)
                 }
             }
             .sorted { $0.title < $1.title }
     } catch {
-        print("Error decoding Samples: \(error.localizedDescription)")
+        print("error: Decoding Samples: \(error.localizedDescription)")
         exit(1)
     }
 }()
@@ -134,6 +134,6 @@ do {
         .replacingOccurrences(of: "/* structs */", with: sampleStructs)
     try content.write(to: outputFileURL, atomically: true, encoding: .utf8)
 } catch {
-    print("Error reading or writing template file: \(error.localizedDescription)")
+    print("error: Reading or writing template file: \(error.localizedDescription)")
     exit(1)
 }

--- a/Shared/Supporting Files/Models/Sample.swift
+++ b/Shared/Supporting Files/Models/Sample.swift
@@ -19,6 +19,9 @@ protocol Sample {
     /// The name of the sample.
     var name: String { get }
     
+    /// The description of the sample.
+    var category: String { get }
+    
     /// A brief description of the sample's functionalities.
     var description: String { get }
     

--- a/Shared/Supporting Files/Models/Sample.swift
+++ b/Shared/Supporting Files/Models/Sample.swift
@@ -19,7 +19,7 @@ protocol Sample {
     /// The name of the sample.
     var name: String { get }
     
-    /// The description of the sample.
+    /// The category in which the sample belongs.
     var category: String { get }
     
     /// A brief description of the sample's functionalities.


### PR DESCRIPTION
## Description

This PR updates the script that generates the `Sample` struct from metadata…

- it exit with error code 1 "Command RuleScriptExecution failed with a nonzero exit code" when a malformatted JSON is encountered, instead of ignoring it, so it is easier for a developer to locate the mistake
- it includes the category from the metadata so we can implement the UI

## Linked Issue(s)

- `swift/issues/4227`
- https://github.com/Esri/arcgis-maps-sdk-swift-samples/projects/1#card-89299131

## How To Test

- Mess up a metadata in any sample
- See if the build script exit with error
- Fix the metadata, clean build folder
- Build again and the error is gone
- You can try to print out the category of a sample somewhere
