### PR TITLE
[Fix] Add unknown default for binary dependency

### DIFF
--- a/Shared/Samples/Analyze network with subnetwork trace/AnalyzeNetworkWithSubnetworkTraceView.Model.swift
+++ b/Shared/Samples/Analyze network with subnetwork trace/AnalyzeNetworkWithSubnetworkTraceView.Model.swift
@@ -285,6 +285,8 @@ extension AnalyzeNetworkWithSubnetworkTraceView {
                 } else {
                     return false
                 }
+            @unknown default:
+                fatalError("Unexpected utility network attribute data type.")
             }
         }
         


### PR DESCRIPTION
## Description

I happened to miss this from #240 . With this fix now the samples app should only build with some Non-sendable warnings.