### PR TITLE
[Fix] accessory button and help text color is not clearly visible

### DIFF
--- a/Shared/Supporting Files/Views/SampleRow.swift
+++ b/Shared/Supporting Files/Views/SampleRow.swift
@@ -40,6 +40,7 @@ struct SampleRow: View {
             Label {} icon: {
                 Image(systemName: "info.circle")
                     .symbolVariant(isShowingDescription ? .fill : .none)
+                    .imageScale(.medium)
             }
             .onTapGesture {
                 isShowingDescription.toggle()

--- a/Shared/Supporting Files/Views/SampleRow.swift
+++ b/Shared/Supporting Files/Views/SampleRow.swift
@@ -32,18 +32,18 @@ struct SampleRow: View {
                 if isShowingDescription {
                     Text(description)
                         .font(.caption)
-                        .foregroundColor(.secondary)
+                        .opacity(0.75)
                         .transition(.move(edge: .top).combined(with: .opacity))
                 }
             }
             Spacer()
-            Button {
-                isShowingDescription.toggle()
-            } label: {
+            Label {} icon: {
                 Image(systemName: "info.circle")
                     .symbolVariant(isShowingDescription ? .fill : .none)
             }
-            .buttonStyle(.borderless)
+            .onTapGesture {
+                isShowingDescription.toggle()
+            }
         }
         .animation(.easeOut(duration: 0.2), value: isShowingDescription)
     }


### PR DESCRIPTION
## Description

Fixes a bug in iOS 16+ where the help text and accessory button are not clearly visible when the list item selection color is the accent color (purple/pink) instead of grey. This PR adds opacity to the help text so that the system sets the text color. The accessory button is now a label with an icon and tap gesture rather than a Button since the system will set the color automatically.

## Linked Issue(s)

- `swift/issues/3878`

## How To Test
- Test on iPhone and iPad on iOS 16 and iOS 17

## Screenshots
Before:
<img src="https://github.com/Esri/arcgis-maps-sdk-swift-samples/assets/117859673/0040a4a6-12b8-4544-91dc-fe8727f8be09" width="500">
<img src="https://github.com/Esri/arcgis-maps-sdk-swift-samples/assets/117859673/cc75a017-c744-497f-a125-d95af04c88ac" width="500">

After:
<img src="https://github.com/Esri/arcgis-maps-sdk-swift-samples/assets/117859673/436aec4c-32a9-4957-b8b1-36e674c5494b" width="500">
<img src="https://github.com/Esri/arcgis-maps-sdk-swift-samples/assets/117859673/89cebeb2-ce8f-414d-b765-03bda3cd1b70" width="500">



