### PR TITLE
[Fix] Issue with sidebar navigation

### DIFF
--- a/Shared/Supporting Files/Views/CategoryGridView.swift
+++ b/Shared/Supporting Files/Views/CategoryGridView.swift
@@ -43,6 +43,7 @@ struct CategoryGridView: View {
                     } label: {
                         CategoryTitleView(category: category)
                     }
+                    .isDetailLink(false)
                     .clipShape(RoundedRectangle(cornerRadius: 15))
                     .contentShape(RoundedRectangle(cornerRadius: 30))
                     .buttonStyle(.plain)

--- a/Shared/Supporting Files/Views/ContentView.swift
+++ b/Shared/Supporting Files/Views/ContentView.swift
@@ -24,7 +24,9 @@ struct ContentView: View {
     var body: some View {
         if #available(iOS 16, *) {
             NavigationSplitView {
-                sidebar
+                NavigationStack {
+                    sidebar
+                }
             } detail: {
                 detail
             }


### PR DESCRIPTION
Fixes issue described [here](https://github.com/Esri/arcgis-maps-sdk-swift-samples/pull/221#issuecomment-1641069920), where going back from a sample takes the user all the way back to the Categories view, not the view for the category to which the sample belongs. This also means that when the categories are displayed in a sidebar, tapping on a category opens that category in the sidebar, which is expected behavior for this kind of a navigation setup on iOS.