### PR TITLE
[Fix] Fix non-adaptive colors in samples

### DIFF
--- a/Shared/Samples/Animate 3D graphic/Animate3DGraphicView.swift
+++ b/Shared/Samples/Animate 3D graphic/Animate3DGraphicView.swift
@@ -42,7 +42,7 @@ struct Animate3DGraphicView: View {
                         StatRow("Roll", value: model.animation.currentFrame.roll.formatted(.angle))
                     }
                     .frame(width: 170, height: 100)
-                    .background(Color.white.opacity(0.5))
+                    .background(.ultraThinMaterial)
                     .cornerRadius(10)
                     .shadow(radius: 3)
                 }

--- a/Shared/Samples/Display dimensions/DisplayDimensionsView.swift
+++ b/Shared/Samples/Display dimensions/DisplayDimensionsView.swift
@@ -53,7 +53,7 @@ struct DisplayDimensionsView: View {
                         ))
                     }
                     .padding(8)
-                    .background(Color.white)
+                    .background(.ultraThinMaterial)
                     .cornerRadius(10)
                     .disabled(dimensionLayer == nil)
                 }

--- a/Shared/Samples/Identify KML features/IdentifyKMLFeaturesView.swift
+++ b/Shared/Samples/Identify KML features/IdentifyKMLFeaturesView.swift
@@ -127,7 +127,9 @@ private extension IdentifyKMLFeaturesView {
         )
         
         // Update the callout text.
-        calloutText = AttributedString(text)
+        var attributedText = AttributedString(text)
+        attributedText.foregroundColor = .label
+        calloutText = attributedText
     }
 }
 

--- a/Shared/Samples/Show mobile map package expiration date/ShowMobileMapPackageExpirationDateView.swift
+++ b/Shared/Samples/Show mobile map package expiration date/ShowMobileMapPackageExpirationDateView.swift
@@ -54,7 +54,7 @@ struct ShowMobileMapPackageExpirationDateView: View {
                 }
                 .multilineTextAlignment(.center)
                 .padding()
-                .background(.white)
+                .background(.thinMaterial)
             }
         }
         .alert(isPresented: $isShowingErrorAlert, presentingError: error)


### PR DESCRIPTION
## Description

This PR makes a few colors dark mode adaptive.

## Linked Issue(s)

- `swift/issues/4792`

## How To Test

Go to the 4 changed samples and cmd + shift + A to switch between light and dark mode.
