### PR TITLE
[Update] Set min scale on maps to avoid huge download

### DIFF
--- a/Shared/Samples/Download vector tiles to local cache/DownloadVectorTilesToLocalCacheView.swift
+++ b/Shared/Samples/Download vector tiles to local cache/DownloadVectorTilesToLocalCacheView.swift
@@ -186,6 +186,8 @@ private extension DownloadVectorTilesToLocalCacheView {
             // Initializes the map.
             map = Map(basemapStyle: .arcGISStreetsNight)
             map.initialViewpoint = Viewpoint(latitude: 34.049, longitude: -117.181, scale: 1e4)
+            // Sets the min scale to avoid requesting a huge download.
+            map.minScale = 1e4
             
             // Initializes the URL for the directory containing vector tile packages.
             vtpkTemporaryURL = temporaryDirectory

--- a/Shared/Samples/Generate offline map/GenerateOfflineMapView.swift
+++ b/Shared/Samples/Generate offline map/GenerateOfflineMapView.swift
@@ -151,6 +151,8 @@ private extension GenerateOfflineMapView {
         init() {
             // Initializes the online map.
             onlineMap = Map(item: napervillePortalItem)
+            // Sets the min scale to avoid requesting a huge download.
+            onlineMap.minScale = 1e4
         }
         
         deinit {


### PR DESCRIPTION
## Description

This PR sets `minScale` on 2 samples to disallow the map to zoom too far and thus download too much data.

## Linked Issue(s)

- #121 

## How To Test

- Run the samples, make sure they can still export/generate files correctly.

## To Discuss

It seems that the generate offline map sample has some issue with generated data. See below for details. They are not affected by the changes in this PR.

- swift/issues/2008
- #261 