### PR TITLE
[Fix] Remove unneeded `import ArcGISToolkit`

### DIFF
--- a/Shared/Samples/Query feature table/QueryFeatureTableView.swift
+++ b/Shared/Samples/Query feature table/QueryFeatureTableView.swift
@@ -14,7 +14,6 @@
 
 import SwiftUI
 import ArcGIS
-import ArcGISToolkit
 
 struct QueryFeatureTableView: View {
     @StateObject private var model = Model()

--- a/Shared/Samples/Show line of sight between points/ShowLineOfSightBetweenPointsView.swift
+++ b/Shared/Samples/Show line of sight between points/ShowLineOfSightBetweenPointsView.swift
@@ -14,7 +14,6 @@
 
 import SwiftUI
 import ArcGIS
-import ArcGISToolkit
 
 struct ShowLineOfSightBetweenPointsView: View {
     /// A scene with an imagery basemap and centered on mountains in Chile.


### PR DESCRIPTION
## Description

This PR removes unneeded imports.

## How To Test

Make sure the app builds with these changes.
