### PR TITLE
Ensure new line for sub-lists

### DIFF
--- a/Shared/Samples/Add feature layers/README.md
+++ b/Shared/Samples/Add feature layers/README.md
@@ -17,24 +17,24 @@ Tap the button on the toolbar to add feature layers, from different sources, to 
 ## How it works
 
 1. Create a `Map` instance with a topographic basemap style.
-2. Load a feature layer with a feature table.
-    i. Create a `ServiceFeatureTable` instance from a URL.
-    ii. Create a `FeatureLayer` instance with the feature table.
-3. Load a feature layer with a portal item.
-    i. Create a `FeatureLayer` instance with a portal item.
-4. Load a feature layer with a geodatabase.
-    i. Instantiate and load a `Geodatabase` using the file name.
-    ii. Get the feature table from the geodatabase with the feature table's name by using the `getGeodatabaseFeatureTable(tableName:)` geodatabase method.
-    iii. Create a `FeatureLayer` instance from the feature table.
-5. Load a feature layer with a GeoPackage.
-    i. Instantiate and load a GeoPackage using its file name.
-    ii. Get the first `GeoPackageFeatureTable` from the `geoPackageFeatureTables` array.
-    iii. Create a `FeatureLayer` instance from the feature table.
-6. Load a feature layer with a shapefile.
-    i. Create a `ShapefileFeatureTable` instance using the shapefile name.
-    ii. Create a `FeatureLayer` instance from the feature table.
-7. Add the feature layer to the map's operational layers.
-8. Create a `MapView` instance with the map.
+2. Load a feature layer with a feature table.  
+    i. Create a `ServiceFeatureTable` instance from a URL.  
+    ii. Create a `FeatureLayer` instance with the feature table.  
+3. Load a feature layer with a portal item.  
+    i. Create a `FeatureLayer` instance with a portal item.  
+4. Load a feature layer with a geodatabase.  
+    i. Instantiate and load a `Geodatabase` using the file name.  
+    ii. Get the feature table from the geodatabase with the feature table's name by using the `getGeodatabaseFeatureTable(tableName:)` geodatabase method.  
+    iii. Create a `FeatureLayer` instance from the feature table.  
+5. Load a feature layer with a GeoPackage.  
+    i. Instantiate and load a GeoPackage using its file name.  
+    ii. Get the first `GeoPackageFeatureTable` from the `geoPackageFeatureTables` array.  
+    iii. Create a `FeatureLayer` instance from the feature table.  
+6. Load a feature layer with a shapefile.  
+    i. Create a `ShapefileFeatureTable` instance using the shapefile name.  
+    ii. Create a `FeatureLayer` instance from the feature table.  
+7. Add the feature layer to the map's operational layers.  
+8. Create a `MapView` instance with the map.  
 
 ## Relevant API
 


### PR DESCRIPTION
## Description

This PR adds trailing spaces within each step in the **How it works** section of the `Add feature layers` sample README to ensure sub-list items exist on new lines.

For example, compare:
- **Swift** - https://developers.arcgis.com/swift/sample-code/add-feature-layers/#how-it-works
- **Kotlin** - https://developers.arcgis.com/kotlin/sample-code/add-feature-layers/#how-it-works

## Linked Issue(s)

n/a - quick fix

## Screenshots

|Before|After|
|:-:|:-:|
| ![image](https://github.com/Esri/arcgis-maps-sdk-swift-samples/assets/25207711/72bcedf6-0c02-46ab-aa81-92b27f5ef22c) | ![image](https://github.com/Esri/arcgis-maps-sdk-swift-samples/assets/25207711/b427bda2-f60d-414d-b32c-c06279d3c9eb) |