### PR TITLE
[Fix] Add category info

### DIFF
--- a/iOS/Info.plist
+++ b/iOS/Info.plist
@@ -33,6 +33,8 @@
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
+	<key>LSApplicationCategoryType</key>
+	<string>public.app-category.education</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>


### PR DESCRIPTION
## Description

This PR adds a category to the `Info.plist` to fix an `Asset validation` error that would be thrown when uploading the project to TestFlight as a Mac app.

## Linked Issue(s)

- `swift/issues/3435`