### PR TITLE
[Fix] Add missing source code files to Build Phases

### DIFF
--- a/Samples.xcodeproj/project.pbxproj
+++ b/Samples.xcodeproj/project.pbxproj
@@ -193,6 +193,8 @@
 		D7ABA2FA2A32760D0021822B /* MeasureDistanceInSceneView.swift in Copy Source Code Files */ = {isa = PBXBuildFile; fileRef = D7ABA2F82A32579C0021822B /* MeasureDistanceInSceneView.swift */; };
 		D7ABA2FF2A32881C0021822B /* ShowViewshedFromGeoelementInSceneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7ABA2FE2A32881C0021822B /* ShowViewshedFromGeoelementInSceneView.swift */; };
 		D7ABA3002A3288970021822B /* ShowViewshedFromGeoelementInSceneView.swift in Copy Source Code Files */ = {isa = PBXBuildFile; fileRef = D7ABA2FE2A32881C0021822B /* ShowViewshedFromGeoelementInSceneView.swift */; };
+		D7AE86202AC3A1050049B626 /* AddCustomDynamicEntityDataSourceView.Vessel.swift in Copy Source Code Files */ = {isa = PBXBuildFile; fileRef = 7900C5F52A83FC3F002D430F /* AddCustomDynamicEntityDataSourceView.Vessel.swift */; };
+		D7AE86212AC3A10A0049B626 /* GroupLayersTogetherView.GroupLayerListView.swift in Copy Source Code Files */ = {isa = PBXBuildFile; fileRef = D75C35662AB50338003CD55F /* GroupLayersTogetherView.GroupLayerListView.swift */; };
 		D7CC33FF2A31475C00198EDF /* ShowLineOfSightBetweenPointsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7CC33FD2A31475C00198EDF /* ShowLineOfSightBetweenPointsView.swift */; };
 		D7CC34002A3147FF00198EDF /* ShowLineOfSightBetweenPointsView.swift in Copy Source Code Files */ = {isa = PBXBuildFile; fileRef = D7CC33FD2A31475C00198EDF /* ShowLineOfSightBetweenPointsView.swift */; };
 		D7E440D72A1ECE7D005D74DE /* CreateBuffersAroundPointsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7E440D62A1ECE7D005D74DE /* CreateBuffersAroundPointsView.swift */; };
@@ -296,6 +298,8 @@
 			dstPath = "";
 			dstSubfolderSpec = 7;
 			files = (
+				D7AE86212AC3A10A0049B626 /* GroupLayersTogetherView.GroupLayerListView.swift in Copy Source Code Files */,
+				D7AE86202AC3A1050049B626 /* AddCustomDynamicEntityDataSourceView.Vessel.swift in Copy Source Code Files */,
 				D7ECF5992AB8BF5A003FB2BE /* RenderMultilayerSymbolsView.swift in Copy Source Code Files */,
 				D7337C612ABD166A00A5D865 /* ShowMobileMapPackageExpirationDateView.swift in Copy Source Code Files */,
 				D704AA5B2AB22D8400A3BB63 /* GroupLayersTogetherView.swift in Copy Source Code Files */,


### PR DESCRIPTION
## Description

This PR implements a fix to the `Group layers together` and `Add custom dynamic entity data source` samples by adding their source code files that were missing from the `Build Phases` -> `Copy Source Code Files`.

## Linked Issue(s)

-  N\A, quick fix

## How To Test

- Verify the code additional code files come up by going to info button -> "Code" -> filename for each sample.

## Screenshots

|Before|After|
|:-:|:-:|
|![Group layers together - before](https://github.com/Esri/arcgis-maps-sdk-swift-samples/assets/34120440/390f5d53-02d7-4b04-acf9-174f3c1208db)|![Group layers together - after](https://github.com/Esri/arcgis-maps-sdk-swift-samples/assets/34120440/31606633-06a9-4631-8263-a21b34d3e623)|


|Before|After|
|:-:|:-:|
|![Add custom dynamic entity data source - before](https://github.com/Esri/arcgis-maps-sdk-swift-samples/assets/34120440/6cbc9b5f-ff7b-49b2-8c0f-ba9899e856c2)|![Add custom dynamic entity data source - after](https://github.com/Esri/arcgis-maps-sdk-swift-samples/assets/34120440/d1ef18f8-81c5-4541-a238-4dec39e0a5ac)|


