### PR TITLE
[Update] Add category to sample row

### DIFF
--- a/Shared/Supporting Files/Views/CategoryGridView.swift
+++ b/Shared/Supporting Files/Views/CategoryGridView.swift
@@ -38,8 +38,11 @@ struct CategoryGridView: View {
             LazyVGrid(columns: columns) {
                 ForEach(categories, id: \.self) { category in
                     NavigationLink {
-                        SampleListView(samples: samples.filter { $0.category == category })
-                            .navigationTitle(category)
+                        SampleListView(
+                            samples: samples.filter { $0.category == category },
+                            shouldShowCategory: false
+                        )
+                        .navigationTitle(category)
                     } label: {
                         CategoryTitleView(category: category)
                     }

--- a/Shared/Supporting Files/Views/CategoryView.swift
+++ b/Shared/Supporting Files/Views/CategoryView.swift
@@ -37,7 +37,7 @@ struct CategoryView: View {
             if !isSearching {
                 CategoryGridView(samples: samples)
             } else {
-                SampleListView(samples: displayedSamples)
+                SampleListView(samples: displayedSamples, shouldShowCategory: true)
             }
         }
         .navigationTitle("Samples")

--- a/Shared/Supporting Files/Views/SampleListView.swift
+++ b/Shared/Supporting Files/Views/SampleListView.swift
@@ -18,9 +18,14 @@ struct SampleListView: View {
     /// All samples that will be displayed in the list.
     let samples: [Sample]
     
+    /// A Boolean value indicating whether the row description should include
+    /// the sample's category. We only need this information when the samples
+    /// in the list are from different categories.
+    let shouldShowCategory: Bool
+    
     var body: some View {
         List(samples, id: \.name) { sample in
-            SampleRow(sample: sample)
+            SampleRow(sample: sample, shouldShowCategory: shouldShowCategory)
         }
     }
 }
@@ -30,44 +35,25 @@ private extension SampleListView {
         /// The sample displayed in the row.
         let sample: Sample
         
-        /// A Boolean value that indicates whether to show the sample's description.
-        @State private var isShowingDescription = false
-        
+        /// A Boolean value that indicates whether to show the sample's category.
+        let shouldShowCategory: Bool
+
         var body: some View {
-            ZStack {
-                NavigationLink {
+            DisclosureGroup {
+                VStack(alignment: .leading) {
+                    if shouldShowCategory {
+                        Text("Category: \(sample.category)")
+                            .bold()
+                    }
+                    Text(sample.description)
+                        .foregroundColor(.secondary)
+                }
+                .listRowSeparator(.hidden)
+                .font(.caption)
+            } label: {
+                NavigationLink(sample.name) {
                     SampleDetailView(sample: sample)
-                } label: {
-                    EmptyView()
                 }
-                .frame(width: 0)
-                .opacity(0)
-                
-                VStack(alignment: .leading, spacing: 5) {
-                    HStack {
-                        Text(sample.name)
-                        Spacer()
-                        Button {
-                            isShowingDescription.toggle()
-                        } label: {
-                            Image(systemName: "chevron.right.circle")
-                                .rotationEffect(isShowingDescription ? .degrees(90) : .zero)
-                        }
-                        .buttonStyle(.borderless)
-                    }
-                    
-                    if isShowingDescription {
-                        Group {
-                            Text("Category: \(sample.category)")
-                                .bold()
-                            Text(sample.description)
-                                .foregroundColor(.secondary)
-                        }
-                        .font(.caption)
-                        .transition(.move(edge: .top).combined(with: .opacity))
-                    }
-                }
-                .animation(.easeOut(duration: 0.2), value: isShowingDescription)
             }
         }
     }

--- a/Shared/Supporting Files/Views/SampleListView.swift
+++ b/Shared/Supporting Files/Views/SampleListView.swift
@@ -34,26 +34,38 @@ private extension SampleListView {
         @State private var isShowingDescription = false
         
         var body: some View {
-            NavigationLink {
-                SampleDetailView(sample: sample)
-            } label: {
-                HStack {
-                    VStack(alignment: .leading, spacing: 5) {
+            ZStack {
+                NavigationLink {
+                    SampleDetailView(sample: sample)
+                } label: {
+                    EmptyView()
+                }
+                .frame(width: 0)
+                .opacity(0)
+                
+                VStack(alignment: .leading, spacing: 5) {
+                    HStack {
                         Text(sample.name)
-                        if isShowingDescription {
-                            Text(sample.description)
-                                .font(.caption)
-                                .foregroundColor(.secondary)
-                                .transition(.move(edge: .top).combined(with: .opacity))
+                        Spacer()
+                        Button {
+                            isShowingDescription.toggle()
+                        } label: {
+                            Image(systemName: "chevron.right.circle")
+                                .rotationEffect(isShowingDescription ? .degrees(90) : .zero)
                         }
+                        .buttonStyle(.borderless)
                     }
-                    Spacer()
-                    Button {
-                        isShowingDescription.toggle()
-                    } label: {
-                        Image(systemName: isShowingDescription ? "info.circle.fill" : "info.circle")
+                    
+                    if isShowingDescription {
+                        Group {
+                            Text("Category: \(sample.category)")
+                                .bold()
+                            Text(sample.description)
+                                .foregroundColor(.secondary)
+                        }
+                        .font(.caption)
+                        .transition(.move(edge: .top).combined(with: .opacity))
                     }
-                    .buttonStyle(.borderless)
                 }
                 .animation(.easeOut(duration: 0.2), value: isShowingDescription)
             }

--- a/Shared/Supporting Files/Views/SampleListView.swift
+++ b/Shared/Supporting Files/Views/SampleListView.swift
@@ -37,7 +37,7 @@ private extension SampleListView {
         
         /// A Boolean value that indicates whether to show the sample's category.
         let shouldShowCategory: Bool
-
+        
         var body: some View {
             DisclosureGroup {
                 VStack(alignment: .leading) {


### PR DESCRIPTION
## Description

This PR adds the category to the sample row in the Sample Viewer. This allows the user to easily find the category of a sample when searching by hitting the description button on the sample row. The description button was also updated from an info symbol to a chevron due to a discussion that can be found in the issue's comments.

## Linked Issue(s)

- `swift/issues/4298`

## How To Test

- Search for a sample.
- Tap on the chevron to see the sample's category and description.
- Tap on the chevron again to close the description.
- Tap on the sample row to open the sample. 

## Screenshots

|Before|After|
|:-:|:-:|
|![Simulator Screen Shot - iPhone 14 Pro - 2023-07-19 at 10 36 11](https://github.com/Esri/arcgis-maps-sdk-swift-samples/assets/34120440/a799da44-20d2-4757-bd97-fe861b458c43)|![Simulator Screen Shot - iPhone 14 Pro - 2023-07-19 at 10 09 53](https://github.com/Esri/arcgis-maps-sdk-swift-samples/assets/34120440/f1d8ab49-e3f2-4e30-a102-337bce60b3bb)|
