### PR TITLE
[Setup] Add previews to samples

### DIFF
--- a/Shared/Samples/Add WMS layer/AddWMSLayerView.swift
+++ b/Shared/Samples/Add WMS layer/AddWMSLayerView.swift
@@ -45,3 +45,7 @@ struct AddWMSLayerView: View {
         MapView(map: map)
     }
 }
+
+#Preview {
+    AddWMSLayerView()
+}

--- a/Shared/Samples/Add clustering feature reduction to a point feature layer/AddClusteringFeatureReductionToAPointFeatureLayerView.swift
+++ b/Shared/Samples/Add clustering feature reduction to a point feature layer/AddClusteringFeatureReductionToAPointFeatureLayerView.swift
@@ -73,3 +73,9 @@ struct AddClusteringFeatureReductionToAPointFeatureLayerView: View {
         }
     }
 }
+
+#Preview {
+    NavigationView {
+        AddClusteringFeatureReductionToAPointFeatureLayerView()
+    }
+}

--- a/Shared/Samples/Add dynamic entity layer/AddDynamicEntityLayerView.swift
+++ b/Shared/Samples/Add dynamic entity layer/AddDynamicEntityLayerView.swift
@@ -114,3 +114,9 @@ struct AddDynamicEntityLayerView: View {
         }
     }
 }
+
+#Preview {
+    NavigationView {
+        AddDynamicEntityLayerView()
+    }
+}

--- a/Shared/Samples/Add scene layer from service/AddSceneLayerFromServiceView.swift
+++ b/Shared/Samples/Add scene layer from service/AddSceneLayerFromServiceView.swift
@@ -52,3 +52,7 @@ private extension URL {
         URL(string: "https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer")!
     }
 }
+
+#Preview {
+    AddSceneLayerFromServiceView()
+}

--- a/Shared/Samples/Analyze network with subnetwork trace/AnalyzeNetworkWithSubnetworkTraceView.swift
+++ b/Shared/Samples/Analyze network with subnetwork trace/AnalyzeNetworkWithSubnetworkTraceView.swift
@@ -311,3 +311,9 @@ private extension UtilityNetworkAttributeComparison.Operator {
     static var allCases: [UtilityNetworkAttributeComparison.Operator] { [.equal, .notEqual, .greaterThan, .greaterThanEqual, .lessThan, .lessThanEqual, .includesTheValues, .doesNotIncludeTheValues, .includesAny, .doesNotIncludeAny]
     }
 }
+
+#Preview {
+    NavigationView {
+        AnalyzeNetworkWithSubnetworkTraceView()
+    }
+}

--- a/Shared/Samples/Apply unique value renderer/ApplyUniqueValueRendererView.swift
+++ b/Shared/Samples/Apply unique value renderer/ApplyUniqueValueRendererView.swift
@@ -78,3 +78,7 @@ struct ApplyUniqueValueRendererView: View {
         MapView(map: map)
     }
 }
+
+#Preview {
+    ApplyUniqueValueRendererView()
+}

--- a/Shared/Samples/Augment reality to fly over scene/AugmentRealityToFlyOverSceneView.swift
+++ b/Shared/Samples/Augment reality to fly over scene/AugmentRealityToFlyOverSceneView.swift
@@ -58,3 +58,7 @@ private extension URL {
         .init(string: "https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer")!
     }
 }
+
+#Preview {
+    AugmentRealityToFlyOverSceneView()
+}

--- a/Shared/Samples/Browse building floors/BrowseBuildingFloorsView.swift
+++ b/Shared/Samples/Browse building floors/BrowseBuildingFloorsView.swift
@@ -75,3 +75,7 @@ private extension PortalItem.ID {
     /// A portal item of Building L's floors on the Esri Redlands campus.
     static var esriBuildingL: Self { Self("f133a698536f44c8884ad81f80b6cfc7")! }
 }
+
+#Preview {
+    BrowseBuildingFloorsView()
+}

--- a/Shared/Samples/Change map view background/ChangeMapViewBackgroundView.swift
+++ b/Shared/Samples/Change map view background/ChangeMapViewBackgroundView.swift
@@ -40,3 +40,9 @@ struct ChangeMapViewBackgroundView: View {
             }
     }
 }
+
+#Preview {
+    NavigationView {
+        ChangeMapViewBackgroundView()
+    }
+}

--- a/Shared/Samples/Change viewpoint/ChangeViewpointView.swift
+++ b/Shared/Samples/Change viewpoint/ChangeViewpointView.swift
@@ -128,3 +128,7 @@ extension ChangeViewpointView {
         }
     }
 }
+
+#Preview {
+    ChangeViewpointView()
+}

--- a/Shared/Samples/Clip geometry/ClipGeometryView.swift
+++ b/Shared/Samples/Clip geometry/ClipGeometryView.swift
@@ -174,3 +174,9 @@ private extension Envelope {
         return builder.toGeometry()
     }
 }
+
+#Preview {
+    NavigationView {
+        ClipGeometryView()
+    }
+}

--- a/Shared/Samples/Create and edit geometries/CreateAndEditGeometriesView.swift
+++ b/Shared/Samples/Create and edit geometries/CreateAndEditGeometriesView.swift
@@ -363,3 +363,9 @@ class GeometryEditorMenuModel: ObservableObject {
         isStarted = true
     }
 }
+
+#Preview {
+    NavigationView {
+        CreateAndEditGeometriesView()
+    }
+}

--- a/Shared/Samples/Create and save KML file/CreateAndSaveKMLView.swift
+++ b/Shared/Samples/Create and save KML file/CreateAndSaveKMLView.swift
@@ -135,3 +135,9 @@ private extension UTType {
     /// A type that represents a KMZ file.
     static let kmz = UTType(filenameExtension: "kmz")!
 }
+
+#Preview {
+    NavigationView {
+        CreateAndSaveKMLView()
+    }
+}

--- a/Shared/Samples/Create buffers around points/CreateBuffersAroundPointsView.swift
+++ b/Shared/Samples/Create buffers around points/CreateBuffersAroundPointsView.swift
@@ -287,3 +287,9 @@ private extension CreateBuffersAroundPointsView {
         }
     }
 }
+
+#Preview {
+    NavigationView {
+        CreateBuffersAroundPointsView()
+    }
+}

--- a/Shared/Samples/Create convex hull around geometries/CreateConvexHullAroundGeometriesView.swift
+++ b/Shared/Samples/Create convex hull around geometries/CreateConvexHullAroundGeometriesView.swift
@@ -141,3 +141,9 @@ private extension Geometry {
         spatialReference: .webMercator
     )
 }
+
+#Preview {
+    NavigationView {
+        CreateConvexHullAroundGeometriesView()
+    }
+}

--- a/Shared/Samples/Create convex hull around points/CreateConvexHullAroundPointsView.swift
+++ b/Shared/Samples/Create convex hull around points/CreateConvexHullAroundPointsView.swift
@@ -128,3 +128,9 @@ private extension CreateConvexHullAroundPointsView {
         }
     }
 }
+
+#Preview {
+    NavigationView {
+        CreateConvexHullAroundPointsView()
+    }
+}

--- a/Shared/Samples/Create load report/CreateLoadReportView.swift
+++ b/Shared/Samples/Create load report/CreateLoadReportView.swift
@@ -53,3 +53,9 @@ struct CreateLoadReportView: View {
             }
     }
 }
+
+#Preview {
+    NavigationView {
+        CreateLoadReportView()
+    }
+}

--- a/Shared/Samples/Create mobile geodatabase/CreateMobileGeodatabaseView.swift
+++ b/Shared/Samples/Create mobile geodatabase/CreateMobileGeodatabaseView.swift
@@ -171,3 +171,9 @@ private extension FormatStyle where Self == Date.VerbatimFormatStyle {
         )
     }
 }
+
+#Preview {
+    NavigationView {
+        CreateMobileGeodatabaseView()
+    }
+}

--- a/Shared/Samples/Create planar and geodetic buffers/CreatePlanarAndGeodeticBuffersView.swift
+++ b/Shared/Samples/Create planar and geodetic buffers/CreatePlanarAndGeodeticBuffersView.swift
@@ -179,3 +179,7 @@ private extension Measurement where UnitType == UnitLength {
     /// The maximum radius.
     static var rMax: Self { Measurement(value: 2_000, unit: UnitLength.miles) }
 }
+
+#Preview {
+    CreatePlanarAndGeodeticBuffersView()
+}

--- a/Shared/Samples/Create symbol styles from web styles/CreateSymbolStylesFromWebStylesView.swift
+++ b/Shared/Samples/Create symbol styles from web styles/CreateSymbolStylesFromWebStylesView.swift
@@ -276,3 +276,9 @@ private extension URL {
         URL(string: "http://services.arcgis.com/V6ZHFr6zdgNZuVG0/arcgis/rest/services/LA_County_Points_of_Interest/FeatureServer/0")!
     }
 }
+
+#Preview {
+    NavigationView {
+        CreateSymbolStylesFromWebStylesView()
+    }
+}

--- a/Shared/Samples/Cut geometry/CutGeometryView.swift
+++ b/Shared/Samples/Cut geometry/CutGeometryView.swift
@@ -152,3 +152,9 @@ private extension Geometry {
         )
     }
 }
+
+#Preview {
+    NavigationView {
+        CutGeometryView()
+    }
+}

--- a/Shared/Samples/Densify and generalize geometry/DensifyAndGeneralizeGeometryView.swift
+++ b/Shared/Samples/Densify and generalize geometry/DensifyAndGeneralizeGeometryView.swift
@@ -180,3 +180,9 @@ extension DensifyAndGeneralizeGeometryView {
         }
     }
 }
+
+#Preview {
+    NavigationView {
+        DensifyAndGeneralizeGeometryView()
+    }
+}

--- a/Shared/Samples/Display annotation/DisplayAnnotationView.swift
+++ b/Shared/Samples/Display annotation/DisplayAnnotationView.swift
@@ -62,3 +62,7 @@ private extension URL {
         URL(string: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/RiversAnnotation/FeatureServer/0")!
     }
 }
+
+#Preview {
+    DisplayAnnotationView()
+}

--- a/Shared/Samples/Display content of utility network container/DisplayContentOfUtilityNetworkContainerView.swift
+++ b/Shared/Samples/Display content of utility network container/DisplayContentOfUtilityNetworkContainerView.swift
@@ -163,3 +163,9 @@ struct DisplayContentOfUtilityNetworkContainerView: View {
         .frame(idealWidth: 320, idealHeight: 428)
     }
 }
+
+#Preview {
+    NavigationView {
+        DisplayContentOfUtilityNetworkContainerView()
+    }
+}

--- a/Shared/Samples/Display map from portal item/DisplayMapFromPortalItemView.swift
+++ b/Shared/Samples/Display map from portal item/DisplayMapFromPortalItemView.swift
@@ -107,3 +107,9 @@ private extension PortalItem.ID {
     /// The portal item ID of the Geology of United States map.
     static var usGeology: Self { Self("92ad152b9da94dee89b9e387dfe21acd")! }
 }
+
+#Preview {
+    NavigationView {
+        DisplayMapFromPortalItemView()
+    }
+}

--- a/Shared/Samples/Display map/DisplayMapView.swift
+++ b/Shared/Samples/Display map/DisplayMapView.swift
@@ -24,3 +24,7 @@ struct DisplayMapView: View {
         MapView(map: map)
     }
 }
+
+#Preview {
+    DisplayMapView()
+}

--- a/Shared/Samples/Display overview map/DisplayOverviewMapView.swift
+++ b/Shared/Samples/Display overview map/DisplayOverviewMapView.swift
@@ -57,3 +57,7 @@ struct DisplayOverviewMapView: View {
 private extension PortalItem.ID {
     static var northAmericaTouristAttractions: Self { Self("97ceed5cfc984b4399e23888f6252856")! }
 }
+
+#Preview {
+    DisplayOverviewMapView()
+}

--- a/Shared/Samples/Display points using clustering feature reduction/DisplayPointsUsingClusteringFeatureReductionView.swift
+++ b/Shared/Samples/Display points using clustering feature reduction/DisplayPointsUsingClusteringFeatureReductionView.swift
@@ -95,3 +95,9 @@ struct DisplayPointsUsingClusteringFeatureReductionView: View {
         }
     }
 }
+
+#Preview {
+    NavigationView {
+        DisplayPointsUsingClusteringFeatureReductionView()
+    }
+}

--- a/Shared/Samples/Display scene/DisplaySceneView.swift
+++ b/Shared/Samples/Display scene/DisplaySceneView.swift
@@ -56,3 +56,7 @@ struct DisplaySceneView: View {
         SceneView(scene: scene)
     }
 }
+
+#Preview {
+    DisplaySceneView()
+}

--- a/Shared/Samples/Display web scene from portal item/DisplayWebSceneFromPortalItemView.swift
+++ b/Shared/Samples/Display web scene from portal item/DisplayWebSceneFromPortalItemView.swift
@@ -40,3 +40,7 @@ private extension PortalItem.ID {
         .init("c6f90b19164c4283884361005faea852")!
     }
 }
+
+#Preview {
+    DisplayWebSceneFromPortalItemView()
+}

--- a/Shared/Samples/Download preplanned map area/DownloadPreplannedMapAreaView.swift
+++ b/Shared/Samples/Download preplanned map area/DownloadPreplannedMapAreaView.swift
@@ -84,3 +84,9 @@ private extension Viewpoint {
         return Viewpoint(boundingGeometry: zoomEnvelope)
     }
 }
+
+#Preview {
+    NavigationView {
+        DownloadPreplannedMapAreaView()
+    }
+}

--- a/Shared/Samples/Download vector tiles to local cache/DownloadVectorTilesToLocalCacheView.swift
+++ b/Shared/Samples/Download vector tiles to local cache/DownloadVectorTilesToLocalCacheView.swift
@@ -290,24 +290,17 @@ private extension DownloadVectorTilesToLocalCacheView {
     }
 }
 
-private extension MapViewProxy {
-    /// Creates an envelope from the given rectangle.
-    /// - Parameter viewRect: The rectangle to create an envelope of.
-    /// - Returns: An envelope of the given rectangle.
-    func envelope(fromViewRect viewRect: CGRect) -> Envelope? {
-        guard let min = location(fromScreenPoint: CGPoint(x: viewRect.minX, y: viewRect.minY)),
-              let max = location(fromScreenPoint: CGPoint(x: viewRect.maxX, y: viewRect.maxY)) else {
-            return nil
-        }
-        return Envelope(min: min, max: max)
-    }
-}
-
 private extension Envelope {
     /// Expands the envelope by a given factor.
     func expanded(by factor: Double) -> Envelope {
         let builder = EnvelopeBuilder(envelope: self)
         builder.expand(by: factor)
         return builder.toGeometry()
+    }
+}
+
+#Preview {
+    NavigationView {
+        DownloadVectorTilesToLocalCacheView()
     }
 }

--- a/Shared/Samples/Filter features in scene/FilterFeaturesInSceneView.swift
+++ b/Shared/Samples/Filter features in scene/FilterFeaturesInSceneView.swift
@@ -234,3 +234,9 @@ private extension Viewpoint {
         )
     )
 }
+
+#Preview {
+    NavigationView {
+        FilterFeaturesInSceneView()
+    }
+}

--- a/Shared/Samples/Find address with reverse geocode/FindAddressWithReverseGeocodeView.swift
+++ b/Shared/Samples/Find address with reverse geocode/FindAddressWithReverseGeocodeView.swift
@@ -155,3 +155,7 @@ private extension URL {
         URL(string: "https://geocode-api.arcgis.com/arcgis/rest/services/World/GeocodeServer")!
     }
 }
+
+#Preview {
+    FindAddressWithReverseGeocodeView()
+}

--- a/Shared/Samples/Find closest facility from point/FindClosestFacilityFromPointView.swift
+++ b/Shared/Samples/Find closest facility from point/FindClosestFacilityFromPointView.swift
@@ -228,3 +228,9 @@ private extension URL {
         URL(string: "https://static.arcgis.com/images/Symbols/SafetyHealth/esriCrimeMarker_56_Gradient.png")!
     }
 }
+
+#Preview {
+    NavigationView {
+        FindClosestFacilityFromPointView()
+    }
+}

--- a/Shared/Samples/Find closest facility to multiple points/FindClosestFacilityToMultiplePointsView.swift
+++ b/Shared/Samples/Find closest facility to multiple points/FindClosestFacilityToMultiplePointsView.swift
@@ -183,3 +183,7 @@ private extension URL {
         URL(string: "https://static.arcgis.com/images/Symbols/SafetyHealth/Hospital.png")!
     }
 }
+
+#Preview {
+    FindClosestFacilityToMultiplePointsView()
+}

--- a/Shared/Samples/Find nearest vertex/FindNearestVertexView.swift
+++ b/Shared/Samples/Find nearest vertex/FindNearestVertexView.swift
@@ -188,3 +188,7 @@ private extension PortalItem.ID {
     /// The ID used in the "US States Generalized" portal item.
     static var usStatesGeneralized: Self { Self("8c2d6d7df8fa4142b0a1211c8dd66903")! }
 }
+
+#Preview {
+    FindNearestVertexView()
+}

--- a/Shared/Samples/Find route around barriers/FindRouteAroundBarriersView.swift
+++ b/Shared/Samples/Find route around barriers/FindRouteAroundBarriersView.swift
@@ -150,3 +150,9 @@ struct FindRouteAroundBarriersView: View {
         .errorAlert(presentingError: $error)
     }
 }
+
+#Preview {
+    NavigationView {
+        FindRouteAroundBarriersView()
+    }
+}

--- a/Shared/Samples/Find route/FindRouteView.swift
+++ b/Shared/Samples/Find route/FindRouteView.swift
@@ -215,3 +215,9 @@ private extension URL {
         URL(string: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/NetworkAnalysis/SanDiego/NAServer/Route")!
     }
 }
+
+#Preview {
+    NavigationView {
+        FindRouteView()
+    }
+}

--- a/Shared/Samples/Generate offline map/GenerateOfflineMapView.swift
+++ b/Shared/Samples/Generate offline map/GenerateOfflineMapView.swift
@@ -242,24 +242,17 @@ private extension GenerateOfflineMapView {
     }
 }
 
-private extension MapViewProxy {
-    /// Creates an envelope from the given rectangle.
-    /// - Parameter viewRect: The rectangle to create an envelope of.
-    /// - Returns: An envelope of the given rectangle.
-    func envelope(fromViewRect viewRect: CGRect) -> Envelope? {
-        guard let min = location(fromScreenPoint: CGPoint(x: viewRect.minX, y: viewRect.minY)),
-              let max = location(fromScreenPoint: CGPoint(x: viewRect.maxX, y: viewRect.maxY)) else {
-            return nil
-        }
-        return Envelope(min: min, max: max)
-    }
-}
-
 private extension Envelope {
     /// Expands the envelope by a given factor.
     func expanded(by factor: Double) -> Envelope {
         let builder = EnvelopeBuilder(envelope: self)
         builder.expand(by: factor)
         return builder.toGeometry()
+    }
+}
+
+#Preview {
+    NavigationView {
+        GenerateOfflineMapView()
     }
 }

--- a/Shared/Samples/Get elevation at point on surface/GetElevationAtPointOnSurfaceView.swift
+++ b/Shared/Samples/Get elevation at point on surface/GetElevationAtPointOnSurfaceView.swift
@@ -129,3 +129,7 @@ private extension ElevationSource {
         .init(url: URL(string: "https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer")!)
     }
 }
+
+#Preview {
+    GetElevationAtPointOnSurfaceView()
+}

--- a/Shared/Samples/Group layers together/GroupLayersTogetherView.swift
+++ b/Shared/Samples/Group layers together/GroupLayersTogetherView.swift
@@ -185,3 +185,9 @@ private extension URL {
         URL(string: "https://tiles.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/DevB_BuildingShells/SceneServer")!
     }
 }
+
+#Preview {
+    NavigationView {
+        GroupLayersTogetherView()
+    }
+}

--- a/Shared/Samples/Identify KML features/IdentifyKMLFeaturesView.swift
+++ b/Shared/Samples/Identify KML features/IdentifyKMLFeaturesView.swift
@@ -134,3 +134,7 @@ private extension URL {
         URL(string: "https://www.wpc.ncep.noaa.gov/kml/noaa_chart/WPC_Day1_SigWx_latest.kml")!
     }
 }
+
+#Preview {
+    IdentifyKMLFeaturesView()
+}

--- a/Shared/Samples/Identify graphics/IdentifyGraphicsView.swift
+++ b/Shared/Samples/Identify graphics/IdentifyGraphicsView.swift
@@ -103,3 +103,7 @@ private extension Collection {
         !self.isEmpty
     }
 }
+
+#Preview {
+    IdentifyGraphicsView()
+}

--- a/Shared/Samples/Identify layer features/IdentifyLayerFeaturesView.swift
+++ b/Shared/Samples/Identify layer features/IdentifyLayerFeaturesView.swift
@@ -134,3 +134,7 @@ private extension URL {
         URL(string: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0")!
     }
 }
+
+#Preview {
+    IdentifyLayerFeaturesView()
+}

--- a/Shared/Samples/Manage operational layers/ManageOperationalLayersView.swift
+++ b/Shared/Samples/Manage operational layers/ManageOperationalLayersView.swift
@@ -158,3 +158,9 @@ private extension URL {
         URL(string: "https://sampleserver5.arcgisonline.com/arcgis/rest/services/Census/MapServer")!
     }
 }
+
+#Preview {
+    NavigationView {
+        ManageOperationalLayersView()
+    }
+}

--- a/Shared/Samples/Measure distance in scene/MeasureDistanceInSceneView.swift
+++ b/Shared/Samples/Measure distance in scene/MeasureDistanceInSceneView.swift
@@ -172,3 +172,7 @@ private extension URL {
         URL(string: "https://tiles.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/Buildings_Brest/SceneServer/layers/0")!
     }
 }
+
+#Preview {
+    MeasureDistanceInSceneView()
+}

--- a/Shared/Samples/Monitor changes to map load status/MonitorChangesToMapLoadStatusView.swift
+++ b/Shared/Samples/Monitor changes to map load status/MonitorChangesToMapLoadStatusView.swift
@@ -55,3 +55,7 @@ private extension LoadStatus {
         }
     }
 }
+
+#Preview {
+    MonitorChangesToMapLoadStatusView()
+}

--- a/Shared/Samples/Navigate route/NavigateRouteView.swift
+++ b/Shared/Samples/Navigate route/NavigateRouteView.swift
@@ -154,7 +154,7 @@ private extension NavigateRouteView {
             autoPanMode = .off
             
             // Creates the graphics for each stop.
-            let stopGraphics = stops.map {
+            let stopGraphics = Self.stops.map {
                 Graphic(
                     geometry: $0.geometry,
                     symbol: SimpleMarkerSymbol(style: .diamond, color: .orange, size: 20)
@@ -183,7 +183,7 @@ private extension NavigateRouteView {
                 parameters.outputSpatialReference = .wgs84
                 
                 // Sets the stops on the parameters.
-                parameters.setStops(stops)
+                parameters.setStops(Self.stops)
                 
                 // Solves the route based on the parameters.
                 routeResult = try await routeTask.solveRoute(using: parameters)
@@ -323,7 +323,9 @@ private extension NavigateRouteView {
             isResettingRoute = false
         }
     }
-    
+}
+
+private extension NavigateRouteView.Model {
     /// The stops for this sample.
     static var stops: [Stop] {
         let one = Stop(point: Point(x: -117.160386727, y: 32.706608, spatialReference: .wgs84))
@@ -346,5 +348,11 @@ private extension URL {
     /// The URL for the route task.
     static var routeTask: URL {
         URL(string: "http://sampleserver7.arcgisonline.com/server/rest/services/NetworkAnalysis/SanDiego/NAServer/Route")!
+    }
+}
+
+#Preview {
+    NavigationView {
+        NavigateRouteView()
     }
 }

--- a/Shared/Samples/Play KML tour/PlayKMLTourView.swift
+++ b/Shared/Samples/Play KML tour/PlayKMLTourView.swift
@@ -163,3 +163,9 @@ private extension URL {
         URL(string: "https://www.arcgis.com/sharing/rest/content/items/f10b1d37fdd645c9bc9b189fb546307c/data")!
     }
 }
+
+#Preview {
+    NavigationView {
+        PlayKMLTourView()
+    }
+}

--- a/Shared/Samples/Project geometry/ProjectGeometryView.swift
+++ b/Shared/Samples/Project geometry/ProjectGeometryView.swift
@@ -107,3 +107,7 @@ private extension Point {
         Text("\(self.x, format: .decimal), \(self.y, format: .decimal)")
     }
 }
+
+#Preview {
+    ProjectGeometryView()
+}

--- a/Shared/Samples/Query feature table/QueryFeatureTableView.swift
+++ b/Shared/Samples/Query feature table/QueryFeatureTableView.swift
@@ -115,3 +115,9 @@ private extension PortalItem.ID {
     /// The portal item ID of a USA 2016 Daytime Population feature layer.
     static var daytimePopulation: Self { Self("f01f0eda766344e29f42031e7bfb7d04")! }
 }
+
+#Preview {
+    NavigationView {
+        QueryFeatureTableView()
+    }
+}

--- a/Shared/Samples/Render multilayer symbols/RenderMultilayerSymbolsView.swift
+++ b/Shared/Samples/Render multilayer symbols/RenderMultilayerSymbolsView.swift
@@ -484,3 +484,7 @@ private extension String {
     /// The JSON for a cross geometry.
     static let crossGeometryJSON = "{\"paths\":[[[-1,1],[0,0],[1,-1]],[[1,1],[0,0],[-1,-1]]]}"
 }
+
+#Preview {
+    RenderMultilayerSymbolsView()
+}

--- a/Shared/Samples/Run valve isolation trace/RunValveIsolationTraceView.swift
+++ b/Shared/Samples/Run valve isolation trace/RunValveIsolationTraceView.swift
@@ -191,3 +191,9 @@ extension RunValveIsolationTraceView.Model.TracingActivity {
         }
     }
 }
+
+#Preview {
+    NavigationView {
+        RunValveIsolationTraceView()
+    }
+}

--- a/Shared/Samples/Search with geocode/SearchWithGeocodeView.swift
+++ b/Shared/Samples/Search with geocode/SearchWithGeocodeView.swift
@@ -135,3 +135,7 @@ private extension SearchWithGeocodeView {
         let searchResultsOverlay = GraphicsOverlay()
     }
 }
+
+#Preview {
+    SearchWithGeocodeView()
+}

--- a/Shared/Samples/Select features in feature layer/SelectFeaturesInFeatureLayerView.swift
+++ b/Shared/Samples/Select features in feature layer/SelectFeaturesInFeatureLayerView.swift
@@ -95,3 +95,7 @@ private extension SelectFeaturesInFeatureLayerView {
 private extension PortalItem.ID {
     static var gdpPerCapita: Self { Self("10d76a5b015647279b165f3a64c2524f")! }
 }
+
+#Preview {
+    SelectFeaturesInFeatureLayerView()
+}

--- a/Shared/Samples/Set basemap/SetBasemapView.swift
+++ b/Shared/Samples/Set basemap/SetBasemapView.swift
@@ -53,3 +53,9 @@ struct SetBasemapView: View {
         }
     }
 }
+
+#Preview {
+    NavigationView {
+        SetBasemapView()
+    }
+}

--- a/Shared/Samples/Set max extent/SetMaxExtentView.swift
+++ b/Shared/Samples/Set max extent/SetMaxExtentView.swift
@@ -74,3 +74,9 @@ private extension Envelope {
         )
     }
 }
+
+#Preview {
+    NavigationView {
+        SetMaxExtentView()
+    }
+}

--- a/Shared/Samples/Set min and max scale/SetMinAndMaxScaleView.swift
+++ b/Shared/Samples/Set min and max scale/SetMinAndMaxScaleView.swift
@@ -34,3 +34,7 @@ struct SetMinAndMaxScaleView: View {
         MapView(map: map)
     }
 }
+
+#Preview {
+    SetMinAndMaxScaleView()
+}

--- a/Shared/Samples/Set surface placement mode/SetSurfacePlacementModeView.swift
+++ b/Shared/Samples/Set surface placement mode/SetSurfacePlacementModeView.swift
@@ -222,3 +222,7 @@ private extension URL {
         URL(string: "https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer")!
     }
 }
+
+#Preview {
+    SetSurfacePlacementModeView()
+}

--- a/Shared/Samples/Set up location-driven geotriggers/SetUpLocationDrivenGeotriggersView.swift
+++ b/Shared/Samples/Set up location-driven geotriggers/SetUpLocationDrivenGeotriggersView.swift
@@ -150,3 +150,9 @@ extension SetUpLocationDrivenGeotriggersView {
         }
     }
 }
+
+#Preview {
+    NavigationView {
+        SetUpLocationDrivenGeotriggersView()
+    }
+}

--- a/Shared/Samples/Set viewpoint rotation/SetViewpointRotationView.swift
+++ b/Shared/Samples/Set viewpoint rotation/SetViewpointRotationView.swift
@@ -67,3 +67,7 @@ struct SetViewpointRotationView: View {
         .padding(.bottom)
     }
 }
+
+#Preview {
+    SetViewpointRotationView()
+}

--- a/Shared/Samples/Set visibility of subtype sublayer/SetVisibilityOfSubtypeSublayerView.swift
+++ b/Shared/Samples/Set visibility of subtype sublayer/SetVisibilityOfSubtypeSublayerView.swift
@@ -59,3 +59,9 @@ struct SetVisibilityOfSubtypeSublayerView: View {
             .errorAlert(presentingError: $error)
     }
 }
+
+#Preview {
+    NavigationView {
+        SetVisibilityOfSubtypeSublayerView()
+    }
+}

--- a/Shared/Samples/Show callout/ShowCalloutView.swift
+++ b/Shared/Samples/Show callout/ShowCalloutView.swift
@@ -56,3 +56,7 @@ struct ShowCalloutView: View {
             }
     }
 }
+
+#Preview {
+    ShowCalloutView()
+}

--- a/Shared/Samples/Show coordinates in multiple formats/ShowCoordinatesInMultipleFormatsView.swift
+++ b/Shared/Samples/Show coordinates in multiple formats/ShowCoordinatesInMultipleFormatsView.swift
@@ -179,3 +179,7 @@ private extension ShowCoordinatesInMultipleFormatsView {
         }
     }
 }
+
+#Preview {
+    ShowCoordinatesInMultipleFormatsView()
+}

--- a/Shared/Samples/Show device location history/ShowDeviceLocationHistoryView.swift
+++ b/Shared/Samples/Show device location history/ShowDeviceLocationHistoryView.swift
@@ -209,3 +209,9 @@ private extension ShowDeviceLocationHistoryView {
         }
     }
 }
+
+#Preview {
+    NavigationView {
+        ShowDeviceLocationHistoryView()
+    }
+}

--- a/Shared/Samples/Show device location/ShowDeviceLocationView.swift
+++ b/Shared/Samples/Show device location/ShowDeviceLocationView.swift
@@ -123,8 +123,6 @@ private extension ShowDeviceLocationView {
 }
 
 private extension LocationDisplay.AutoPanMode {
-    static var allCases: [LocationDisplay.AutoPanMode] { [.off, .recenter, .navigation, .compassNavigation] }
-    
     /// A human-readable label for each auto-pan mode.
     var label: String {
         switch self {
@@ -145,5 +143,11 @@ private extension LocationDisplay.AutoPanMode {
         case .compassNavigation: return "LocationDisplayHeadingIcon"
         @unknown default: return "LocationDisplayOffIcon"
         }
+    }
+}
+
+#Preview {
+    NavigationView {
+        ShowDeviceLocationView()
     }
 }

--- a/Shared/Samples/Show extruded features/ShowExtrudedFeaturesView.swift
+++ b/Shared/Samples/Show extruded features/ShowExtrudedFeaturesView.swift
@@ -125,3 +125,7 @@ private extension URL {
         URL(string: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer/3")!
     }
 }
+
+#Preview {
+    ShowExtrudedFeaturesView()
+}

--- a/Shared/Samples/Show labels on layer/ShowLabelsOnLayerView.swift
+++ b/Shared/Samples/Show labels on layer/ShowLabelsOnLayerView.swift
@@ -104,3 +104,7 @@ private extension PortalItem.ID {
     /// An id for a USA Congressional Districts Analysis feature table.
     static var usaCongressionalDistricts: Self { Self("cc6a869374434bee9fefad45e291b779 ")! }
 }
+
+#Preview {
+    ShowLabelsOnLayerView()
+}

--- a/Shared/Samples/Show line of sight between points/ShowLineOfSightBetweenPointsView.swift
+++ b/Shared/Samples/Show line of sight between points/ShowLineOfSightBetweenPointsView.swift
@@ -87,3 +87,7 @@ private extension URL {
         URL(string: "https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer")!
     }
 }
+
+#Preview {
+    ShowLineOfSightBetweenPointsView()
+}

--- a/Shared/Samples/Show popup/ShowPopupView.swift
+++ b/Shared/Samples/Show popup/ShowPopupView.swift
@@ -68,3 +68,7 @@ private extension PortalItem.ID {
     /// The ID used in the "Incidents in San Francisco" portal item.
     static var incidentsInSanFrancisco: Self { Self("fb788308ea2e4d8682b9c05ef641f273")! }
 }
+
+#Preview {
+    ShowPopupView()
+}

--- a/Shared/Samples/Show realistic light and shadows/ShowRealisticLightAndShadowsView.swift
+++ b/Shared/Samples/Show realistic light and shadows/ShowRealisticLightAndShadowsView.swift
@@ -140,3 +140,9 @@ private extension SceneView.SunLighting {
 private extension Date {
     static let startOfDay = Calendar.current.startOfDay(for: .now)
 }
+
+#Preview {
+    NavigationView {
+        ShowRealisticLightAndShadowsView()
+    }
+}

--- a/Shared/Samples/Show result of spatial operations/ShowResultOfSpatialOperationsView.swift
+++ b/Shared/Samples/Show result of spatial operations/ShowResultOfSpatialOperationsView.swift
@@ -167,3 +167,15 @@ private extension Geometry {
         )
     }
 }
+
+#if DEBUG
+private extension ShowResultOfSpatialOperationsView.Model {
+    typealias SpatialOperation = ShowResultOfSpatialOperationsView.SpatialOperation
+}
+
+#Preview {
+    NavigationView {
+        ShowResultOfSpatialOperationsView()
+    }
+}
+#endif

--- a/Shared/Samples/Show result of spatial relationships/ShowResultOfSpatialRelationshipsView.swift
+++ b/Shared/Samples/Show result of spatial relationships/ShowResultOfSpatialRelationshipsView.swift
@@ -272,3 +272,13 @@ private extension Graphic {
         return Graphic(geometry: point, symbol: markerSymbol)
     }
 }
+
+#if DEBUG
+private extension ShowResultOfSpatialRelationshipsView.Model {
+    typealias Relationship = ShowResultOfSpatialRelationshipsView.Relationship
+}
+
+#Preview {
+    ShowResultOfSpatialRelationshipsView()
+}
+#endif

--- a/Shared/Samples/Show utility associations/ShowUtilityAssociationsView.swift
+++ b/Shared/Samples/Show utility associations/ShowUtilityAssociationsView.swift
@@ -268,3 +268,9 @@ private extension Viewpoint {
         )
     }
 }
+
+#Preview {
+    NavigationView {
+        ShowUtilityAssociationsView()
+    }
+}

--- a/Shared/Samples/Show viewshed from point in scene/ShowViewshedFromPointInSceneView.swift
+++ b/Shared/Samples/Show viewshed from point in scene/ShowViewshedFromPointInSceneView.swift
@@ -50,3 +50,9 @@ struct ShowViewshedFromPointInSceneView: View {
             }
     }
 }
+
+#Preview {
+    NavigationView {
+        ShowViewshedFromPointInSceneView()
+    }
+}

--- a/Shared/Samples/Style graphics with renderer/StyleGraphicsWithRendererView.swift
+++ b/Shared/Samples/Style graphics with renderer/StyleGraphicsWithRendererView.swift
@@ -210,3 +210,7 @@ private extension StyleGraphicsWithRendererView {
         }
     }
 }
+
+#Preview {
+    StyleGraphicsWithRendererView()
+}

--- a/Shared/Samples/Style graphics with symbols/StyleGraphicsWithSymbolsView.swift
+++ b/Shared/Samples/Style graphics with symbols/StyleGraphicsWithSymbolsView.swift
@@ -209,3 +209,7 @@ private extension Geometry {
         )
     }
 }
+
+#Preview {
+    StyleGraphicsWithSymbolsView()
+}

--- a/Shared/Samples/Style point with picture marker symbols/StylePointWithPictureMarkerSymbolsView.swift
+++ b/Shared/Samples/Style point with picture marker symbols/StylePointWithPictureMarkerSymbolsView.swift
@@ -91,3 +91,7 @@ struct StylePointWithPictureMarkerSymbolsView: View {
         MapView(map: map, graphicsOverlays: [graphicsOverlay])
     }
 }
+
+#Preview {
+    StylePointWithPictureMarkerSymbolsView()
+}

--- a/Shared/Samples/Trace utility network/TraceUtilityNetworkView.swift
+++ b/Shared/Samples/Trace utility network/TraceUtilityNetworkView.swift
@@ -107,3 +107,9 @@ private extension Viewpoint {
         )
     }
 }
+
+#Preview {
+    NavigationView {
+        TraceUtilityNetworkView()
+    }
+}


### PR DESCRIPTION
## Description

This PR adds a preview to the top level view for each sample. Samples that used navigation related components, such as a toolbar, had to be wrapped in a `NavigationView` to work correctly. Some samples also required some small changes for their preview to compile. Those special cases can be found in the second commit of this PR.

**Note:** With how on-demand resource are set up in this project, they do not work with previews and cause them to crash. As a result, The samples that use on-demand resource were not given a preview.

<details><summary>List of Omitted Samples (as of creation)</summary><p>

1. Add custom dynamic entity data source
2. Add feature layers
3. Add raster from file
4. Animate 3D graphic
5. Animate images with image overlay
6. Augment reality to show tabletop scene
7. Change camera controller
8. Display dimensions
9. Display map from mobile map package
10. Display scene from mobile scene package
11. Find route in mobile map package
12. Find route in transport network
13. Geocode offline
14. Identify raster cell
15. Show device location with NMEA data sources
16. Show mobile map package expiration date
17. Show viewshed from geoelement in scene
18. Style features with custom dictionary
19. Style symbols from mobile style file

</p></details>


## Linked Issue(s)

- `swift/issues/4845`

## How To Test

- Verify the preview in the top level view of each sample works as expected.
- Verify the samples that were additionally modified work as expected.
