### PR TITLE
[Setup] Add link to open GitHub repo

### DIFF
--- a/Shared/Supporting Files/Models/Sample.swift
+++ b/Shared/Supporting Files/Models/Sample.swift
@@ -41,6 +41,12 @@ protocol Sample {
 // MARK: Computed Variables
 
 extension Sample {
+    /// The URL to a sample's sub-directory on GitHub main branch.
+    var gitHubURL: URL {
+        URL(string: "https://github.com/Esri/arcgis-maps-sdk-swift-samples/tree/main/Shared/Samples")!
+            .appendingPathComponent(name)
+    }
+    
     /// The URL to a sample's `README.md` file.
     var readmeURL: URL {
         Bundle.main.url(forResource: name, withExtension: "md", subdirectory: "READMEs")!

--- a/Shared/Supporting Files/Views/SampleDetailView.swift
+++ b/Shared/Supporting Files/Views/SampleDetailView.swift
@@ -86,7 +86,7 @@ struct SampleDetailView: View {
         .toolbar {
             ToolbarItemGroup(placement: .topBarTrailing) {
 #if targetEnvironment(macCatalyst)
-                Link("View on GitHub", destination: .samplesDirectory.appendingPathComponent(sample.name))
+                Link("View on GitHub", destination: sample.gitHubURL)
 #endif
                 Button {
                     isSampleInfoViewPresented = true
@@ -111,11 +111,4 @@ struct SampleDetailView: View {
 
 extension SampleDetailView: Identifiable {
     var id: String { sample.nameInUpperCamelCase }
-}
-
-private extension URL {
-    /// The URL to the Samples sub-directory on GitHub's main branch.
-    static let samplesDirectory = URL(
-        string: "https://github.com/Esri/arcgis-maps-sdk-swift-samples/tree/main/Shared/Samples"
-    )!
 }


### PR DESCRIPTION
## Description

This PR adds a link button to the top bar on Mac Catalyst, so it can open the corresponding subfolder on GitHub.

This feature is implemented on .NET MAUI, so it is nice to have for our desktop offering as well.

## Linked Issue(s)

- https://github.com/Esri/arcgis-maps-sdk-dotnet-samples/pull/1363

## How To Test

- Run on iOS. Nothing has changed.
- Run on Mac Catalyst, click the button to open the sample in a browser.
- Test the create and edit geometries sample to see how 3 buttons in a bar works. 🥂 

## To Discuss

Unlike .NET, I didn't use the GitHub logo for the button to avoid any branding infringement.

For samples that is newly added to `v.next`, it opens 404 page. Not good, but shouldn't be a problem to the end users.

`View on GitHub` or `Open on GitHub`?