### PR TITLE
[Fix] Center category grid text

### DIFF
--- a/Shared/Supporting Files/Views/CategoryGridView.swift
+++ b/Shared/Supporting Files/Views/CategoryGridView.swift
@@ -72,6 +72,7 @@ private extension CategoryGridView {
                         Image("\(category.replacingOccurrences(of: " ", with: "-"))-icon")
                             .colorInvert()
                         Text(category)
+                            .multilineTextAlignment(.center)
                             .foregroundColor(.white)
                             .offset(y: 45)
                     }


### PR DESCRIPTION
## Description

This PR implements a fix to the Sample Viewer by centering category title text on the category grid tiles. Initially, text was aligned left when there were multiple lines.

## How To Test

- Load the Sample Viewer on iPad and verify the text is centered on the category grid titles.
- Verify the app works the same otherwise. 

## Screenshots

|Before|After|
|:-:|:-:|
|![iPad Screen Shot, Before](https://github.com/Esri/arcgis-maps-sdk-swift-samples/assets/34120440/f6c556ab-af04-45a5-8b1a-0ed4d2b119f0)|![iPad Screen Shot, After](https://github.com/Esri/arcgis-maps-sdk-swift-samples/assets/34120440/356d2025-cc17-408e-9e2b-e9387ff1260b)|

