### PR TITLE
[Update] Replace EnvironmentObject with ObservedObject in samples

### DIFF
--- a/Shared/Samples/Add dynamic entity layer/AddDynamicEntityLayerView.SettingsView.swift
+++ b/Shared/Samples/Add dynamic entity layer/AddDynamicEntityLayerView.SettingsView.swift
@@ -18,7 +18,7 @@ import SwiftUI
 extension AddDynamicEntityLayerView {
     struct SettingsView: View {
         /// The view model for the sample.
-        @EnvironmentObject private var model: Model
+        @ObservedObject var model: Model
         
         /// The action to dismiss the settings sheet.
         @Environment(\.dismiss) private var dismiss: DismissAction

--- a/Shared/Samples/Add dynamic entity layer/AddDynamicEntityLayerView.swift
+++ b/Shared/Samples/Add dynamic entity layer/AddDynamicEntityLayerView.swift
@@ -93,8 +93,8 @@ struct AddDynamicEntityLayerView: View {
         let button = Button("Dynamic Entity Settings") {
             isShowingSettings = true
         }
-        let settingsView = SettingsView(calloutPlacement: $placement)
-            .environmentObject(model)
+        let settingsView = SettingsView(model: model, calloutPlacement: $placement)
+        
         if #available(iOS 16, *) {
             button
                 .popover(isPresented: $isShowingSettings, arrowEdge: .bottom) {

--- a/Shared/Samples/Change map view background/ChangeMapViewBackgroundView.SettingsView.swift
+++ b/Shared/Samples/Change map view background/ChangeMapViewBackgroundView.SettingsView.swift
@@ -17,7 +17,7 @@ import SwiftUI
 extension ChangeMapViewBackgroundView {
     struct SettingsView: View {
         /// The view model for the sample.
-        @EnvironmentObject private var model: ChangeMapViewBackgroundView.Model
+        @ObservedObject var model: Model
         
         var body: some View {
             List {

--- a/Shared/Samples/Change map view background/ChangeMapViewBackgroundView.swift
+++ b/Shared/Samples/Change map view background/ChangeMapViewBackgroundView.swift
@@ -33,8 +33,7 @@ struct ChangeMapViewBackgroundView: View {
                         isShowingSettings = true
                     }
                     .sheet(isPresented: $isShowingSettings, detents: [.medium], dragIndicatorVisibility: .visible) {
-                        SettingsView()
-                            .environmentObject(model)
+                        SettingsView(model: model)
                     }
                 }
             }

--- a/Shared/Samples/Download preplanned map area/DownloadPreplannedMapAreaView.MapPicker.swift
+++ b/Shared/Samples/Download preplanned map area/DownloadPreplannedMapAreaView.MapPicker.swift
@@ -21,7 +21,7 @@ extension DownloadPreplannedMapAreaView {
         @Environment(\.dismiss) private var dismiss
         
         /// The view model for the download preplanned map area view.
-        @EnvironmentObject private var model: Model
+        @ObservedObject var model: Model
         
         var body: some View {
             NavigationView {

--- a/Shared/Samples/Download preplanned map area/DownloadPreplannedMapAreaView.swift
+++ b/Shared/Samples/Download preplanned map area/DownloadPreplannedMapAreaView.swift
@@ -38,8 +38,7 @@ struct DownloadPreplannedMapAreaView: View {
                         isShowingSelectMapView.toggle()
                     }
                     .sheet(isPresented: $isShowingSelectMapView, detents: [.medium]) {
-                        MapPicker()
-                            .environmentObject(model)
+                        MapPicker(model: model)
                     }
                     
                     Spacer()

--- a/Shared/Samples/Find route around barriers/FindRouteAroundBarriersView.Views.swift
+++ b/Shared/Samples/Find route around barriers/FindRouteAroundBarriersView.Views.swift
@@ -19,7 +19,7 @@ extension FindRouteAroundBarriersView {
     /// The list of settings for the sample.
     struct SettingsList: View {
         /// The view model for the sample.
-        @EnvironmentObject private var model: Model
+        @ObservedObject var model: Model
         
         /// A Boolean value indicating whether routing will find the best sequence.
         @State private var routingFindsBestSequence = false

--- a/Shared/Samples/Find route around barriers/FindRouteAroundBarriersView.swift
+++ b/Shared/Samples/Find route around barriers/FindRouteAroundBarriersView.swift
@@ -119,8 +119,7 @@ struct FindRouteAroundBarriersView: View {
                         Spacer()
                         
                         SheetButton(title: "Settings") {
-                            SettingsList()
-                                .environmentObject(model)
+                            SettingsList(model: model)
                         } label: {
                             Image(systemName: "gear")
                         }

--- a/Shared/Samples/Geocode offline/GeocodeOfflineView.swift
+++ b/Shared/Samples/Geocode offline/GeocodeOfflineView.swift
@@ -44,8 +44,7 @@ struct GeocodeOfflineView: View {
     ]
     
     var body: some View {
-        GeocodeMapView(viewpoint: $viewpoint)
-            .environmentObject(model)
+        GeocodeMapView(model: model, viewpoint: $viewpoint)
             .searchable(text: $searchText, prompt: "Type in an address")
             .onSubmit(of: .search) {
                 submittedSearchText = searchText
@@ -90,7 +89,7 @@ private extension GeocodeOfflineView {
     /// The map view for the sample.
     struct GeocodeMapView: View {
         /// The view model for the sample.
-        @EnvironmentObject private var model: Model
+        @ObservedObject var model: Model
         
         /// The action that ends the current search interaction.
         @Environment(\.dismissSearch) private var dismissSearch

--- a/Shared/Samples/Show viewshed from point in scene/ShowViewshedFromPointInSceneView.ViewshedSettingsView.swift
+++ b/Shared/Samples/Show viewshed from point in scene/ShowViewshedFromPointInSceneView.ViewshedSettingsView.swift
@@ -17,7 +17,7 @@ import SwiftUI
 extension ShowViewshedFromPointInSceneView {
     struct ViewshedSettingsView: View {
         /// The view model for the sample.
-        @EnvironmentObject private var model: Model
+        @ObservedObject var model: Model
         
         var body: some View {
             List {

--- a/Shared/Samples/Show viewshed from point in scene/ShowViewshedFromPointInSceneView.swift
+++ b/Shared/Samples/Show viewshed from point in scene/ShowViewshedFromPointInSceneView.swift
@@ -43,8 +43,7 @@ struct ShowViewshedFromPointInSceneView: View {
                         isShowingSettings = true
                     }
                     .sheet(isPresented: $isShowingSettings, detents: [.medium], dragIndicatorVisibility: .visible) {
-                        ViewshedSettingsView()
-                            .environmentObject(model)
+                        ViewshedSettingsView(model: model)
                     }
                 }
             }

--- a/Shared/Samples/Trace utility network/TraceUtilityNetworkView.swift
+++ b/Shared/Samples/Trace utility network/TraceUtilityNetworkView.swift
@@ -17,7 +17,7 @@ import SwiftUI
 
 struct TraceUtilityNetworkView: View {
     /// The view model for the sample.
-    @StateObject var model = TraceUtilityNetworkView.Model()
+    @StateObject var model = Model()
     
     var body: some View {
         MapViewReader { mapViewProxy in


### PR DESCRIPTION
## Description

This PR replaces the use of the `EnvironmentObject` with `ObservedObject` in the samples since the ones that were using it just passed their view model down to a single child view.

## Linked Issue(s)

- #137 
- `swift/issues/4843`

## How To Test

- Ensure the affected samples work as expected.
