### PR TITLE
[Update] Refactor DownloadVectorTilesToLocalCacheView

### DIFF
--- a/Shared/Samples/Download vector tiles to local cache/DownloadVectorTilesToLocalCacheView.swift
+++ b/Shared/Samples/Download vector tiles to local cache/DownloadVectorTilesToLocalCacheView.swift
@@ -233,8 +233,11 @@ private extension DownloadVectorTilesToLocalCacheView {
             self.exportVectorTilesTask = exportVectorTilesTask
         }
         
-        /// Downloads the vector tiles within the area of interest.
-        /// - Parameter extent: The area of interest's envelope to download vector tiles.
+        /// Downloads the vector tiles within the area of interest at given scale.
+        /// - Parameters:
+        ///   - extent: The area of interest's envelope to export vector tiles.
+        ///   - maxScale: The map scale which determines how far in to export
+        ///   the vector tiles. Set to `0` to include all levels of detail.
         func downloadVectorTiles(extent: Envelope, maxScale: Double) async throws {
             // Creates the parameters for the export vector tiles job.
             let parameters = try await exportVectorTilesTask.makeDefaultExportVectorTilesParameters(

--- a/Shared/Samples/Download vector tiles to local cache/DownloadVectorTilesToLocalCacheView.swift
+++ b/Shared/Samples/Download vector tiles to local cache/DownloadVectorTilesToLocalCacheView.swift
@@ -108,7 +108,7 @@ struct DownloadVectorTilesToLocalCacheView: View {
                                 // Downloads the vector tiles.
                                 do {
                                     try await model.downloadVectorTiles(extent: extent)
-                                    // Show results when the download finishes.
+                                    // Shows results when the download finishes.
                                     isShowingResults = true
                                     // Sets downloading to false when the download finishes.
                                     isDownloading = false


### PR DESCRIPTION
## Description

This PR refactors `DownloadVectorTilesToLocalCacheView`. Close #114 

## Linked Issue(s)

- https://github.com/Esri/arcgis-maps-sdk-swift-samples/pull/107#discussion_r1091301687
- #114 

## How To Test

- Run the sample and ensure the vector tiles download still works.
- Use Network Link Conditioner or other ways to emulate these scenarios
    - The basemap loads too slowly, so the `exportVectorTilesTask` is `nil`
    - The `exportVectorTilesTask` loads too slowly, so its load status is not `loaded`
    - In both cases, the download button should be disabled
- When reviewing code, you can hide whitespaces to simplify the review process
