### PR TITLE
[Update] Replace deprecated API `navigationBarTrailing`

### DIFF
--- a/Samples.xcodeproj/project.pbxproj
+++ b/Samples.xcodeproj/project.pbxproj
@@ -2326,7 +2326,7 @@
 					StyleSymbolsFromMobileStyleFile,
 				);
 				LastSwiftUpdateCheck = 1330;
-				LastUpgradeCheck = 1500;
+				LastUpgradeCheck = 1530;
 				ORGANIZATIONNAME = Esri;
 				TargetAttributes = {
 					00E5401227F3CCA200CF66D5 = {

--- a/Samples.xcodeproj/xcshareddata/xcschemes/Samples.xcscheme
+++ b/Samples.xcodeproj/xcshareddata/xcschemes/Samples.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1500"
+   LastUpgradeVersion = "1530"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Shared/Supporting Files/Views/FavoritesView.swift
+++ b/Shared/Supporting Files/Views/FavoritesView.swift
@@ -42,7 +42,7 @@ struct FavoritesView: View {
         }
         .listStyle(.sidebar)
         .toolbar {
-            ToolbarItemGroup(placement: .navigationBarTrailing) {
+            ToolbarItemGroup(placement: .topBarTrailing) {
                 EditButton()
                 
                 Button {
@@ -105,7 +105,7 @@ private extension FavoritesView {
                         Text("Choose a sample to add to Favorites")
                             .font(.subheadline)
                     }
-                    ToolbarItem(placement: .navigationBarTrailing) {
+                    ToolbarItem(placement: .topBarTrailing) {
                         Button("Done") {
                             dismiss()
                         }

--- a/Shared/Supporting Files/Views/SampleDetailView.swift
+++ b/Shared/Supporting Files/Views/SampleDetailView.swift
@@ -84,7 +84,7 @@ struct SampleDetailView: View {
         .navigationTitle(sample.name)
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
-            ToolbarItem(placement: .navigationBarTrailing) {
+            ToolbarItem(placement: .topBarTrailing) {
                 Button {
                     isSampleInfoViewPresented = true
                 } label: {

--- a/Shared/Supporting Files/Views/Sidebar.swift
+++ b/Shared/Supporting Files/Views/Sidebar.swift
@@ -34,7 +34,7 @@ struct Sidebar: View {
             }
         }
         .toolbar {
-            ToolbarItem(placement: .navigationBarTrailing) {
+            ToolbarItem(placement: .topBarTrailing) {
                 Button {
                     isAboutViewPresented = true
                 } label: {


### PR DESCRIPTION
## Description

This PR replaces [`navigationBarTrailing`](https://developer.apple.com/documentation/swiftui/toolbaritemplacement/navigationbartrailing) with `topBarTrailing` as the new API is back deployed to iOS 14+.

This PR also bumps up the Xcode project file recommended settings check to Xcode 15.3.

## How To Test

- Go to the changed places and see if the change look good on both iOS and Mac Catalyst.
