### PR TITLE
[Update] Adjust info view control size

### DIFF
--- a/Shared/Supporting Files/Views/SampleInfoView.swift
+++ b/Shared/Supporting Files/Views/SampleInfoView.swift
@@ -43,7 +43,9 @@ struct SampleInfoView: View {
                     }
                 }
                 .pickerStyle(.segmented)
-                .frame(idealWidth: 320)
+                // Set the ideal width to a big value so the segmented control
+                // takes up the entire empty space of the toolbar on iOS 17.
+                .frame(idealWidth: UIScreen.main.bounds.width)
             }
             
             ToolbarItem(placement: .confirmationAction) {

--- a/Shared/Supporting Files/Views/SampleInfoView.swift
+++ b/Shared/Supporting Files/Views/SampleInfoView.swift
@@ -43,6 +43,7 @@ struct SampleInfoView: View {
                     }
                 }
                 .pickerStyle(.segmented)
+                .frame(idealWidth: 320)
             }
             
             ToolbarItem(placement: .confirmationAction) {
@@ -51,13 +52,15 @@ struct SampleInfoView: View {
                 }
             }
             
-            ToolbarItem(placement: .bottomBar) {
+            ToolbarItemGroup(placement: .bottomBar) {
                 if informationMode == .code {
+                    Spacer()
                     Picker("Source Code File Picker", selection: $selectedSnippetIndex) {
                         ForEach(sample.snippetURLs.indices, id: \.self) { index in
                             Text(sample.snippets[index].dropLast(6))
                         }
                     }
+                    Spacer()
                 }
             }
         }


### PR DESCRIPTION
## Description

This PR adjusts the info view's control position and size.

- Add an ideal width to the segmented picker so it's width doesn't differ among iOS versions
- Add spacer to bottom bar to make the code picker centered

## Linked Issue(s)

See `swift/issues/4377`.

## How To Test

Build and run on iOS 16/17 iPad.

## To Discuss

- Ideally, we don't apply the fixed width frame modifier to the segmented picker. But that would cause the width problem described in issue 4377.
- Another idea is to use `fixedSize()` modifier to make the segmented control tight. While it is commonly seen on iPhone, it is generally wider on iPad and Mac.
- Please share your thoughts on which looks better:
   - segmented picker: tight / fixed width (current) / fill the top bar (original, with bug on iOS 17)
   - code picker: centered (current) / aligned to the right / system default (original)
