### PR TITLE
[Update] Manage bookmarks bookmark removal

### DIFF
--- a/Shared/Samples/Manage bookmarks/ManageBookmarksView.swift
+++ b/Shared/Samples/Manage bookmarks/ManageBookmarksView.swift
@@ -143,9 +143,9 @@ private extension ManageBookmarksView {
                     }
                     .onDelete { offsets in
                         // Delete the bookmarks at the given offsets on row deletion.
+                        let bookmarksToRemove = offsets.map { bookmarks[$0] }
+                        map.removeBookmarks(bookmarksToRemove)
                         bookmarks.remove(atOffsets: offsets)
-                        map.removeAllBookmarks()
-                        map.addBookmarks(bookmarks)
                     }
                     .buttonStyle(.plain)
                 }
@@ -153,6 +153,8 @@ private extension ManageBookmarksView {
                 .navigationBarTitleDisplayMode(.inline)
                 .toolbar {
                     ToolbarItem(placement: .topBarTrailing) {
+                        // Note: There is a bug in iOS 17 that prevents the `EditButton` from working
+                        // on the first tap when it is embedded in a `NavigationView` in a `popover`.
                         EditButton()
                     }
                 }


### PR DESCRIPTION
## Description

This PR updates `Manage bookmarks` samples to remove bookmarks using the previous broken [removeBookmarks(_:)](https://developers.arcgis.com/swift/api-reference/documentation/arcgis/geomodel/removebookmarks(_:)) method. It also adds a comment about a SwiftUI bug with the `EditButton`.

## Linked Issue(s)

The remove bookmark methods were fixed in: 
- `swift/issues/4898`

## How To Test

- Load the sample using `200.4.0`.
- Open the list of bookmarks and remove one.
- Close and reopen the list to ensure the given bookmark was actually removed.
