### PR TITLE
[Fix] "false" utility network load problem

### DIFF
--- a/Shared/Samples/Trace utility network/TraceUtilityNetworkView.Model.swift
+++ b/Shared/Samples/Trace utility network/TraceUtilityNetworkView.Model.swift
@@ -204,7 +204,7 @@ extension TraceUtilityNetworkView {
                 return
             }
             
-            // Clear all sublayers then add the layers relevant for the demo.
+            // Clears all sublayers then add the layers relevant for the demo.
             map.removeAllOperationalLayers()
             
             featureLayerURLs.forEach { url in


### PR DESCRIPTION
## Description

This PR fixes an issue in the `Trace utility network` sample.

In the original PR, when the sample opens, a computed property `private var network: UtilityNetwork? { map.utilityNetworks.first }` tries to get the first utility network from the web map. However, because the web map is not explicitly loaded, `network` can become `nil` occasionally, depending on the load timing of the map.

This leads to the problem in 4401 where the `network?.makeElement(arcGISFeature: feature)` call silently fails. A status message was added in #248 to show the error.

After discussing with Jen, both the web map and the network need to be loaded. Only loading the map is not enough; only loading the network doesn't guarantee the map to be present either. Once the map is loaded, we can safely assume the utility network's description is available.

## Linked Issue(s)

- `swift/issues/4401`
- https://github.com/Esri/arcgis-maps-sdk-swift-samples/pull/130#discussion_r1147978503

## How To Test

- On `v.next`, sometimes you cannot add element to the utility network
- With the fixes on this branch, the sample is correct
