### PR TITLE
[Fix] Configure the attribute linter rule to exclude some cases

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -73,6 +73,8 @@ opt_in_rules:
   - vertical_whitespace_opening_braces
   - yoda_condition
 
+attributes:
+  attributes_with_arguments_always_on_line_above: false
 identifier_name:
   min_length:
     # Do not flag short identifiers


### PR DESCRIPTION
## Description

This PR opts out a linter rule that was introduced in SwiftLint 0.52.0. When I upgraded to the latest version 0.52.4, I saw these warnings with the attributes with argument, such as

```swift
// current
@Environment(\.dismiss) private var dismiss: DismissAction

// linter suggested
@Environment(\.dismiss)
private var dismiss: DismissAction
```

![attributes](https://github.com/Esri/arcgis-maps-sdk-swift-samples/assets/9660181/da18bbf2-3f3b-4c38-bfeb-fa7df49d4099)

My preference is to still keep them on the same line, because even if they have arguments, they annotate a variable nonetheless; in contrast to sth like `@MainActor` that annotates a type, which I'm OK with putting on the line above.

## Linked Issue(s)

- https://realm.github.io/SwiftLint/attributes.html
- https://github.com/realm/SwiftLint/issues/4843
- https://github.com/realm/SwiftLint/pull/4855
- https://github.com/realm/SwiftLint/tree/0.52.0

## How To Test

1. Upgrade `SwiftLint`
2. Run `v.next` see the warnings, this branch no linter warning.
