### PR TITLE
[Update] Add `redirect_from` links to clustering samples

### DIFF
--- a/Shared/Samples/Configure clusters/README.metadata.json
+++ b/Shared/Samples/Configure clusters/README.metadata.json
@@ -24,7 +24,9 @@
         "IdentifyLayerResult",
         "Popup"
     ],
-    "redirect_from": [],
+    "redirect_from": [
+        "/swift/sample-code/add-clustering-feature-reduction-to-a-point-feature-layer/"
+    ],
     "relevant_apis": [
         "AggregateGeoElement",
         "ClassBreaksRenderer",

--- a/Shared/Samples/Display clusters/README.metadata.json
+++ b/Shared/Samples/Display clusters/README.metadata.json
@@ -20,7 +20,9 @@
         "GeoElement",
         "IdentifyLayerResult"
     ],
-    "redirect_from": [],
+    "redirect_from": [
+        "/swift/sample-code/display-points-using-clustering-feature-reduction/"
+    ],
     "relevant_apis": [
         "AggregateGeoElement",
         "FeatureLayer",


### PR DESCRIPTION
## Description

This PR adds the values to the `redirect_from` field in the metadatas of the clustering samples (`Configure clusters` & `Display clusters`). This is due to the samples being renamed in #348.

## Linked Issue(s)

- `swift/issues/5089`
