### PR TITLE
[Fix] Add unknown default for binary dependency

### DIFF
--- a/Shared/Samples/Analyze network with subnetwork trace/AnalyzeNetworkWithSubnetworkTraceView.Model.swift
+++ b/Shared/Samples/Analyze network with subnetwork trace/AnalyzeNetworkWithSubnetworkTraceView.Model.swift
@@ -347,6 +347,8 @@ extension AnalyzeNetworkWithSubnetworkTraceView {
                 return value as! Double
             case .boolean:
                 return value as! Bool
+            @unknown default:
+                fatalError("Unexpected utility network attribute data type.")
             }
         }
     }


### PR DESCRIPTION
## Description

This PR fixes an unknown default warning using the swift-toolkit-daily package.

## How To Test

- Build using binary won't have warning
- Build using source code will show a warning

## Related

- https://github.com/apple/swift-evolution/blob/main/proposals/0192-non-exhaustive-enums.md
- https://forums.swift.org/t/handling-future-cases-of-enums-in-libraries-without-binary-stability-concerns/32026/11
