### PR TITLE
[Setup] Remove `anyobject_protocol` rule

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -28,7 +28,6 @@ disabled_rules:
 
 # Some rules are only opt-in
 opt_in_rules: 
-  - anyobject_protocol
   - array_init
   - attributes
   - closure_end_indentation


### PR DESCRIPTION
The rule [has been deprecated](https://github.com/realm/SwiftLint/releases/tag/0.50.0) and now produces a warning:

![image](https://github.com/Esri/arcgis-maps-sdk-swift-samples/assets/2257493/f59d3518-b562-41c9-8f7c-eb441bb0f7fd)