### PR TITLE
[Fix] Custom sheet auto dismiss

### DIFF
--- a/Shared/Supporting Files/Extensions/View+Sheet.swift
+++ b/Shared/Supporting Files/Extensions/View+Sheet.swift
@@ -26,6 +26,9 @@ extension View {
     ///   - idealHeight: The ideal height of the popover.
     ///   - onDismiss: A closure to execute when dismissing the sheet.
     ///   - content: A closure returning the content of the sheet.
+    ///
+    /// > Note: This modifier may not work with other UIKit derived views, such as an `Alert`.
+    ///  Using them both in the same view may cause undefined behavior.
     func sheet<Content>(
         isPresented: Binding<Bool>,
         detents: [Detent],

--- a/Shared/Supporting Files/Extensions/View+Sheet.swift
+++ b/Shared/Supporting Files/Extensions/View+Sheet.swift
@@ -26,9 +26,8 @@ extension View {
     ///   - idealHeight: The ideal height of the popover.
     ///   - onDismiss: A closure to execute when dismissing the sheet.
     ///   - content: A closure returning the content of the sheet.
-    ///
-    /// > Note: This modifier may not work with other UIKit derived views, such as an `Alert`.
-    ///  Using them both in the same view may cause undefined behavior.
+    /// - Note: This modifier can have conflict with modal presentation views, such as an alert.
+    /// When the sheet is presented, it may cause the "already presenting" problem.
     func sheet<Content>(
         isPresented: Binding<Bool>,
         detents: [Detent],

--- a/Shared/Supporting Files/Extensions/View+Sheet.swift
+++ b/Shared/Supporting Files/Extensions/View+Sheet.swift
@@ -179,7 +179,7 @@ private extension SheetModifier {
                 .task(id: isPresented) {
                     if isPresented {
                         // Sleep to prevent appearing when other content is disappearing.
-                        try? await Task.sleep(nanoseconds: 100)
+                        try? await Task.sleep(nanoseconds: 1000)
                         
                         if isSheetLayout {
                             isSheetVisible = true

--- a/Shared/Supporting Files/Extensions/View+Sheet.swift
+++ b/Shared/Supporting Files/Extensions/View+Sheet.swift
@@ -284,16 +284,16 @@ private struct Sheet<Content>: UIViewRepresentable where Content: View {
         guard let rootViewController = uiView.window?.rootViewController else { return }
         
         /// A Boolean value indicating whether the presented view controller is a hosting controller.
-        let isPresentedControllerHostingType = rootViewController.presentedViewController is UIHostingController<Content>
+        let presentedControllerIsHosting = rootViewController.presentedViewController is UIHostingController<Content>
         
         /// A Boolean value indicating whether the presented view controller is an alert controller.
-        let isPresentedControllerAlertType = rootViewController.presentedViewController is UIAlertController
+        let presentedControllerIsAlert = rootViewController.presentedViewController is UIAlertController
         
         /// A Boolean value indicating whether the sheet was already presenting.
-        let wasPresenting = rootViewController.presentedViewController != nil && isPresentedControllerHostingType
+        let wasPresenting = rootViewController.presentedViewController != nil && presentedControllerIsHosting
         
         /// A Boolean value indicating whether the hosting controller is being dismissed.
-        let isHostBeingDismissed = model.hostingController.isBeingDismissed
+        let hostingControllerIsBeingDismissed = model.hostingController.isBeingDismissed
         
         // Ensures that the device's layout is such that a sheet should be presented and
         // the hosting controller's sheet presentation controller exists.
@@ -301,7 +301,7 @@ private struct Sheet<Content>: UIViewRepresentable where Content: View {
               let sheet = model.hostingController.sheetPresentationController else {
             // Dismisses the sheet if it is being presented and a popover should
             // be presented instead.
-            if isPresentedControllerHostingType && !isHostBeingDismissed {
+            if presentedControllerIsHosting && !hostingControllerIsBeingDismissed {
                 rootViewController.dismiss(animated: false)
             }
             return
@@ -314,13 +314,13 @@ private struct Sheet<Content>: UIViewRepresentable where Content: View {
             configureSheetPresentationController(sheet)
             // Presents the hosting controller.
             rootViewController.present(model.hostingController, animated: !model.isTransitioningFromPopover)
-        } else if !isPresented && wasPresenting && !isHostBeingDismissed && !isPresentedControllerAlertType {
+        } else if !isPresented && wasPresenting && !hostingControllerIsBeingDismissed && !presentedControllerIsAlert {
             // Dismisses the view controller presented by the root view controller
             // if 'isPresented' is false, but was presenting before (popover), is
             // not currently being dismissed, and is not an alert.
-            rootViewController.dismiss(animated: isPresentedControllerHostingType)
-            model.isTransitioningFromPopover = !isPresentedControllerHostingType
-        } else if isHostBeingDismissed {
+            rootViewController.dismiss(animated: presentedControllerIsHosting)
+            model.isTransitioningFromPopover = !presentedControllerIsHosting
+        } else if hostingControllerIsBeingDismissed {
             // Sets 'isPresented' to false when the hosting controller is being dismissed.
             Task {
                 isPresented = false


### PR DESCRIPTION
## Description

This PR implements fixes to the following bugs that would occur when using the custom sheet modifier in the sample viewer:
1. If there was more than one custom sheet within a given view, some of the sheets would auto-dismiss upon opening, e.g. a sample containing settings sheet would cause the info sheet to auto-dismiss when opened.
2. Whenever a custom sheet was closed, `Modifying state during view update, this will cause undefined behavior.` would be thrown. 
3. Custom sheets dismissed using the `DismissAction` from the `Environment` wouldn't always re-present.

URL to custom sheet modifier file: [View+Sheet.swift](https://github.com/Esri/arcgis-maps-sdk-swift-samples/blob/Caleb/Fix-SheetExtensionAutoDismiss/Shared/Supporting%20Files/Extensions/View%2BSheet.swift)

## Linked Issue(s)

- `swift/issues/4778`

## How To Test

<details><summary>Test Code</summary>

```swift
struct DisplayMapView: View {
    /// A map with imagery basemap.
    @State private var map = Map(basemapStyle: .arcGISImagery)
    
    @State private var isShowingDoneSheet = false
    
    @State private var isShowingDragSheet = false
    
    @State private var isShowingDismissSheet = false
    
    var body: some View {
        // Creates a map view to display the map.
        MapView(map: map)
            .toolbar {
                ToolbarItemGroup(placement: .bottomBar) {
                    Button("Plain") {
                        isShowingDragSheet = true
                    }
                    .sheet(isPresented: $isShowingDragSheet, detents: [.medium, .large], dragIndicatorVisibility: .visible) {
                        print("Dismissed")
                    } content: {
                        Text("Some text.")
                    }
                    Spacer()
                    
                    Button("Done") {
                        isShowingDoneSheet = true
                    }
                    .sheet(isPresented: $isShowingDoneSheet, detents: [.medium]) {
                        print("Dismissed")
                    } content: {
                        NavigationView {
                            Text("Press Done.")
                                .toolbar {
                                    ToolbarItem(placement: .confirmationAction) {
                                        Button("Done") {
                                            isShowingDoneSheet = false
                                        }
                                    }
                                }
                        }
                    }
                    Spacer()
                    
                    Button("Dismiss") {
                        isShowingDismissSheet = true
                    }
                    .sheet(isPresented: $isShowingDismissSheet, detents: [.large]) {
                        print("Dismissed")
                    } content: {
                        DismissSheetView()
                    }
                }
            }
    }
}

private extension DisplayMapView {
    struct DismissSheetView: View {
        /// The action to dismiss the sheet.
        @Environment(\.dismiss) private var dismiss
        
        var body: some View {
            NavigationView {
                Text("Press dismiss")
                    .toolbar {
                        ToolbarItem(placement: .confirmationAction) {
                            Button("Dismiss") {
                                dismiss()
                            }
                        }
                    }
            }
        }
    }
}

```
</details>

- Copy the code above into the `Display map` sample.
- In the sample, verify the sheets open and close as expected using the buttons in the bottom toolbar.
- Verify that info sheet (top-right button) works as expected.
- Verify the rest of the samples using the custom sheet work as expected. 
