### PR TITLE
[Fix] Update README.md to correct image path typo

### DIFF
--- a/Shared/Samples/Monitor changes to map load status/README.md
+++ b/Shared/Samples/Monitor changes to map load status/README.md
@@ -2,7 +2,7 @@
 
 Determine the map's load status which can be: `notLoaded`, `failed`, `loading`, or `loaded`.
 
-![Image of monitor changes to map load status](monitor-changes-to-map-toad-status.png)
+![Image of monitor changes to map load status](monitor-changes-to-map-load-status.png)
 
 ## Use case
 


### PR DESCRIPTION
## Description

I was browsing the site earlier today and noticed the image at this path was not displaying:
https://developers.arcgis.com/swift/sample-code/monitor-changes-to-map-load-status/

A simple correction to the image's referenced filename appears to do the trick.

## Linked Issue(s)

n/a

## Screenshots

|Before|After|
|:-:|:-:|
| ![image](https://github.com/Esri/arcgis-maps-sdk-swift-samples/assets/25207711/52745d9c-69fd-43b2-acf2-af8660b4c576) | ![image](https://github.com/Esri/arcgis-maps-sdk-swift-samples/assets/25207711/7c366b43-9371-4b40-af47-0186f7446291) |