### PR TITLE
[Fix] Custom Boolean bindings bug on Mac Catalyst

### DIFF
--- a/Shared/Samples/Display dimensions/DisplayDimensionsView.swift
+++ b/Shared/Samples/Display dimensions/DisplayDimensionsView.swift
@@ -22,6 +22,12 @@ struct DisplayDimensionsView: View {
     /// The dimensional layer added to the map.
     @State private var dimensionLayer: DimensionLayer?
     
+    /// A Boolean value indicating whether the dimension layer's content is visible.
+    @State private var dimensionLayerIsVisible = true
+    
+    /// A Boolean value indicating whether the dimension layer's definition expression is set.
+    @State private var definitionExpressionIsSet = false
+    
     /// The error shown in the error alert.
     @State private var error: Error?
     
@@ -38,14 +44,18 @@ struct DisplayDimensionsView: View {
                 VStack {
                     Spacer()
                     Group {
-                        Toggle("Dimension Layer", isOn: Binding(
-                            get: { dimensionLayer?.isVisible ?? false },
-                            set: { dimensionLayer?.isVisible = $0 }
-                        ))
-                        Toggle("Definition Expression:\nDimensions >= 450m", isOn: Binding(
-                            get: { dimensionLayer?.definitionExpression == "DIMLENGTH >= 450" },
-                            set: { dimensionLayer?.definitionExpression = $0 ? "DIMLENGTH >= 450" : "" }
-                        ))
+                        Toggle("Dimension Layer", isOn: $dimensionLayerIsVisible)
+                            .onChange(of: dimensionLayerIsVisible) { newValue in
+                                dimensionLayer?.isVisible = newValue
+                            }
+                        
+                        Toggle(
+                            "Definition Expression:\nDimensions >= 450m",
+                            isOn: $definitionExpressionIsSet
+                        )
+                        .onChange(of: definitionExpressionIsSet) { newValue in
+                            dimensionLayer?.definitionExpression = newValue ? "DIMLENGTH >= 450" : ""
+                        }
                     }
                     .padding(8)
                     .background(.ultraThinMaterial)

--- a/Shared/Samples/Find route around barriers/FindRouteAroundBarriersView.Views.swift
+++ b/Shared/Samples/Find route around barriers/FindRouteAroundBarriersView.Views.swift
@@ -16,42 +16,46 @@ import ArcGIS
 import SwiftUI
 
 extension FindRouteAroundBarriersView {
-    /// The list of settings for the sample.
-    struct SettingsList: View {
-        /// The view model for the sample.
-        @ObservedObject var model: Model
+    /// A list of settings for modifying route parameters.
+    struct RouteParametersSettingsList: View {
+        /// The route parameters to modify.
+        private let routeParameters: RouteParameters
         
         /// A Boolean value indicating whether routing will find the best sequence.
-        @State private var routingFindsBestSequence = false
+        @State private var routingFindsBestSequence: Bool
+        
+        /// A Boolean value indicating whether routing will preserve the first stop.
+        @State private var routePreservesFirstStop: Bool
+        
+        /// A Boolean value indicating whether routing will preserve the last stop.
+        @State private var routePreservesLastStop: Bool
+        
+        init(for routeParameters: RouteParameters) {
+            self.routeParameters = routeParameters
+            _routingFindsBestSequence = State(initialValue: routeParameters.findsBestSequence)
+            _routePreservesFirstStop = State(initialValue: routeParameters.preservesFirstStop)
+            _routePreservesLastStop = State(initialValue: routeParameters.preservesLastStop)
+        }
         
         var body: some View {
             List {
-                Toggle(isOn: $routingFindsBestSequence) {
-                    Text("Find Best Sequence")
-                }
-                .onChange(of: routingFindsBestSequence) { newValue in
-                    model.routeParameters.findsBestSequence = newValue
-                }
+                Toggle("Find Best Sequence", isOn: $routingFindsBestSequence)
+                    .onChange(of: routingFindsBestSequence) { newValue in
+                        routeParameters.findsBestSequence = newValue
+                    }
                 
                 Section {
-                    Toggle(isOn: Binding(
-                        get: { model.routeParameters.preservesFirstStop },
-                        set: { model.routeParameters.preservesFirstStop = $0 }
-                    )) {
-                        Text("Preserve First Stop")
-                    }
+                    Toggle("Preserve First Stop", isOn: $routePreservesFirstStop)
+                        .onChange(of: routePreservesFirstStop) { newValue in
+                            routeParameters.preservesFirstStop = newValue
+                        }
                     
-                    Toggle(isOn: Binding(
-                        get: { model.routeParameters.preservesLastStop },
-                        set: { model.routeParameters.preservesLastStop = $0 }
-                    )) {
-                        Text("Preserve Last Stop")
-                    }
+                    Toggle("Preserve Last Stop", isOn: $routePreservesLastStop)
+                        .onChange(of: routePreservesLastStop) { newValue in
+                            routeParameters.preservesLastStop = newValue
+                        }
                 }
                 .disabled(!routingFindsBestSequence)
-            }
-            .onAppear {
-                routingFindsBestSequence = model.routeParameters.findsBestSequence
             }
         }
     }

--- a/Shared/Samples/Find route around barriers/FindRouteAroundBarriersView.swift
+++ b/Shared/Samples/Find route around barriers/FindRouteAroundBarriersView.swift
@@ -119,7 +119,7 @@ struct FindRouteAroundBarriersView: View {
                         Spacer()
                         
                         SheetButton(title: "Route Settings") {
-                            SettingsList(model: model)
+                            RouteParametersSettingsList(for: model.routeParameters)
                         } label: {
                             Image(systemName: "gear")
                         }

--- a/Shared/Samples/Group layers together/GroupLayersTogetherView.GroupLayerListView.swift
+++ b/Shared/Samples/Group layers together/GroupLayersTogetherView.GroupLayerListView.swift
@@ -34,9 +34,7 @@ extension GroupLayersTogetherView {
                     case .independent:
                         // Toggles for sublayers that can change their visibility independently.
                         ForEach(groupLayer.layers, id: \.name) { layer in
-                            Toggle(isOn: isVisibleBinding(for: layer)) {
-                                Text(formatLayerName(of: layer.name))
-                            }
+                            LayerVisibilityToggle(formatLayerName(of: layer.name), layer: layer)
                         }
                         
                     case .exclusive:
@@ -64,10 +62,7 @@ extension GroupLayersTogetherView {
                 }
                 .disabled(isDisabled)
             } header: {
-                // The group layer visibility toggle.
-                Toggle(isOn: isVisibleBinding(for: groupLayer)) {
-                    Text(groupLayer.name)
-                }
+                LayerVisibilityToggle(groupLayer.name, layer: groupLayer)
             }
             .task {
                 // Listen for changes to is visible to disable the section
@@ -84,16 +79,6 @@ extension GroupLayersTogetherView {
                     )?.name ?? ""
                 }
             }
-        }
-        
-        /// Creates a custom binding for toggling a layers's visibility.
-        /// - Parameter layer: The `Layer` to create the `Binding` from.
-        /// - Returns: The new custom `Binding` object.
-        private func isVisibleBinding(for layer: Layer) -> Binding<Bool> {
-            return Binding(
-                get: { layer.isVisible },
-                set: { layer.isVisible = $0 }
-            )
         }
         
         /// Formats a layer's name to be more human readable.
@@ -114,6 +99,31 @@ extension GroupLayersTogetherView {
             default:
                 return name
             }
+        }
+    }
+    
+    /// A toggle for changing a given layer's visibility.
+    private struct LayerVisibilityToggle: View {
+        /// The title of the toggle.
+        private let title: String
+        
+        /// The layer.
+        private let layer: Layer
+        
+        /// A Boolean value indicating whether the layer's content is visible.
+        @State private var layerIsVisible: Bool
+        
+        init(_ title: String, layer: Layer) {
+            self.title = title
+            self.layer = layer
+            _layerIsVisible = State(initialValue: layer.isVisible)
+        }
+        
+        var body: some View {
+            Toggle(title, isOn: $layerIsVisible)
+                .onChange(of: layerIsVisible) { newValue in
+                    layer.isVisible = newValue
+                }
         }
     }
 }


### PR DESCRIPTION
## Description

This PR implements a fix for a bug where toggle states would not update on Mac Catalyst when a custom binding was used. The bindings were replaced with State variables that trigger updates to a given value through an `onChange` modifier.

Sample affected:
- Display dimensions
- Find route around barriers
- Group layers together

## Linked Issue(s)

- `swift/issues/4994`

## How To Test

- Test the toggles in the samples listed on Mac Catalyst.
- Ensure the samples' functionality is otherwise unchanged.

