### PR TITLE
[Update] Replace deprecated safe area API in SampleInfoView

### DIFF
--- a/Shared/Supporting Files/Views/SampleInfoView.swift
+++ b/Shared/Supporting Files/Views/SampleInfoView.swift
@@ -33,7 +33,7 @@ struct SampleInfoView: View {
             WebView(htmlString: codeHTML)
                 .opacity(informationMode == .code ? 1 : 0)
         }
-        .edgesIgnoringSafeArea([.horizontal, .bottom])
+        .ignoresSafeArea(edges: [.horizontal, .bottom])
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItem(placement: .principal) {


### PR DESCRIPTION
## Description

This PR replace deprecated API.

- [edgesIgnoringSafeArea(_:)](https://developer.apple.com/documentation/swiftui/view/edgesignoringsafearea(_:)) is deprecated, [ignoresSafeArea(_:edges:)](https://developer.apple.com/documentation/swiftui/view/ignoressafearea(_:edges:)) is used instead.

## How To Test

Open a source code pane, the view should still extend all the way to the bounds.
