### PR TITLE
[Update] Samples list accessing

### DIFF
--- a/Shared/SamplesApp.swift
+++ b/Shared/SamplesApp.swift
@@ -23,7 +23,7 @@ struct SamplesApp: App {
     
     var body: some SwiftUI.Scene {
         WindowGroup {
-            ContentView(samples: Self.samples)
+            ContentView()
         }
     }
 }

--- a/Shared/Supporting Files/Views/CategoriesView.swift
+++ b/Shared/Supporting Files/Views/CategoriesView.swift
@@ -15,22 +15,14 @@
 import SwiftUI
 
 struct CategoriesView: View {
-    /// All samples retrieved from the Samples directory.
-    private let samples: [Sample]
-    
     /// The sample categories generated from the samples list.
-    private let categories: [String]
-    
-    init(samples: [Sample]) {
-        self.samples = samples
-        self.categories = Set(samples.map(\.category)).sorted()
-    }
+    private let categories = Set(SamplesApp.samples.map(\.category)).sorted()
     
     var body: some View {
         ScrollView {
             LazyVGrid(columns: [GridItem(), GridItem()]) {
                 NavigationLink {
-                    FavoritesView(samples: samples)
+                    FavoritesView()
                         .navigationTitle("Favorites")
                 } label: {
                     CategoryTile(name: "Favorites")
@@ -41,7 +33,7 @@ struct CategoriesView: View {
                 
                 ForEach(categories, id: \.self) { category in
                     NavigationLink {
-                        List(samples.filter { $0.category == category }, id: \.name) { sample in
+                        List(SamplesApp.samples.filter { $0.category == category }, id: \.name) { sample in
                             SampleLink(sample)
                         }
                         .listStyle(.sidebar)

--- a/Shared/Supporting Files/Views/ContentView.swift
+++ b/Shared/Supporting Files/Views/ContentView.swift
@@ -15,9 +15,6 @@
 import SwiftUI
 
 struct ContentView: View {
-    /// All samples retrieved from the Samples directory.
-    let samples: [Sample]
-    
     /// The search query in the search bar.
     @State private var query = ""
     
@@ -41,7 +38,7 @@ struct ContentView: View {
     }
     
     var sidebar: some View {
-        Sidebar(samples: samples, query: query)
+        Sidebar(query: query)
             .searchable(text: $query)
     }
     

--- a/Shared/Supporting Files/Views/FavoritesView.swift
+++ b/Shared/Supporting Files/Views/FavoritesView.swift
@@ -15,9 +15,6 @@
 import SwiftUI
 
 struct FavoritesView: View {
-    /// All samples retrieved from the Samples directory.
-    let samples: [Sample]
-    
     /// A Boolean value indicating whether the add favorite sheet is showing.
     @State private var addFavoriteSheetIsShowing = false
     
@@ -27,7 +24,7 @@ struct FavoritesView: View {
     /// A list of the favorite samples.
     private var favoriteSamples: [Sample] {
         favoriteNames.compactMap { name in
-            samples.first(where: { $0.name == name })
+            SamplesApp.samples.first(where: { $0.name == name })
         }
     }
     
@@ -54,7 +51,7 @@ struct FavoritesView: View {
                     Image(systemName: "plus")
                 }
                 .sheet(isPresented: $addFavoriteSheetIsShowing) {
-                    AddFavoriteView(samples: samples)
+                    AddFavoriteView()
                 }
             }
         }
@@ -64,9 +61,6 @@ struct FavoritesView: View {
 private extension FavoritesView {
     /// A view to add a favorite sample from a searchable list.
     struct AddFavoriteView: View {
-        /// All samples retrieved from the Samples directory.
-        let samples: [Sample]
-        
         /// The action to dismiss the sheet.
         @Environment(\.dismiss) private var dismiss: DismissAction
         
@@ -79,8 +73,8 @@ private extension FavoritesView {
         /// The list of samples filtered by the search query.
         private var filteredSamples: [Sample] {
             query.isEmpty
-            ? samples
-            : samples.filter {
+            ? SamplesApp.samples
+            : SamplesApp.samples.filter {
                 $0.name.localizedStandardContains(query)
             }
         }

--- a/Shared/Supporting Files/Views/SamplesSearchView.swift
+++ b/Shared/Supporting Files/Views/SamplesSearchView.swift
@@ -21,6 +21,14 @@ struct SamplesSearchView: View {
     /// The search result to display in the various sections.
     private let searchResult: SearchResult
     
+    /// Creates a sample search view.
+    /// - Parameters:
+    ///   - query: The search query in the search bar.
+    init(query: String) {
+        self.query = query
+        self.searchResult = Self.searchSamples(with: query)
+    }
+    
     var body: some View {
         List {
             if !searchResult.nameMatches.isEmpty {
@@ -50,17 +58,6 @@ struct SamplesSearchView: View {
 
 // MARK: Search
 
-extension SamplesSearchView {
-    /// Create a sample search view.
-    /// - Parameters:
-    ///   - samples: All samples retrieved from the Samples directory.
-    ///   - query: The search query in the search bar.
-    init(samples: [Sample], query: String) {
-        self.query = query
-        self.searchResult = Self.searchSamples(in: samples, with: query)
-    }
-}
-
 private extension SamplesSearchView {
     /// A struct that contains various search results to be displayed in
     /// different sections in a list.
@@ -78,11 +75,11 @@ private extension SamplesSearchView {
         }
     }
     
-    /// Searches through a list of samples to find ones that match the query.
+    /// Searches through the list of samples to find ones that match the query.
     /// - Parameters:
-    ///   - samples: The samples to search through.
     ///   - query: The query to search with.
-    private static func searchSamples(in samples: [Sample], with query: String) -> SearchResult {
+    private static func searchSamples(with query: String) -> SearchResult {
+        let samples = SamplesApp.samples
         let nameMatches: [Sample]
         let descriptionMatches: [Sample]
         let tagMatches: [Sample]

--- a/Shared/Supporting Files/Views/Sidebar.swift
+++ b/Shared/Supporting Files/Views/Sidebar.swift
@@ -20,20 +20,17 @@ struct Sidebar: View {
     
     /// A Boolean value that indicates whether to present the about view.
     @State private var isAboutViewPresented = false
-    
-    /// All samples retrieved from the Samples directory.
-    let samples: [Sample]
-    
+
     /// The search query.
     let query: String
     
     var body: some View {
         Group {
             if !isSearching {
-                CategoriesView(samples: samples)
+                CategoriesView()
                     .navigationTitle("Categories")
             } else {
-                SamplesSearchView(samples: samples, query: query)
+                SamplesSearchView(query: query)
             }
         }
         .toolbar {

--- a/Shared/Supporting Files/Views/Sidebar.swift
+++ b/Shared/Supporting Files/Views/Sidebar.swift
@@ -20,7 +20,7 @@ struct Sidebar: View {
     
     /// A Boolean value that indicates whether to present the about view.
     @State private var isAboutViewPresented = false
-
+    
     /// The search query.
     let query: String
     


### PR DESCRIPTION
## Description

This PR updates how the list of samples is accessed by views within the Sample Viewer. Before, the list was passed down from `SamplesApp` as a parameter to the subsequent child views until it was eventually used. Those parameters were removed, and now, the views that need the list of samples access it through the static variable, ` SamplesApp.samples`.

## Linked Issue(s)

- `swift/issues/4842`

## How To Test

- Ensure the Sample Viewer works the same as before, particularly the categories, favorites, and searching. 