### PR TITLE
[Update] Allow bundle resources on Mac Catalyst

### DIFF
--- a/Shared/SamplesApp.swift
+++ b/Shared/SamplesApp.swift
@@ -23,9 +23,7 @@ struct SamplesApp: App {
     
     var body: some SwiftUI.Scene {
         WindowGroup {
-            ContentView(
-                samples: Self.samples
-            )
+            ContentView(samples: Self.samples)
         }
     }
 }

--- a/Shared/SamplesApp.swift
+++ b/Shared/SamplesApp.swift
@@ -25,10 +25,6 @@ struct SamplesApp: App {
         WindowGroup {
             ContentView(
                 samples: Self.samples
-                #if targetEnvironment(macCatalyst)
-                    // On-demand resources aren't available on Mac Catalyst yet.
-                    .filter { !$0.hasDependencies }
-                #endif
             )
         }
     }

--- a/Shared/Supporting Files/Views/SampleDetailView.swift
+++ b/Shared/Supporting Files/Views/SampleDetailView.swift
@@ -27,7 +27,8 @@ struct SampleDetailView: View {
     /// A Boolean value indicating whether a sample should use on-demand resources.
     var usesOnDemandResources: Bool {
 #if targetEnvironment(macCatalyst)
-        // Mac Catalyst isn't supported by `NSBundleResourceRequest`.
+        // Mac Catalyst isn't supported by `NSBundleResourceRequest`. Instead, Xcode
+        // put the offline data into the app bundle on Mac Catalyst.
         return false
 #else
         return sample.hasDependencies

--- a/Shared/Supporting Files/Views/SampleDetailView.swift
+++ b/Shared/Supporting Files/Views/SampleDetailView.swift
@@ -24,6 +24,16 @@ struct SampleDetailView: View {
     /// An object to manage on-demand resources for a sample with dependencies.
     @StateObject private var onDemandResource: OnDemandResource
     
+    /// A Boolean value indicating whether a sample should use on-demand resources.
+    var usesOnDemandResources: Bool {
+#if targetEnvironment(macCatalyst)
+        // Mac Catalyst isn't supported by `NSBundleResourceRequest`.
+        return false
+#else
+        return sample.hasDependencies
+#endif
+    }
+    
     init(sample: Sample) {
         self.sample = sample
         self._onDemandResource = StateObject(
@@ -33,7 +43,7 @@ struct SampleDetailView: View {
     
     var body: some View {
         Group {
-            if sample.hasDependencies {
+            if usesOnDemandResources {
                 // 'onDemandResource' is created in this branch.
                 Group {
                     switch onDemandResource.requestState {


### PR DESCRIPTION
## Description

This PR allows the samples with dependent data files to run on Mac Catalyst.

## Linked Issue(s)

- `swift/issues/4354`
- https://github.com/Esri/arcgis-maps-sdk-swift-samples/pull/93#issuecomment-1339643112
- https://github.com/Esri/arcgis-maps-sdk-swift-samples/projects/1#card-87094498

## How To Test

- Build and run the app on Mac Catalyst
    - You'll see the samples that use offline data, such as mobile map package and feature layer samples
    - You can open these samples on Mac Catalyst without crashing
- Build and run on iOS
    - The samples still download using the ODR API

## To Discuss

I was surprised to find that Apple provides native support for using those ODR-on-iOS directly on Mac Catalyst, without a custom copy files or copy bundle resources phase in the build phases. I was under the impression that all files with ODR tag are **not** part of the bundle, regardless of the target.

My guess is that, if a file is associated with an ODR tag, in the backstage, Xcode handles it differently for iOS vs Mac Catalyst. On iOS, those files are excluded from the bundle, whereas they are included as part of the bundle on Mac Catalyst.

The only problem is I cannot find an official documentation to back this theory up. Can someone help with that? Thanks. 🤔 