### PR TITLE
[Update] `DowloadPortalItemData` script

### DIFF
--- a/Scripts/DowloadPortalItemData.swift
+++ b/Scripts/DowloadPortalItemData.swift
@@ -19,6 +19,7 @@
 // A mapping of item IDs to filenames is maintained in the download directory.
 // This mapping efficiently checks whether an item has already been downloaded.
 // If an item already exists, it will skip that item.
+// To delete and re-downloaded an item, remove it's entry in the plist.
 
 import Foundation
 

--- a/Scripts/DowloadPortalItemData.swift
+++ b/Scripts/DowloadPortalItemData.swift
@@ -161,10 +161,10 @@ func downloadFile(at sourceURL: URL, to downloadDirectory: URL, completion: @esc
                 
                 if isArchive {
                     let extractURL = downloadURL.pathExtension == "zip"
-                        // Uncompresses to directory named after archive.
-                        ? downloadURL.deletingPathExtension()
-                        // Uncompresses to appropriate subdirectory.
-                        : downloadURL.deletingLastPathComponent()
+                    // Uncompresses to directory named after archive.
+                    ? downloadURL.deletingPathExtension()
+                    // Uncompresses to appropriate subdirectory.
+                    : downloadURL.deletingLastPathComponent()
                     try uncompressArchive(at: temporaryURL, to: extractURL)
                 } else {
                     try FileManager.default.moveItem(at: temporaryURL, to: downloadURL)


### PR DESCRIPTION
## Description

This PR updates the `DowloadPortalItemData` script to allow items to be deleted and re-downloaded when their entry in the `.downloaded_items.plist` is removed. This also fixes a bug where download failures would result in an empty folder, causing the scrip to think the item successfully downloaded. The PR additionally replaces the dispatch group in the script with async-await syntax.
URL to script: [DowloadPortalItemData](https://github.com/Esri/arcgis-maps-sdk-swift-samples/blob/Caleb/Fix-DowloadPortalItemDataScript/Scripts/DowloadPortalItemData.swift) 

## Linked Issue(s)

- `swift/issues/4891`

## How To Test

- Delete an item from the `.downloaded_items.plist`.
- Build the project and check the local console log to ensure the item re-downloaded.
