### PR TITLE
[Fix] Monitor changes to map load status README image path typo

### DIFF
--- a/Shared/Samples/Monitor changes to map load status/README.md
+++ b/Shared/Samples/Monitor changes to map load status/README.md
@@ -2,7 +2,7 @@
 
 Determine the map's load status which can be: `notLoaded`, `failed`, `loading`, or `loaded`.
 
-![Image of monitor changes to map load status](monitor-changes-to-map-toad-status.png)
+![Image of monitor changes to map load status](monitor-changes-to-map-load-status.png)
 
 ## Use case
 


### PR DESCRIPTION
## Description

This PR implements a fix to the `Monitor changes to map load status` [README](https://github.com/Esri/arcgis-maps-sdk-swift-samples/tree/v.next/Shared/Samples/Monitor%20changes%20to%20map%20load%20status) since the image was not loading correctly due to a typo the image path. `main` is also being updated by #270.

## How To Test

- Ensure the image loads correcting on the [README](https://github.com/Esri/arcgis-maps-sdk-swift-samples/tree/Caleb/Fix-MonitorMapLoadStatusReadME/Shared/Samples/Monitor%20changes%20to%20map%20load%20status) and that every thing else remains unchanged.

## Screenshots

|Before|After|
|:-:|:-:|
|![Screenshot 2023-09-21 at 10 10 43 AM](https://github.com/Esri/arcgis-maps-sdk-swift-samples/assets/34120440/9828a471-df87-4f5a-b817-051e7dd0f6b0)|![Screenshot 2023-09-21 at 10 10 38 AM](https://github.com/Esri/arcgis-maps-sdk-swift-samples/assets/34120440/34bf9c22-e426-4255-8aec-ad9c48235325)|





