### PR TITLE
[Fix] Sample Viewer navigation bug

### DIFF
--- a/Shared/Supporting Files/Views/ContentView.swift
+++ b/Shared/Supporting Files/Views/ContentView.swift
@@ -28,7 +28,9 @@ struct ContentView: View {
                     sidebar
                 }
             } detail: {
-                detail
+                NavigationStack {
+                    detail
+                }
             }
         } else {
             NavigationView {


### PR DESCRIPTION
## Description

This PR implements a fix to bugs that would come from nested `NavigationLink`s (e.g. using one in the top view of a sample) on iOS 16+ on both iPad and iPhone.

## Linked Issue(s)

- `swift/issues/NA` (quick fix)

## How To Test

- Ensure the navigating through the Sample Viewer is same. 