### PR TITLE
[Fix] Only `import Combine` for needed types

### DIFF
--- a/Shared/Samples/Analyze network with subnetwork trace/AnalyzeNetworkWithSubnetworkTraceView.Model.swift
+++ b/Shared/Samples/Analyze network with subnetwork trace/AnalyzeNetworkWithSubnetworkTraceView.Model.swift
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 import ArcGIS
-import SwiftUI
 import Combine
+import Foundation
 
 extension AnalyzeNetworkWithSubnetworkTraceView {
     /// The view model for this sample.

--- a/Shared/Samples/Create load report/CreateLoadReportView.Model.swift
+++ b/Shared/Samples/Create load report/CreateLoadReportView.Model.swift
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 import ArcGIS
-import SwiftUI
+import Combine
+import Foundation
 
 extension CreateLoadReportView {
     /// The model used to store the geo model and other expensive objects
@@ -284,11 +285,11 @@ extension CreateLoadReportView {
         
         /// Creates a summary for the provided phase.
         /// - Parameter phase: The phase to generate a summary for.
-        /// - Returns: A localized string key representing the summary for the provided phase.
-        func summaryForPhase(_ phase: CodedValue) -> LocalizedStringKey {
+        /// - Returns: A string representing the summary for the provided phase.
+        func summaryForPhase(_ phase: CodedValue) -> String {
             let format: IntegerFormatStyle<Int> = .number
             if let summary = summaries.summary(forPhase: phase) {
-                return "C: \(summary.totalCustomers, format: format)  L: \(summary.totalLoad, format: format)"
+                return "C: \(summary.totalCustomers.formatted(format))  L: \(summary.totalLoad.formatted(format))"
             } else {
                 return "N/A"
             }

--- a/Shared/Samples/Set up location-driven geotriggers/SetUpLocationDrivenGeotriggersView.Model.swift
+++ b/Shared/Samples/Set up location-driven geotriggers/SetUpLocationDrivenGeotriggersView.Model.swift
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import SwiftUI
 import ArcGIS
+import Combine
+import Foundation
 
 extension SetUpLocationDrivenGeotriggersView {
     /// The view model for the sample.

--- a/Shared/Samples/Set up location-driven geotriggers/SetUpLocationDrivenGeotriggersView.Model.swift
+++ b/Shared/Samples/Set up location-driven geotriggers/SetUpLocationDrivenGeotriggersView.Model.swift
@@ -14,7 +14,6 @@
 
 import ArcGIS
 import Combine
-import Foundation
 
 extension SetUpLocationDrivenGeotriggersView {
     /// The view model for the sample.

--- a/Shared/Samples/Set visibility of subtype sublayer/SetVisibilityOfSubtypeSublayerView.Model.swift
+++ b/Shared/Samples/Set visibility of subtype sublayer/SetVisibilityOfSubtypeSublayerView.Model.swift
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import ArcGIS
-import Combine
 import Foundation
 
 extension SetVisibilityOfSubtypeSublayerView {

--- a/Shared/Samples/Set visibility of subtype sublayer/SetVisibilityOfSubtypeSublayerView.Model.swift
+++ b/Shared/Samples/Set visibility of subtype sublayer/SetVisibilityOfSubtypeSublayerView.Model.swift
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import SwiftUI
 import ArcGIS
+import Combine
+import Foundation
 
 extension SetVisibilityOfSubtypeSublayerView {
     /// The view model for this sample.


### PR DESCRIPTION
## Description

This PR fixes extraneous `import SwiftUI` in data model swift files.

## Linked Issue(s)

- https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/pull/410
- https://github.com/Esri/arcgis-maps-sdk-swift-samples/projects/1#card-89559142

## How To Test

Build and run the app, and it still behaves the same.
