### PR TITLE
[Fix] Add status message and fix UI for `Trace utility network`

### DIFF
--- a/Shared/Samples/Trace utility network/TraceUtilityNetworkView.Model.swift
+++ b/Shared/Samples/Trace utility network/TraceUtilityNetworkView.Model.swift
@@ -167,6 +167,10 @@ extension TraceUtilityNetworkView {
                 @unknown default:
                     return
                 }
+            } else {
+                Task {
+                    await updateUserHint(withMessage: "An error occurred while adding element to the trace.")
+                }
             }
         }
         

--- a/Shared/Samples/Trace utility network/TraceUtilityNetworkView.Views.swift
+++ b/Shared/Samples/Trace utility network/TraceUtilityNetworkView.Views.swift
@@ -88,10 +88,11 @@ extension TraceUtilityNetworkView {
                         actions: { terminalPickerButtons }
                     )
             case .traceCompleted, .traceFailed:
+                Spacer()
                 Button("Reset", role: .destructive) {
                     model.reset()
                 }
-                .padding()
+                Spacer()
             }
         }
     }


### PR DESCRIPTION
## Description

This PR

- Add a status message for potentially failed/nil method
- Fix the UI on iOS 17 for bottom bar. It is defaulted to the left edge without spacers.

## Linked Issue(s)

- `swift/issues/4401`

## How To Test

Run the sample on iOS 17 beta, UI looks good.
