### PR TITLE
[Update] Sample Viewer encryption info

### DIFF
--- a/iOS/Info.plist
+++ b/iOS/Info.plist
@@ -31,6 +31,8 @@
 	</array>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>


### PR DESCRIPTION
## Description

This PR implements adds `ITSAppUsesNonExemptEncryption` to the `Info.plist` to prevent a `Missing compliance` warning shown when the the app is uploaded to TestFlight. This allow for future automation of the process. 

## Linked Issue(s)

- `swift/issues/3435`

## How To Test

- The Sample Viewer builds as expected.
