### PR TITLE
[Fix] Handle cancellation error in Identify raster

### DIFF
--- a/Shared/Samples/Identify raster cell/IdentifyRasterCellView.swift
+++ b/Shared/Samples/Identify raster cell/IdentifyRasterCellView.swift
@@ -113,6 +113,9 @@ private extension IdentifyRasterCellView {
                 // Get the first raster cell from the identify result.
                 let rasterCell = identifyResult.geoElements.first(where: { $0 is RasterCell })
                 return rasterCell as? RasterCell
+            } catch is CancellationError {
+                // Does nothing if the error is a cancellation error.
+                return nil
             } catch {
                 self.error = error
                 return nil


### PR DESCRIPTION
## Description

This PR fixes `Identify raster` in `Layer` category.

The cancellation error thrown by the identify operation is ignored so the error alert doesn't constantly pop up.

## Linked Issue(s)

- `swift/issues/4793`

## How To Test

Long tap and drag on the map. With the fixes there shouldn't be a cancellation error alert.
