### PR TITLE
[Update] Remove `DowloadPortalItemData` script GCD

### DIFF
--- a/Scripts/DowloadPortalItemData.swift
+++ b/Scripts/DowloadPortalItemData.swift
@@ -259,15 +259,15 @@ await withTaskGroup(of: Void.self) { group in
         fflush(stdout)
         group.addTask {
             do {
-                let downloadName = try await downloadFile(
+                guard let downloadName = try await downloadFile(
                     from: portalItem.dataURL,
                     to: destinationURL
-                )
+                ) else { return }
                 print("note: Downloaded item: \(portalItem.identifier)")
                 fflush(stdout)
                 
-                await MainActor.run {
-                    downloadedItems[portalItem.identifier] = downloadName
+                _ = await MainActor.run {
+                    downloadedItems.updateValue(downloadName, forKey: portalItem.identifier)
                 }
             } catch {
                 print("error: Error downloading item \(portalItem.identifier): \(error.localizedDescription)")

--- a/Scripts/DowloadPortalItemData.swift
+++ b/Scripts/DowloadPortalItemData.swift
@@ -230,16 +230,17 @@ var downloadedItems = previousDownloadedItems
 
 await withTaskGroup(of: Void.self) { group in
     for portalItem in portalItems {
-        // Checks to see if an item is already downloaded.
-        guard downloadedItems[portalItem.identifier] == nil else {
-            print("note: Item already downloaded: \(portalItem.identifier)")
-            continue
-        }
-        
         let destinationURL = downloadDirectoryURL.appendingPathComponent(
             portalItem.identifier,
             isDirectory: true
         )
+        
+        // Checks to see if an item needs downloading.
+        guard downloadedItems[portalItem.identifier] == nil ||
+                !FileManager.default.fileExists(atPath: destinationURL.path) else {
+            print("note: Item already downloaded: \(portalItem.identifier)")
+            continue
+        }
         
         // Deletes the directory when the item is not in the plist.
         try? FileManager.default.removeItem(at: destinationURL)

--- a/Scripts/DowloadPortalItemData.swift
+++ b/Scripts/DowloadPortalItemData.swift
@@ -126,61 +126,47 @@ func uncompressArchive(at sourceURL: URL, to destinationURL: URL) throws {
     process.waitUntilExit()
 }
 
-/// Downloads file from portal and write the file(s) to appropriate path(s).
+/// Downloads a file from a given portal and writes it to a given path.
 /// - Parameters:
 ///   - sourceURL: The portal URL to the resource.
-///   - downloadDirectory: The directory that stores downloaded data.
-///   - completion: A closure to handle the results.
-func downloadFile(at sourceURL: URL, to downloadDirectory: URL, completion: @escaping (Result<URL, Error>) -> Void) {
-    let downloadTaskCompleted = { (temporaryURL: URL?, response: URLResponse?, error: Error?) in
-        if let temporaryURL = temporaryURL,
-           let response = response,
-           let suggestedFilename = response.suggestedFilename {
-            do {
-                let downloadName: String
-                let isArchive = (suggestedFilename as NSString).pathExtension == "zip"
-                // If the downloaded file is an archive and contains
-                //   - 1 file, use the name of that file.
-                //   - multiple files, use the suggested filename (*.zip).
-                // If it is not an archive, use the server suggested filename.
-                if isArchive {
-                    let count = try count(ofFilesInArchiveAt: temporaryURL)
-                    if count == 1 {
-                        downloadName = try name(ofFileInArchiveAt: temporaryURL)
-                    } else {
-                        downloadName = suggestedFilename
-                    }
-                } else {
-                    downloadName = suggestedFilename
-                }
-                
-                let downloadURL = downloadDirectory.appendingPathComponent(downloadName, isDirectory: false)
-                
-                if FileManager.default.fileExists(atPath: downloadURL.path) {
-                    try FileManager.default.removeItem(at: downloadURL)
-                }
-                
-                if isArchive {
-                    let extractURL = downloadURL.pathExtension == "zip"
-                        // Uncompresses to directory named after archive.
-                        ? downloadURL.deletingPathExtension()
-                        // Uncompresses to appropriate subdirectory.
-                        : downloadURL.deletingLastPathComponent()
-                    try uncompressArchive(at: temporaryURL, to: extractURL)
-                } else {
-                    try FileManager.default.moveItem(at: temporaryURL, to: downloadURL)
-                }
-                
-                completion(.success(downloadURL))
-            } catch {
-                completion(.failure(error))
-            }
-        } else if let error = error {
-            completion(.failure(error))
+///   - downloadDirectory: The directory to store the downloaded data in.
+/// - Throws: Exceptions when downloading, naming, uncompressing, and moving the file.
+/// - Returns: The name of the downloaded file.
+func downloadFile(from sourceURL: URL, to downloadDirectory: URL) async throws -> String? {
+    let (temporaryURL, response) = try await URLSession.shared.download(from: sourceURL)
+    
+    guard let suggestedFilename = response.suggestedFilename else { return nil }
+    let isArchive = NSString(string: suggestedFilename).pathExtension == "zip"
+    
+    let downloadName: String = try {
+        // If the downloaded file is an archive and contains
+        //   - 1 file, use the name of that file.
+        //   - multiple files, use the server suggested filename (*.zip).
+        // If it is not an archive, use the server suggested filename.
+        if isArchive,
+           try count(ofFilesInArchiveAt: temporaryURL) == 1 {
+            return try name(ofFileInArchiveAt: temporaryURL)
+        } else {
+            return suggestedFilename
         }
+    }()
+    let downloadURL = downloadDirectory.appendingPathComponent(downloadName, isDirectory: false)
+    
+    try? FileManager.default.removeItem(at: downloadURL)
+    
+    if isArchive {
+        let extractURL = downloadURL.pathExtension == "zip"
+        // Uncompresses to directory named after archive.
+        ? downloadURL.deletingPathExtension()
+        // Uncompresses to appropriate subdirectory.
+        : downloadURL.deletingLastPathComponent()
+        
+        try uncompressArchive(at: temporaryURL, to: extractURL)
+    } else {
+        try FileManager.default.moveItem(at: temporaryURL, to: downloadURL)
     }
-    let downloadTask = URLSession.shared.downloadTask(with: sourceURL, completionHandler: downloadTaskCompleted)
-    downloadTask.resume()
+    
+    return downloadName
 }
 
 // MARK: Script Entry
@@ -242,45 +228,57 @@ let previousDownloadedItems: DownloadedItems = {
 }()
 var downloadedItems = previousDownloadedItems
 
-// Asynchronously downloads portal items.
-let dispatchGroup = DispatchGroup()
-
-for portalItem in portalItems {
-    // Checks to see if an item is already downloaded.
-    guard downloadedItems[portalItem.identifier] == nil else {
-        print("note: Item already downloaded: \(portalItem.identifier)")
-        continue
-    }
-    
-    let destinationURL = downloadDirectoryURL.appendingPathComponent(portalItem.identifier, isDirectory: true)
-    
-    // Deletes the directory when the item is not in the plist.
-    try? FileManager.default.removeItem(at: destinationURL)
-    
-    do {
-        // Creates an enclosing directory with portal item ID as its name.
-        try FileManager.default.createDirectory(at: destinationURL, withIntermediateDirectories: false)
-    } catch {
-        print("error: Error creating download directory: \(error.localizedDescription)")
-        exit(1)
-    }
-    
-    print("note: Downloading item \(portalItem.identifier)")
-    fflush(stdout)
-    dispatchGroup.enter()
-    downloadFile(at: portalItem.dataURL, to: destinationURL) { result in
-        switch result {
-        case .success(let url):
-            downloadedItems[portalItem.identifier] = url.lastPathComponent
-            dispatchGroup.leave()
-        case .failure(let error):
-            print("error: Error downloading item \(portalItem.identifier): \(error.localizedDescription)")
-            URLSession.shared.invalidateAndCancel()
+await withTaskGroup(of: (Identifier, Filename?).self) { group in
+    for portalItem in portalItems {
+        // Checks to see if an item is already downloaded.
+        guard downloadedItems[portalItem.identifier] == nil else {
+            print("note: Item already downloaded: \(portalItem.identifier)")
+            continue
+        }
+        
+        let destinationURL = downloadDirectoryURL.appendingPathComponent(
+            portalItem.identifier,
+            isDirectory: true
+        )
+        
+        // Deletes the directory when the item is not in the plist.
+        try? FileManager.default.removeItem(at: destinationURL)
+        
+        do {
+            // Creates an enclosing directory with the portal item ID as its name.
+            try FileManager.default.createDirectory(
+                at: destinationURL,
+                withIntermediateDirectories: false
+            )
+        } catch {
+            print("error: Error creating download directory: \(error.localizedDescription)")
             exit(1)
         }
+        
+        print("note: Downloading item \(portalItem.identifier)")
+        fflush(stdout)
+        group.addTask {
+            do {
+                let downloadName = try await downloadFile(
+                    from: portalItem.dataURL,
+                    to: destinationURL
+                )
+                return (portalItem.identifier, downloadName)
+            } catch {
+                print("error: Error downloading item \(portalItem.identifier): \(error.localizedDescription)")
+                URLSession.shared.invalidateAndCancel()
+                exit(1)
+            }
+        }
+    }
+    
+    for await (identifier, filename) in group {
+        downloadedItems[identifier] = filename
+        
+        print("note: Downloaded item: \(identifier)")
+        fflush(stdout)
     }
 }
-dispatchGroup.wait()
 
 // Updates the downloaded items property list record if needed.
 if downloadedItems != previousDownloadedItems {

--- a/Scripts/DowloadPortalItemData.swift
+++ b/Scripts/DowloadPortalItemData.swift
@@ -228,7 +228,7 @@ let previousDownloadedItems: DownloadedItems = {
 }()
 var downloadedItems = previousDownloadedItems
 
-await withTaskGroup(of: (Identifier, Filename?).self) { group in
+await withTaskGroup(of: Void.self) { group in
     for portalItem in portalItems {
         // Checks to see if an item is already downloaded.
         guard downloadedItems[portalItem.identifier] == nil else {
@@ -263,20 +263,18 @@ await withTaskGroup(of: (Identifier, Filename?).self) { group in
                     from: portalItem.dataURL,
                     to: destinationURL
                 )
-                return (portalItem.identifier, downloadName)
+                print("note: Downloaded item: \(portalItem.identifier)")
+                fflush(stdout)
+                
+                await MainActor.run {
+                    downloadedItems[portalItem.identifier] = downloadName
+                }
             } catch {
                 print("error: Error downloading item \(portalItem.identifier): \(error.localizedDescription)")
                 URLSession.shared.invalidateAndCancel()
                 exit(1)
             }
         }
-    }
-    
-    for await (identifier, filename) in group {
-        downloadedItems[identifier] = filename
-        
-        print("note: Downloaded item: \(identifier)")
-        fflush(stdout)
     }
 }
 

--- a/Scripts/DowloadPortalItemData.swift
+++ b/Scripts/DowloadPortalItemData.swift
@@ -126,7 +126,7 @@ func uncompressArchive(at sourceURL: URL, to destinationURL: URL) throws {
     process.waitUntilExit()
 }
 
-/// Downloads a file from a given portal and writes it to a given path.
+/// Downloads a file from a URL to a given location.
 /// - Parameters:
 ///   - sourceURL: The portal URL to the resource.
 ///   - downloadDirectory: The directory to store the downloaded data in.

--- a/Scripts/DowloadPortalItemData.swift
+++ b/Scripts/DowloadPortalItemData.swift
@@ -256,8 +256,6 @@ await withTaskGroup(of: Void.self) { group in
             exit(1)
         }
         
-        print("note: Downloading item \(portalItem.identifier)")
-        fflush(stdout)
         group.addTask {
             do {
                 guard let downloadName = try await downloadFile(


### PR DESCRIPTION
## Description

This PR updates the `DowloadPortalItemData` script in the Sample Viewer to use Swift concurrency instead of GCD.
URL to script: [DowloadPortalItemData.swift](https://github.com/Esri/arcgis-maps-sdk-swift-samples/blob/Caleb/Update-DownloadPortalItemScriptAsync/Scripts/DowloadPortalItemData.swift)

Follow up PR to #361.

## Linked Issue(s)

- `swift/issues/4892`

## How To Test

- Delete the `Portal Data` folder or remove entires from the `.downloaded_items.plist`.
- Build the project and view the Log to ensure the files downloaded as expected.
- Open some sample using the resources to ensure they don't crash, e.g., `Animate 3d graphic`.
