### PR TITLE
Add dynamic entity layer settings presentation refactor

### DIFF
--- a/Shared/Samples/Add dynamic entity layer/AddDynamicEntityLayerView.SettingsView.swift
+++ b/Shared/Samples/Add dynamic entity layer/AddDynamicEntityLayerView.SettingsView.swift
@@ -23,44 +23,55 @@ extension AddDynamicEntityLayerView {
         @Environment(\.dismiss) private var dismiss: DismissAction
         
         var body: some View {
-            NavigationView {
-                List {
-                    Section("Track display properties") {
-                        Toggle("Track Lines", isOn: $model.showsTrackLine)
-                        Toggle("Previous Observations", isOn: $model.showsPreviousObservations)
-                    }
-                    
-                    Section("Observations") {
-                        VStack {
-                            HStack {
-                                Text("Observations per track")
-                                Spacer()
-                                Text(model.maximumObservations.formatted())
-                                    .foregroundColor(.secondary)
-                            }
-                            Slider(value: $model.maximumObservations, in: model.maxObservationRange, step: 1)
-                        }
-                        HStack {
-                            Spacer()
-                            Button("Purge All Observations") {
-                                Task {
-                                    try? await model.streamService.purgeAll()
-                                }
-                            }
-                            Spacer()
-                        }
-                    }
+            if #available(iOS 16, *) {
+                NavigationStack {
+                    root
                 }
-                .navigationTitle("Dynamic Entity Settings")
-                .navigationBarTitleDisplayMode(.inline)
-                .toolbar {
-                    ToolbarItem(placement: .confirmationAction) {
-                        Button("Done") {
-                            dismiss()
-                        }
-                    }
+            } else {
+                NavigationView {
+                    root
                 }
                 .navigationViewStyle(.stack)
+            }
+        }
+        
+        @ViewBuilder var root: some View {
+            Form {
+                Section("Track display properties") {
+                    Toggle("Track Lines", isOn: $model.showsTrackLine)
+                    Toggle("Previous Observations", isOn: $model.showsPreviousObservations)
+                }
+                
+                Section("Observations") {
+                    VStack {
+                        HStack {
+                            Text("Observations per track")
+                            Spacer()
+                            Text(model.maximumObservations.formatted())
+                                .foregroundColor(.secondary)
+                        }
+                        Slider(value: $model.maximumObservations, in: model.maxObservationRange, step: 1)
+                    }
+                    HStack {
+                        Spacer()
+                        Button("Purge All Observations") {
+                            Task {
+                                try? await model.streamService.purgeAll()
+                            }
+                        }
+                        Spacer()
+                    }
+                }
+            }
+            .toggleStyle(.switch)
+            .navigationTitle("Dynamic Entity Settings")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") {
+                        dismiss()
+                    }
+                }
             }
         }
     }

--- a/Shared/Samples/Add dynamic entity layer/AddDynamicEntityLayerView.swift
+++ b/Shared/Samples/Add dynamic entity layer/AddDynamicEntityLayerView.swift
@@ -20,10 +20,10 @@ struct AddDynamicEntityLayerView: View {
     @StateObject private var model = Model()
     
     /// A Boolean value indicating whether the settings view should be presented.
-    @State var isShowingSettings = false
+    @State private var isShowingSettings = false
     
     /// The initial viewpoint for the map.
-    @State var viewpoint = Viewpoint(
+    @State private var viewpoint = Viewpoint(
         center: Point(x: -12452361.486, y: 4949774.965),
         scale: 200_000
     )
@@ -32,12 +32,6 @@ struct AddDynamicEntityLayerView: View {
     var isConnected: Bool {
         model.streamService.connectionStatus == .connected
     }
-    
-    /// The horizontal size class of the environment.
-    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
-    
-    /// The vertical size class of the environment.
-    @Environment(\.verticalSizeClass) private var verticalSizeClass
     
     var body: some View {
         // Creates a map view to display the map.
@@ -80,20 +74,23 @@ struct AddDynamicEntityLayerView: View {
         let button = Button("Dynamic Entity Settings") {
             isShowingSettings = true
         }
-        if #available(iOS 16, *),
-           horizontalSizeClass == .compact,
-           verticalSizeClass == .regular {
+        let settingsView = SettingsView()
+            .environmentObject(model)
+        if #available(iOS 16, *) {
             button
-                .sheet(isPresented: $isShowingSettings) {
-                    SettingsView()
-                        .environmentObject(model)
+                .popover(isPresented: $isShowingSettings, arrowEdge: .bottom) {
+                    settingsView
                         .presentationDetents([.fraction(0.5)])
+#if targetEnvironment(macCatalyst)
+                        .frame(minWidth: 300, minHeight: 270)
+#else
+                        .frame(minWidth: 320, minHeight: 390)
+#endif
                 }
         } else {
             button
                 .sheet(isPresented: $isShowingSettings, detents: [.medium]) {
-                    SettingsView()
-                        .environmentObject(model)
+                    settingsView
                 }
         }
     }


### PR DESCRIPTION
@des12437 I played around with things for a bit and this seems to work on iPhone (portrait and landscape), iPad, and macOS. Please take a look and tell me what you think. Note that the `popover` modifier is adaptive, meaning that it will use a sheet in compact width environments.