### PR TITLE
[Update] Download preplanned map area feedback

### DIFF
--- a/Shared/Samples/Download preplanned map area/DownloadPreplannedMapAreaView.MapPicker.swift
+++ b/Shared/Samples/Download preplanned map area/DownloadPreplannedMapAreaView.MapPicker.swift
@@ -67,7 +67,10 @@ extension DownloadPreplannedMapAreaView {
                 .navigationBarTitleDisplayMode(.inline)
                 .toolbar {
                     ToolbarItem(placement: .confirmationAction) {
-                        Button("Done") { dismiss() }
+                        Button("Done") {
+                            model.isShowingSelectMapView = false
+                            dismiss()
+                        }
                     }
                 }
             }

--- a/Shared/Samples/Download preplanned map area/DownloadPreplannedMapAreaView.Model.swift
+++ b/Shared/Samples/Download preplanned map area/DownloadPreplannedMapAreaView.Model.swift
@@ -58,6 +58,12 @@ extension DownloadPreplannedMapAreaView {
         /// A Boolean value indicating if the offline content can be deleted.
         @Published private(set) var canRemoveDownloadedMaps = false
         
+        /// A Boolean value indicating whether to select a map.
+        @Published var isShowingSelectMapView = false
+        
+        /// A Boolean value indicating if the selected offline map just changed.
+        @Published var offlineMapDidChange = false
+        
         init() {
             // Creates temp directory.
             temporaryDirectory = FileManager.createTemporaryDirectory()
@@ -108,6 +114,7 @@ extension DownloadPreplannedMapAreaView {
                 } else if case .success(let mmpk) = info.result {
                     // If we have already downloaded, then open the map in the mmpk.
                     offlineMap = mmpk.maps.first
+                    offlineMapDidChange = true
                 } else {
                     // If we have a failure, then keep the online map selected.
                     selectedMap = oldValue


### PR DESCRIPTION
## Description

This PR addresses feedback from Nick on the initial testing for 200.1.0 sample viewer TestFlight app for the `Download  preplanned map area` sample:
- > Oooh. A legit bug! I dismissed the preplanned area picker in the preplanned sample then navigated back from the preplanned sample to the samples list and the preplanned area picker reappeared over the sample list! I think you have to download a preplanned area to see this.
Might be related to the sheet issue as well: https://github.com/Esri/arcgis-maps-sdk-swift-samples/issues/80

  This PR fixes this bug caused by a sheet selection bug. The sheet can be closed with a "Done" button which calls 'dismiss()' but does not set the selection value to false. The "Done" button now sets the selection value, but to do so the value had to be moved from to view to the model which is not ideal.

- > This map ("Seager Park Area") looks empty by default on an iPhone. I have to zoom in to notice it has content. Not sure what to do about that though…
  >I spotted the same when I review this sample. The best way IMO is to set the initial zoom scale on these preplanned map area to a close enough value so the symbols appear on all platform regardless desktop or mobile.
  
  This issue is fixed by expanding the visible area's envelope when an offline map is selected. Now all layer content is visible for each offline map.


- > Would it be better if, when you download an area, it is automatically selected? Currently you have to tap to download, wait for it to download, and then tap it again to select it.

  I did not implement this suggestion based on discussion in the swift issue deciding to not make this change.

## Linked Issue(s)

- `swift/issues/3931`

## How To Test
- View each offline map after downloading and verify that all layer content is visible.

## Screenshots
Before/After layer visibility

<img src="https://github.com/Esri/arcgis-maps-sdk-swift-samples/assets/117859673/1371cb60-d2fa-4e3a-92e9-f9ad0bb6955b" width="250">
<img src="https://github.com/Esri/arcgis-maps-sdk-swift-samples/assets/117859673/22bfc9ea-4300-41cf-a86b-f76a884b35b6" width="250">

## To Discuss

- Should the selection sheet bug fix be removed from this PR in favor of waiting for the expected fix in https://github.com/Esri/arcgis-maps-sdk-swift-samples/issues/80 once iOS 16 is the minimum deployment target?