### PR TITLE
[Update] Refactor GenerateOfflineMapView

### DIFF
--- a/Shared/Samples/Generate offline map/GenerateOfflineMapView.swift
+++ b/Shared/Samples/Generate offline map/GenerateOfflineMapView.swift
@@ -22,6 +22,9 @@ struct GenerateOfflineMapView: View {
     /// A Boolean value indicating whether the job is cancelling.
     @State private var isCancellingJob = false
     
+    /// The error shown in the error alert.
+    @State private var error: Error?
+    
     /// The view model for this sample.
     @StateObject private var model = Model()
     
@@ -30,9 +33,9 @@ struct GenerateOfflineMapView: View {
             MapViewReader { mapView in
                 MapView(map: model.offlineMap ?? model.onlineMap)
                     .interactionModes(isGeneratingOfflineMap ? [] : [.pan, .zoom])
-                    .errorAlert(presentingError: $model.error)
+                    .errorAlert(presentingError: $error)
                     .task {
-                        await model.initializeOfflineMapTask()
+                        try? await model.initializeOfflineMapTask()
                     }
                     .onDisappear {
                         Task { await model.cancelJob() }
@@ -103,8 +106,12 @@ struct GenerateOfflineMapView: View {
                                 // Creates an envelope from the rectangle.
                                 guard let extent = mapView.envelope(fromViewRect: viewRect) else { return }
                                 
-                                // Generates an offline map.
-                                await model.generateOfflineMap(extent: extent)
+                                do {
+                                    // Generates an offline map.
+                                    try await model.generateOfflineMap(extent: extent)
+                                } catch {
+                                    self.error = error
+                                }
                                 
                                 // Sets generating an offline map to false.
                                 isGeneratingOfflineMap = false
@@ -122,16 +129,13 @@ private extension GenerateOfflineMapView {
     @MainActor
     class Model: ObservableObject {
         /// The offline map that is generated.
-        @Published var offlineMap: Map!
+        @Published private(set) var offlineMap: Map!
         
         /// A Boolean value indicating whether the generate button is disabled.
-        @Published var isGenerateDisabled = true
-        
-        /// The error shown in the error alert.
-        @Published var error: Error?
+        @Published private(set) var isGenerateDisabled = true
         
         /// The generate offline map job.
-        @Published var generateOfflineMapJob: GenerateOfflineMapJob!
+        @Published private(set) var generateOfflineMapJob: GenerateOfflineMapJob!
         
         /// The offline map task.
         private var offlineMapTask: OfflineMapTask!
@@ -161,41 +165,29 @@ private extension GenerateOfflineMapView {
         }
         
         /// Initializes the offline map task.
-        func initializeOfflineMapTask() async {
-            do {
-                // Waits for the online map to load.
-                try await onlineMap.load()
-                offlineMapTask = OfflineMapTask(onlineMap: onlineMap)
-                isGenerateDisabled = false
-            } catch {
-                self.error = error
-            }
+        func initializeOfflineMapTask() async throws {
+            // Waits for the online map to load.
+            try await onlineMap.load()
+            offlineMapTask = OfflineMapTask(onlineMap: onlineMap)
+            isGenerateDisabled = false
         }
         
         /// Creates the generate offline map parameters.
         /// - Parameter areaOfInterest: The area of interest to create the parameters for.
         /// - Returns: A `GenerateOfflineMapParameters` if there are no errors. Otherwise, it returns `nil`,
-        private func makeGenerateOfflineMapParameters(areaOfInterest: Envelope) async -> GenerateOfflineMapParameters? {
-            do {
-                // Returns the default parameters for the offline map task.
-                return try await offlineMapTask.makeDefaultGenerateOfflineMapParameters(areaOfInterest: areaOfInterest)
-            } catch {
-                self.error = error
-                return nil
-            }
+        private func makeGenerateOfflineMapParameters(areaOfInterest: Envelope) async  throws -> GenerateOfflineMapParameters {
+            // Returns the default parameters for the offline map task.
+            return try await offlineMapTask.makeDefaultGenerateOfflineMapParameters(areaOfInterest: areaOfInterest)
         }
         
         /// Generates the offline map.
         /// - Parameter extent: The area of interest's envelope to generate an offline map for.
-        func generateOfflineMap(extent: Envelope) async {
+        func generateOfflineMap(extent: Envelope) async throws {
             // Disables the generate offline map button.
             isGenerateDisabled = true
             
             // Creates the default parameters for the offline map task.
-            guard let parameters = await makeGenerateOfflineMapParameters(areaOfInterest: extent) else {
-                isGenerateDisabled = false
-                return
-            }
+            let parameters = try await makeGenerateOfflineMapParameters(areaOfInterest: extent)
             
             // Creates the generate offline map job based on the parameters.
             generateOfflineMapJob = offlineMapTask.makeGenerateOfflineMapJob(
@@ -211,17 +203,12 @@ private extension GenerateOfflineMapView {
                 isGenerateDisabled = offlineMap != nil
             }
             
-            do {
-                // Awaits the output of the job.
-                let output = try await generateOfflineMapJob.output
-                // Sets the offline map to the output's offline map.
-                offlineMap = output.offlineMap
-                // Sets the initial viewpoint of the offline map.
-                offlineMap.initialViewpoint = Viewpoint(boundingGeometry: extent.expanded(by: 0.8))
-            } catch {
-                // Shows an alert with the error if the job fails.
-                self.error = error
-            }
+            // Awaits the output of the job.
+            let output = try await generateOfflineMapJob.output
+            // Sets the offline map to the output's offline map.
+            offlineMap = output.offlineMap
+            // Sets the initial viewpoint of the offline map.
+            offlineMap.initialViewpoint = Viewpoint(boundingGeometry: extent.expanded(by: 0.8))
         }
         
         /// Cancels the generate offline map job.


### PR DESCRIPTION
## Description

This PR refactors `GenerateOfflineMapView`. Close #108 

## Linked Issue(s)

- #108 

## How To Test

Make sure the sample still works.

- To make the error propagate, `throws` keyword needs to be added to several methods.
