### PR TITLE
[Fix] Clicking anywhere on the cell is not working in Analyze network with subnetwork trace sample

### DIFF
--- a/Shared/Samples/Analyze network with subnetwork trace/AnalyzeNetworkWithSubnetworkTraceView.swift
+++ b/Shared/Samples/Analyze network with subnetwork trace/AnalyzeNetworkWithSubnetworkTraceView.swift
@@ -116,6 +116,7 @@ struct AnalyzeNetworkWithSubnetworkTraceView: View {
         Spacer()
         Button {
             isConditionMenuPresented = true
+            inputValue = nil
         } label: {
             Image(systemName: "plus")
                 .imageScale(.large)

--- a/Shared/Samples/Analyze network with subnetwork trace/AnalyzeNetworkWithSubnetworkTraceView.swift
+++ b/Shared/Samples/Analyze network with subnetwork trace/AnalyzeNetworkWithSubnetworkTraceView.swift
@@ -254,8 +254,8 @@ struct AnalyzeNetworkWithSubnetworkTraceView: View {
         List(model.possibleAttributes, id: \.name) { attribute in
             HStack {
                 Text(attribute.name)
+                Spacer()
                 if attribute === selectedAttribute {
-                    Spacer()
                     Image(systemName: "checkmark")
                         .foregroundColor(.accentColor)
                 }
@@ -273,8 +273,8 @@ struct AnalyzeNetworkWithSubnetworkTraceView: View {
             List(UtilityNetworkAttributeComparison.Operator.allCases, id: \.self) { comparison in
                 HStack {
                     Text(comparison.title)
+                    Spacer()
                     if comparison == selectedComparison {
-                        Spacer()
                         Image(systemName: "checkmark")
                             .foregroundColor(.accentColor)
                     }
@@ -294,8 +294,8 @@ struct AnalyzeNetworkWithSubnetworkTraceView: View {
                 List(domain.codedValues, id: \.name) { value in
                     HStack {
                         Text(value.name)
+                        Spacer()
                         if value === selectedValue as? CodedValue {
-                            Spacer()
                             Image(systemName: "checkmark")
                                 .foregroundColor(.accentColor)
                         }


### PR DESCRIPTION
## Description
List items can now be selected by clicking anywhere in the cell. Before only the cell text was selectable. This PR also has a bug fix to reset previous textfield input. 

## Linked Issue(s)

- `swift/issues/4402`

## How To Test
Add condition by selecting the attribute, comparison, and value. Make sure that list item can be selected by clicking anywhere in the cell. 

## To Discuss

I tried to use a Button to avoid use of `.onTapGesture` but the UI had a few issues including incorrect accent color and line separator style, so I decided to use the original implementation:

<img src="https://github.com/Esri/arcgis-maps-sdk-swift-samples/assets/117859673/9459fe9c-22c2-465c-8ffa-1f4dad594169" width="500">

