### PR TITLE
[Fix] ODR-related crash

### DIFF
--- a/Shared/Supporting Files/Views/SampleListView.swift
+++ b/Shared/Supporting Files/Views/SampleListView.swift
@@ -36,6 +36,7 @@ private extension SampleListView {
         var body: some View {
             NavigationLink {
                 SampleDetailView(sample: sample)
+                    .id(sample.name)
             } label: {
                 HStack {
                     VStack(alignment: .leading, spacing: 5) {


### PR DESCRIPTION
The crash is due to `OnDemandResource` state being re-used across samples, a problem described in the [Initialize state objects using external data](https://developer.apple.com/documentation/swiftui/stateobject#Initialize-state-objects-using-external-data) section of the `StateObject` doc:

> SwiftUI only initializes a state object the first time you call its initializer in a given view. This ensures that the object provides stable storage even as the view’s inputs change. However, it might result in unexpected behavior or unwanted side effects if you explicitly initialize the state object.

The solution is described in the [Force reinitialization by changing view identity](https://developer.apple.com/documentation/swiftui/stateobject#Force-reinitialization-by-changing-view-identity) section.

This fix assumes that sample names will always be unique. Please let me know if that is an incorrect assumption. If it is, I can combine the sample name and category into a single hash and use that as the identifier instead.