### PR TITLE
[Update] Add exception for 'Arcade' in common.py script

### DIFF
--- a/Scripts/CI/common.py
+++ b/Scripts/CI/common.py
@@ -23,6 +23,7 @@ from typing import List, Set
 # A set of words that get omitted during letter-case checks.
 # This set will be updated when a special word appears in a new sample.
 exception_proper_nouns = {
+    'Arcade',
     'ArcGIS Online',
     'ArcGIS Pro',
     'GeoPackage',


### PR DESCRIPTION
## Description

This PR updates the `common.py` script exclude `Arcade`. This will allow the metadata checker to pass on #336.

## Linked Issue(s)

- `swift/issues/4907`