### PR TITLE
[Update] Add metadata category checking

### DIFF
--- a/Scripts/CI/common.py
+++ b/Scripts/CI/common.py
@@ -33,21 +33,19 @@ exception_proper_nouns = {
     'Web Mercator'
 }
 
-# A set of category folder names for legacy support.
+# A set of category folder names.
 categories = {
-    'Maps',
-    'Layers',
-    'Features',
-    'Display information',
-    'Search',
-    'Edit data',
-    'Geometry',
-    'Route and directions',
     'Analysis',
-    'Cloud and portal',
+    'Augmented Reality',
+    'Cloud and Portal',
+    'Edit and Manage Data',
+    'Layers',
+    'Maps',
     'Scenes',
-    'Utility network',
-    'Augmented reality'
+    'Routing and Logistics',
+    'Search and Query',
+    'Utility Networks',
+    'Visualization'
 }
 # endregion
 

--- a/Scripts/CI/common.py
+++ b/Scripts/CI/common.py
@@ -377,6 +377,19 @@ class Metadata:
 
         return json.dumps(data, indent=4, sort_keys=True)
 
+    def check_category(self) -> None:
+        """
+        Check if
+        1. metadata contains a category.
+        2. category is valid.
+        
+        :return: None. Throws if exception occurs.
+        """
+        if not self.category:
+            raise Exception(f'Error category - Missing category.')
+        elif self.category not in categories:
+            raise Exception(f'Error category - Invalid category - "{self.category}".')
+
 
 class Readme:
     essential_headers = {

--- a/Scripts/CI/metadata_checker.py
+++ b/Scripts/CI/metadata_checker.py
@@ -78,6 +78,12 @@ def run_check(path: str) -> None:
         diff = '\n'.join(unified_diff(expected, actual))
         raise Exception(f'Error inconsistent metadata - {path} - {diff}')
 
+    # 4. Check category.
+    try:
+        checker.check_category()
+    except Exception as err:
+        raise Exception(f'{checker.folder_path} - {err}')
+
 
 def all_samples(path: str):
     """


### PR DESCRIPTION
## Description

This PR updates the CI style check to ensure the category in the metadata is valid.

## Linked Issue(s)

Closes #337 

## How To Test

- Change the category in a sample's metadata to an invalid value.
- Run the style check on sample to ensure the check works.
    - E.g., `python3 Scripts/CI/metadata_checker.py -s "Shared/Samples/Display map/"`.

