### PR TITLE
[Update] Remove iOS 15 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This repository contains Swift sample code demonstrating the capabilities of the
 * [ArcGIS Maps SDK for Swift Toolkit](https://github.com/Esri/arcgis-maps-sdk-swift-toolkit) 200.3 (or newer)
 * Xcode 15.0 (or newer)
 
-The *ArcGIS Maps SDK for Swift Samples app* has a *Target SDK* version of *15.0*, meaning that it can run on devices with *iOS 15.0* or newer.
+The *ArcGIS Maps SDK for Swift Samples app* has a *Target SDK* version of *16.0*, meaning that it can run on devices with *iOS 16.0* or newer.
 
 ## Building Samples Using Swift Package Manager
 

--- a/Samples.xcodeproj/project.pbxproj
+++ b/Samples.xcodeproj/project.pbxproj
@@ -2843,8 +2843,8 @@
 				CURRENT_PROJECT_VERSION = 1;
 				EMBED_ASSET_PACKS_IN_PRODUCT_BUNDLE = YES;
 				INFOPLIST_FILE = "$(SRCROOT)/iOS/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
-				"IPHONEOS_DEPLOYMENT_TARGET[sdk=macosx*]" = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=macosx*]" = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2874,8 +2874,8 @@
 				DEVELOPMENT_TEAM = "";
 				EMBED_ASSET_PACKS_IN_PRODUCT_BUNDLE = YES;
 				INFOPLIST_FILE = "$(SRCROOT)/iOS/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
-				"IPHONEOS_DEPLOYMENT_TARGET[sdk=macosx*]" = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=macosx*]" = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Shared/Samples/Add dynamic entity layer/AddDynamicEntityLayerView.SettingsView.swift
+++ b/Shared/Samples/Add dynamic entity layer/AddDynamicEntityLayerView.SettingsView.swift
@@ -27,15 +27,8 @@ extension AddDynamicEntityLayerView {
         @Binding var calloutPlacement: CalloutPlacement?
         
         var body: some View {
-            if #available(iOS 16, *) {
-                NavigationStack {
-                    root
-                }
-            } else {
-                NavigationView {
-                    root
-                }
-                .navigationViewStyle(.stack)
+            NavigationStack {
+                root
             }
         }
         

--- a/Shared/Samples/Add dynamic entity layer/AddDynamicEntityLayerView.swift
+++ b/Shared/Samples/Add dynamic entity layer/AddDynamicEntityLayerView.swift
@@ -95,23 +95,16 @@ struct AddDynamicEntityLayerView: View {
         }
         let settingsView = SettingsView(model: model, calloutPlacement: $placement)
         
-        if #available(iOS 16, *) {
-            button
-                .popover(isPresented: $isShowingSettings, arrowEdge: .bottom) {
-                    settingsView
-                        .presentationDetents([.fraction(0.5)])
+        button
+            .popover(isPresented: $isShowingSettings, arrowEdge: .bottom) {
+                settingsView
+                    .presentationDetents([.fraction(0.5)])
 #if targetEnvironment(macCatalyst)
-                        .frame(minWidth: 300, minHeight: 270)
+                    .frame(minWidth: 300, minHeight: 270)
 #else
-                        .frame(minWidth: 320, minHeight: 390)
+                    .frame(minWidth: 320, minHeight: 390)
 #endif
-                }
-        } else {
-            button
-                .sheet(isPresented: $isShowingSettings, detents: [.medium]) {
-                    settingsView
-                }
-        }
+            }
     }
 }
 

--- a/Shared/Samples/Add dynamic entity layer/AddDynamicEntityLayerView.swift
+++ b/Shared/Samples/Add dynamic entity layer/AddDynamicEntityLayerView.swift
@@ -109,7 +109,7 @@ struct AddDynamicEntityLayerView: View {
 }
 
 #Preview {
-    NavigationView {
+    NavigationStack {
         AddDynamicEntityLayerView()
     }
 }

--- a/Shared/Samples/Add features with contingent values/AddFeaturesWithContingentValuesView.swift
+++ b/Shared/Samples/Add features with contingent values/AddFeaturesWithContingentValuesView.swift
@@ -85,7 +85,7 @@ struct AddFeaturesWithContingentValuesView: View {
                 Button("") {}
                     .opacity(0)
                     .sheet(isPresented: $addFeatureSheetIsPresented, detents: [.medium]) {
-                        NavigationView {
+                        NavigationStack {
                             AddFeatureView(model: model)
                                 .navigationTitle("Add Bird Nest")
                                 .navigationBarTitleDisplayMode(.inline)
@@ -104,7 +104,6 @@ struct AddFeaturesWithContingentValuesView: View {
                                     }
                                 }
                         }
-                        .navigationViewStyle(.stack)
                     }
                     .task(id: addFeatureSheetIsPresented) {
                         // When the sheet closes, remove the feature if it is invalid.

--- a/Shared/Samples/Analyze network with subnetwork trace/AnalyzeNetworkWithSubnetworkTraceView.swift
+++ b/Shared/Samples/Analyze network with subnetwork trace/AnalyzeNetworkWithSubnetworkTraceView.swift
@@ -86,14 +86,8 @@ struct AnalyzeNetworkWithSubnetworkTraceView: View {
                 }
             })
             .sheet(isPresented: $isConditionMenuPresented) {
-                if #available(iOS 16, *) {
-                    NavigationStack {
-                        conditionMenu
-                    }
-                } else {
-                    NavigationView {
-                        conditionMenu
-                    }
+                NavigationStack {
+                    conditionMenu
                 }
             }
             .overlay(alignment: .center) { loadingView }

--- a/Shared/Samples/Analyze network with subnetwork trace/AnalyzeNetworkWithSubnetworkTraceView.swift
+++ b/Shared/Samples/Analyze network with subnetwork trace/AnalyzeNetworkWithSubnetworkTraceView.swift
@@ -237,7 +237,6 @@ struct AnalyzeNetworkWithSubnetworkTraceView: View {
                 }
             }
         }
-        .navigationViewStyle(.stack)
     }
     
     @ViewBuilder var attributesView: some View {
@@ -307,7 +306,7 @@ private extension UtilityNetworkAttributeComparison.Operator {
 }
 
 #Preview {
-    NavigationView {
+    NavigationStack {
         AnalyzeNetworkWithSubnetworkTraceView()
     }
 }

--- a/Shared/Samples/Animate 3D graphic/Animate3DGraphicView.SettingsView.swift
+++ b/Shared/Samples/Animate 3D graphic/Animate3DGraphicView.SettingsView.swift
@@ -50,7 +50,7 @@ extension Animate3DGraphicView {
         
         /// The view content of the settings sheet.
         private var settingsContent: some View {
-            NavigationView {
+            NavigationStack {
                 content
                     .navigationTitle("\(label) Settings")
                     .navigationBarTitleDisplayMode(.inline)
@@ -62,7 +62,6 @@ extension Animate3DGraphicView {
                         }
                     }
             }
-            .navigationViewStyle(.stack)
         }
     }
 }

--- a/Shared/Samples/Animate 3D graphic/Animate3DGraphicView.SettingsView.swift
+++ b/Shared/Samples/Animate 3D graphic/Animate3DGraphicView.SettingsView.swift
@@ -36,23 +36,16 @@ extension Animate3DGraphicView {
                 isPresented = true
             }
             
-            if #available(iOS 16, *) {
-                button
-                    .popover(isPresented: $isPresented, arrowEdge: .bottom) {
-                        settingsContent
-                            .presentationDetents([.fraction(0.5)])
+            button
+                .popover(isPresented: $isPresented, arrowEdge: .bottom) {
+                    settingsContent
+                        .presentationDetents([.fraction(0.5)])
 #if targetEnvironment(macCatalyst)
-                            .frame(minWidth: 300, minHeight: 270)
+                        .frame(minWidth: 300, minHeight: 270)
 #else
-                            .frame(minWidth: 320, minHeight: 390)
+                        .frame(minWidth: 320, minHeight: 390)
 #endif
-                    }
-            } else {
-                button
-                    .sheet(isPresented: $isPresented) {
-                        settingsContent
-                    }
-            }
+                }
         }
         
         /// The view content of the settings sheet.

--- a/Shared/Samples/Augment reality to navigate route/AugmentRealityToNavigateRouteView.swift
+++ b/Shared/Samples/Augment reality to navigate route/AugmentRealityToNavigateRouteView.swift
@@ -173,7 +173,9 @@ struct AugmentRealityToNavigateRouteView: View {
         )
         guard let routeTracker else { return }
         
-        routeTracker.voiceGuidanceUnitSystem = Locale.current.usesMetricSystem ? .metric : .imperial
+        routeTracker.voiceGuidanceUnitSystem = Locale.current.measurementSystem == .us
+        ? .imperial
+        : .metric
         
         routeDataModel.routeTracker = routeTracker
         

--- a/Shared/Samples/Augment reality to show hidden infrastructure/AugmentRealityToShowHiddenInfrastructureView.swift
+++ b/Shared/Samples/Augment reality to show hidden infrastructure/AugmentRealityToShowHiddenInfrastructureView.swift
@@ -39,7 +39,7 @@ struct AugmentRealityToShowHiddenInfrastructureView: View {
     @State private var error: Error?
     
     var body: some View {
-        NavigationView {
+        NavigationStack {
             MapView(map: model.map, graphicsOverlays: [model.pipesGraphicsOverlay])
                 .locationDisplay(model.locationDisplay)
                 .geometryEditor(model.geometryEditor)

--- a/Shared/Samples/Change map view background/ChangeMapViewBackgroundView.swift
+++ b/Shared/Samples/Change map view background/ChangeMapViewBackgroundView.swift
@@ -40,7 +40,7 @@ struct ChangeMapViewBackgroundView: View {
 }
 
 #Preview {
-    NavigationView {
+    NavigationStack {
         ChangeMapViewBackgroundView()
     }
 }

--- a/Shared/Samples/Clip geometry/ClipGeometryView.swift
+++ b/Shared/Samples/Clip geometry/ClipGeometryView.swift
@@ -176,7 +176,7 @@ private extension Envelope {
 }
 
 #Preview {
-    NavigationView {
+    NavigationStack {
         ClipGeometryView()
     }
 }

--- a/Shared/Samples/Configure clusters/ConfigureClustersView.SettingsView.swift
+++ b/Shared/Samples/Configure clusters/ConfigureClustersView.SettingsView.swift
@@ -32,7 +32,7 @@ extension ConfigureClustersView {
         @State private var selectedMaxScale = 0
         
         var body: some View {
-            NavigationView {
+            NavigationStack {
                 Form {
                     Section("Cluster Labels Visibility") {
                         Toggle("Show Labels", isOn: $model.showsLabels)
@@ -76,7 +76,6 @@ extension ConfigureClustersView {
                     }
                 }
             }
-            .navigationViewStyle(.stack)
         }
     }
 }

--- a/Shared/Samples/Configure clusters/ConfigureClustersView.swift
+++ b/Shared/Samples/Configure clusters/ConfigureClustersView.swift
@@ -75,7 +75,7 @@ struct ConfigureClustersView: View {
 }
 
 #Preview {
-    NavigationView {
+    NavigationStack {
         ConfigureClustersView()
     }
 }

--- a/Shared/Samples/Create and edit geometries/CreateAndEditGeometriesView.swift
+++ b/Shared/Samples/Create and edit geometries/CreateAndEditGeometriesView.swift
@@ -365,7 +365,7 @@ class GeometryEditorMenuModel: ObservableObject {
 }
 
 #Preview {
-    NavigationView {
+    NavigationStack {
         CreateAndEditGeometriesView()
     }
 }

--- a/Shared/Samples/Create and save KML file/CreateAndSaveKMLView.swift
+++ b/Shared/Samples/Create and save KML file/CreateAndSaveKMLView.swift
@@ -137,7 +137,7 @@ private extension UTType {
 }
 
 #Preview {
-    NavigationView {
+    NavigationStack {
         CreateAndSaveKMLView()
     }
 }

--- a/Shared/Samples/Create buffers around points/CreateBuffersAroundPointsView.swift
+++ b/Shared/Samples/Create buffers around points/CreateBuffersAroundPointsView.swift
@@ -288,7 +288,7 @@ private extension CreateBuffersAroundPointsView {
 }
 
 #Preview {
-    NavigationView {
+    NavigationStack {
         CreateBuffersAroundPointsView()
     }
 }

--- a/Shared/Samples/Create convex hull around geometries/CreateConvexHullAroundGeometriesView.swift
+++ b/Shared/Samples/Create convex hull around geometries/CreateConvexHullAroundGeometriesView.swift
@@ -143,7 +143,7 @@ private extension Geometry {
 }
 
 #Preview {
-    NavigationView {
+    NavigationStack {
         CreateConvexHullAroundGeometriesView()
     }
 }

--- a/Shared/Samples/Create convex hull around points/CreateConvexHullAroundPointsView.swift
+++ b/Shared/Samples/Create convex hull around points/CreateConvexHullAroundPointsView.swift
@@ -130,7 +130,7 @@ private extension CreateConvexHullAroundPointsView {
 }
 
 #Preview {
-    NavigationView {
+    NavigationStack {
         CreateConvexHullAroundPointsView()
     }
 }

--- a/Shared/Samples/Create load report/CreateLoadReportView.swift
+++ b/Shared/Samples/Create load report/CreateLoadReportView.swift
@@ -55,7 +55,7 @@ struct CreateLoadReportView: View {
 }
 
 #Preview {
-    NavigationView {
+    NavigationStack {
         CreateLoadReportView()
     }
 }

--- a/Shared/Samples/Create mobile geodatabase/CreateMobileGeodatabaseView.swift
+++ b/Shared/Samples/Create mobile geodatabase/CreateMobileGeodatabaseView.swift
@@ -118,7 +118,7 @@ private extension CreateMobileGeodatabaseView {
     
     /// The list of features in the feature table.
     var tableList: some View {
-        NavigationView {
+        NavigationStack {
             List {
                 Section("OID and Collection Timestamp") {
                     ForEach(model.features, id: \.self) { feature in
@@ -140,7 +140,6 @@ private extension CreateMobileGeodatabaseView {
                 }
             }
         }
-        .navigationViewStyle(.stack)
     }
 }
 
@@ -166,7 +165,7 @@ private extension FormatStyle where Self == Date.VerbatimFormatStyle {
 }
 
 #Preview {
-    NavigationView {
+    NavigationStack {
         CreateMobileGeodatabaseView()
     }
 }

--- a/Shared/Samples/Create mobile geodatabase/CreateMobileGeodatabaseView.swift
+++ b/Shared/Samples/Create mobile geodatabase/CreateMobileGeodatabaseView.swift
@@ -104,23 +104,16 @@ private extension CreateMobileGeodatabaseView {
             tableSheetIsShowing = true
         }
         
-        if #available(iOS 16, *) {
-            button
-                .popover(isPresented: $tableSheetIsShowing, arrowEdge: .bottom) {
-                    tableList
-                        .presentationDetents([.fraction(0.5)])
+        button
+            .popover(isPresented: $tableSheetIsShowing, arrowEdge: .bottom) {
+                tableList
+                    .presentationDetents([.fraction(0.5)])
 #if targetEnvironment(macCatalyst)
-                        .frame(minWidth: 300, minHeight: 270)
+                    .frame(minWidth: 300, minHeight: 270)
 #else
-                        .frame(minWidth: 320, minHeight: 390)
+                    .frame(minWidth: 320, minHeight: 390)
 #endif
-                }
-        } else {
-            button
-                .sheet(isPresented: $tableSheetIsShowing) {
-                    tableList
-                }
-        }
+            }
     }
     
     /// The list of features in the feature table.

--- a/Shared/Samples/Create symbol styles from web styles/CreateSymbolStylesFromWebStylesView.swift
+++ b/Shared/Samples/Create symbol styles from web styles/CreateSymbolStylesFromWebStylesView.swift
@@ -67,7 +67,7 @@ struct CreateSymbolStylesFromWebStylesView: View {
     
     /// The legend list that describes what each symbol represents.
     private var legendList: some View {
-        NavigationView {
+        NavigationStack {
             List(legendItems, id: \.name) { legendItem in
                 Label {
                     Text(legendItem.name)
@@ -85,7 +85,6 @@ struct CreateSymbolStylesFromWebStylesView: View {
                 }
             }
         }
-        .navigationViewStyle(.stack)
         .frame(idealWidth: 320, idealHeight: 428)
     }
 }
@@ -278,7 +277,7 @@ private extension URL {
 }
 
 #Preview {
-    NavigationView {
+    NavigationStack {
         CreateSymbolStylesFromWebStylesView()
     }
 }

--- a/Shared/Samples/Cut geometry/CutGeometryView.swift
+++ b/Shared/Samples/Cut geometry/CutGeometryView.swift
@@ -154,7 +154,7 @@ private extension Geometry {
 }
 
 #Preview {
-    NavigationView {
+    NavigationStack {
         CutGeometryView()
     }
 }

--- a/Shared/Samples/Densify and generalize geometry/DensifyAndGeneralizeGeometryView.swift
+++ b/Shared/Samples/Densify and generalize geometry/DensifyAndGeneralizeGeometryView.swift
@@ -182,7 +182,7 @@ extension DensifyAndGeneralizeGeometryView {
 }
 
 #Preview {
-    NavigationView {
+    NavigationStack {
         DensifyAndGeneralizeGeometryView()
     }
 }

--- a/Shared/Samples/Display clusters/DisplayClustersView.swift
+++ b/Shared/Samples/Display clusters/DisplayClustersView.swift
@@ -99,7 +99,7 @@ struct DisplayClustersView: View {
 }
 
 #Preview {
-    NavigationView {
+    NavigationStack {
         DisplayClustersView()
     }
 }

--- a/Shared/Samples/Display content of utility network container/DisplayContentOfUtilityNetworkContainerView.swift
+++ b/Shared/Samples/Display content of utility network container/DisplayContentOfUtilityNetworkContainerView.swift
@@ -141,7 +141,7 @@ struct DisplayContentOfUtilityNetworkContainerView: View {
     
     /// The legends list.
     private var sheetContent: some View {
-        NavigationView {
+        NavigationStack {
             List(model.legendItems, id: \.name) { legend in
                 Label {
                     Text(legend.name)
@@ -159,13 +159,12 @@ struct DisplayContentOfUtilityNetworkContainerView: View {
                 }
             }
         }
-        .navigationViewStyle(.stack)
         .frame(idealWidth: 320, idealHeight: 428)
     }
 }
 
 #Preview {
-    NavigationView {
+    NavigationStack {
         DisplayContentOfUtilityNetworkContainerView()
     }
 }

--- a/Shared/Samples/Display map from portal item/DisplayMapFromPortalItemView.swift
+++ b/Shared/Samples/Display map from portal item/DisplayMapFromPortalItemView.swift
@@ -109,7 +109,7 @@ private extension PortalItem.ID {
 }
 
 #Preview {
-    NavigationView {
+    NavigationStack {
         DisplayMapFromPortalItemView()
     }
 }

--- a/Shared/Samples/Download preplanned map area/DownloadPreplannedMapAreaView.MapPicker.swift
+++ b/Shared/Samples/Download preplanned map area/DownloadPreplannedMapAreaView.MapPicker.swift
@@ -24,7 +24,7 @@ extension DownloadPreplannedMapAreaView {
         @ObservedObject var model: Model
         
         var body: some View {
-            NavigationView {
+            NavigationStack {
                 List {
                     Section {
                         Picker("Web Maps (Online)", selection: $model.selectedMap) {
@@ -71,7 +71,6 @@ extension DownloadPreplannedMapAreaView {
                     }
                 }
             }
-            .navigationViewStyle(.stack)
         }
     }
     

--- a/Shared/Samples/Download preplanned map area/DownloadPreplannedMapAreaView.swift
+++ b/Shared/Samples/Download preplanned map area/DownloadPreplannedMapAreaView.swift
@@ -85,7 +85,7 @@ private extension Viewpoint {
 }
 
 #Preview {
-    NavigationView {
+    NavigationStack {
         DownloadPreplannedMapAreaView()
     }
 }

--- a/Shared/Samples/Download vector tiles to local cache/DownloadVectorTilesToLocalCacheView.swift
+++ b/Shared/Samples/Download vector tiles to local cache/DownloadVectorTilesToLocalCacheView.swift
@@ -127,7 +127,7 @@ struct DownloadVectorTilesToLocalCacheView: View {
                                 // Removes the temporary files when the cover is dismissed.
                                 model.removeTemporaryFiles()
                             } content: {
-                                NavigationView {
+                                NavigationStack {
                                     MapView(map: model.downloadedVectorTilesMap)
                                         .navigationTitle("Vector tile package")
                                         .navigationBarTitleDisplayMode(.inline)
@@ -314,7 +314,7 @@ private extension Envelope {
 }
 
 #Preview {
-    NavigationView {
+    NavigationStack {
         DownloadVectorTilesToLocalCacheView()
     }
 }

--- a/Shared/Samples/Filter features in scene/FilterFeaturesInSceneView.swift
+++ b/Shared/Samples/Filter features in scene/FilterFeaturesInSceneView.swift
@@ -236,7 +236,7 @@ private extension Viewpoint {
 }
 
 #Preview {
-    NavigationView {
+    NavigationStack {
         FilterFeaturesInSceneView()
     }
 }

--- a/Shared/Samples/Find closest facility from point/FindClosestFacilityFromPointView.swift
+++ b/Shared/Samples/Find closest facility from point/FindClosestFacilityFromPointView.swift
@@ -230,7 +230,7 @@ private extension URL {
 }
 
 #Preview {
-    NavigationView {
+    NavigationStack {
         FindClosestFacilityFromPointView()
     }
 }

--- a/Shared/Samples/Find route around barriers/FindRouteAroundBarriersView.Views.swift
+++ b/Shared/Samples/Find route around barriers/FindRouteAroundBarriersView.Views.swift
@@ -98,7 +98,7 @@ extension FindRouteAroundBarriersView {
         
         /// The content to display in the sheet with a title and done button.
         @ViewBuilder private var sheetContent: some View {
-            NavigationView {
+            NavigationStack {
                 content()
                     .navigationTitle(title)
                     .navigationBarTitleDisplayMode(.inline)
@@ -110,7 +110,6 @@ extension FindRouteAroundBarriersView {
                         }
                     }
             }
-            .navigationViewStyle(.stack)
         }
     }
 }

--- a/Shared/Samples/Find route around barriers/FindRouteAroundBarriersView.Views.swift
+++ b/Shared/Samples/Find route around barriers/FindRouteAroundBarriersView.Views.swift
@@ -75,23 +75,16 @@ extension FindRouteAroundBarriersView {
         @State private var sheetIsShowing = false
         
         var body: some View {
-            if #available(iOS 16, *) {
-                button
-                    .popover(isPresented: $sheetIsShowing, arrowEdge: .bottom) {
-                        sheetContent
-                            .presentationDetents([.fraction(0.5)])
+            button
+                .popover(isPresented: $sheetIsShowing, arrowEdge: .bottom) {
+                    sheetContent
+                        .presentationDetents([.fraction(0.5)])
 #if targetEnvironment(macCatalyst)
-                            .frame(minWidth: 300, minHeight: 270)
+                        .frame(minWidth: 300, minHeight: 270)
 #else
-                            .frame(minWidth: 320, minHeight: 390)
+                        .frame(minWidth: 320, minHeight: 390)
 #endif
-                    }
-            } else {
-                button
-                    .sheet(isPresented: $sheetIsShowing, detents: [.medium]) {
-                        sheetContent
-                    }
-            }
+                }
         }
         
         /// The button that presents the sheet.

--- a/Shared/Samples/Find route around barriers/FindRouteAroundBarriersView.swift
+++ b/Shared/Samples/Find route around barriers/FindRouteAroundBarriersView.swift
@@ -151,7 +151,7 @@ struct FindRouteAroundBarriersView: View {
 }
 
 #Preview {
-    NavigationView {
+    NavigationStack {
         FindRouteAroundBarriersView()
     }
 }

--- a/Shared/Samples/Find route/FindRouteView.swift
+++ b/Shared/Samples/Find route/FindRouteView.swift
@@ -65,7 +65,7 @@ struct FindRouteView: View {
                     }
                     .disabled(model.directions.isEmpty)
                     .popover(isPresented: $isShowingDirections) {
-                        NavigationView {
+                        NavigationStack {
                             List(model.directions, id: \.text) { directionManeuver in
                                 Text(directionManeuver.text)
                             }
@@ -79,7 +79,6 @@ struct FindRouteView: View {
                                 }
                             }
                         }
-                        .navigationViewStyle(.stack)
                         .frame(idealWidth: 320, idealHeight: 428)
                     }
                 }
@@ -217,7 +216,7 @@ private extension URL {
 }
 
 #Preview {
-    NavigationView {
+    NavigationStack {
         FindRouteView()
     }
 }

--- a/Shared/Samples/Generate offline map/GenerateOfflineMapView.swift
+++ b/Shared/Samples/Generate offline map/GenerateOfflineMapView.swift
@@ -245,7 +245,7 @@ private extension Envelope {
 }
 
 #Preview {
-    NavigationView {
+    NavigationStack {
         GenerateOfflineMapView()
     }
 }

--- a/Shared/Samples/Group layers together/GroupLayersTogetherView.swift
+++ b/Shared/Samples/Group layers together/GroupLayersTogetherView.swift
@@ -79,7 +79,7 @@ struct GroupLayersTogetherView: View {
     
     /// The list of group layers and their child layers that are currently added to the map.
     private var layersList: some View {
-        NavigationView {
+        NavigationStack {
             List {
                 ForEach(scene.operationalLayers as! [GroupLayer], id: \.name) { groupLayer in
                     GroupLayerListView(groupLayer: groupLayer)
@@ -95,7 +95,6 @@ struct GroupLayersTogetherView: View {
                 }
             }
         }
-        .navigationViewStyle(.stack)
         .frame(idealWidth: 320, idealHeight: 428)
     }
 }
@@ -180,7 +179,7 @@ private extension URL {
 }
 
 #Preview {
-    NavigationView {
+    NavigationStack {
         GroupLayersTogetherView()
     }
 }

--- a/Shared/Samples/Group layers together/GroupLayersTogetherView.swift
+++ b/Shared/Samples/Group layers together/GroupLayersTogetherView.swift
@@ -65,23 +65,16 @@ struct GroupLayersTogetherView: View {
             isShowingLayersSheet = true
         }
         
-        if #available(iOS 16, *) {
-            button
-                .popover(isPresented: $isShowingLayersSheet, arrowEdge: .bottom) {
-                    layersList
-                        .presentationDetents([.fraction(0.5)])
+        button
+            .popover(isPresented: $isShowingLayersSheet, arrowEdge: .bottom) {
+                layersList
+                    .presentationDetents([.fraction(0.5)])
 #if targetEnvironment(macCatalyst)
-                        .frame(minWidth: 300, minHeight: 270)
+                    .frame(minWidth: 300, minHeight: 270)
 #else
-                        .frame(minWidth: 320, minHeight: 390)
+                    .frame(minWidth: 320, minHeight: 390)
 #endif
-                }
-        } else {
-            button
-                .sheet(isPresented: $isShowingLayersSheet, detents: [.medium]) {
-                    layersList
-                }
-        }
+            }
     }
     
     /// The list of group layers and their child layers that are currently added to the map.

--- a/Shared/Samples/List spatial reference transformations/ListSpatialReferenceTransformationsView.swift
+++ b/Shared/Samples/List spatial reference transformations/ListSpatialReferenceTransformationsView.swift
@@ -46,7 +46,7 @@ struct ListSpatialReferenceTransformationsView: View {
                 }
                 .errorAlert(presentingError: $error)
             
-            NavigationView {
+            NavigationStack {
                 TransformationsList(model: model)
                     .navigationTitle("Transformations")
                     .navigationBarTitleDisplayMode(.inline)
@@ -56,7 +56,6 @@ struct ListSpatialReferenceTransformationsView: View {
                         }
                     }
             }
-            .navigationViewStyle(.stack)
         }
     }
     

--- a/Shared/Samples/Manage bookmarks/ManageBookmarksView.swift
+++ b/Shared/Samples/Manage bookmarks/ManageBookmarksView.swift
@@ -119,7 +119,7 @@ private extension ManageBookmarksView {
         @State private var bookmarks: [Bookmark] = []
         
         var body: some View {
-            NavigationView {
+            NavigationStack {
                 List {
                     ForEach(bookmarks, id: \.self) { bookmark in
                         Button {
@@ -154,12 +154,11 @@ private extension ManageBookmarksView {
                 .toolbar {
                     ToolbarItem(placement: .topBarTrailing) {
                         // Note: There is a bug in iOS 17 that prevents the `EditButton` from working
-                        // on the first tap when it is embedded in a `NavigationView` in a `popover`.
+                        // on the first tap when it is embedded in a `NavigationStack` in a `popover`.
                         EditButton()
                     }
                 }
             }
-            .navigationViewStyle(.stack)
             .onAppear {
                 bookmarks = map.bookmarks
             }
@@ -237,7 +236,7 @@ private extension View {
 }
 
 #Preview {
-    NavigationView {
+    NavigationStack {
         ManageBookmarksView()
     }
 }

--- a/Shared/Samples/Manage bookmarks/ManageBookmarksView.swift
+++ b/Shared/Samples/Manage bookmarks/ManageBookmarksView.swift
@@ -222,23 +222,16 @@ private extension View {
         @ViewBuilder content: @escaping () -> Content
     ) -> some View where Content: View {
         Group {
-            if #available(iOS 16, *) {
-                self
-                    .popover(isPresented: isPresented, arrowEdge: .bottom) {
-                        content()
-                            .presentationDetents([.medium, .large])
+            self
+                .popover(isPresented: isPresented, arrowEdge: .bottom) {
+                    content()
+                        .presentationDetents([.medium, .large])
 #if targetEnvironment(macCatalyst)
-                            .frame(minWidth: 300, minHeight: 270)
+                        .frame(minWidth: 300, minHeight: 270)
 #else
-                            .frame(minWidth: 320, minHeight: 390)
+                        .frame(minWidth: 320, minHeight: 390)
 #endif
-                    }
-            } else {
-                self
-                    .sheet(isPresented: isPresented, detents: [.medium, .large]) {
-                        content()
-                    }
-            }
+                }
         }
     }
 }

--- a/Shared/Samples/Manage operational layers/ManageOperationalLayersView.swift
+++ b/Shared/Samples/Manage operational layers/ManageOperationalLayersView.swift
@@ -160,7 +160,7 @@ private extension URL {
 }
 
 #Preview {
-    NavigationView {
+    NavigationStack {
         ManageOperationalLayersView()
     }
 }

--- a/Shared/Samples/Navigate route with rerouting/NavigateRouteWithReroutingView.Model.swift
+++ b/Shared/Samples/Navigate route with rerouting/NavigateRouteWithReroutingView.Model.swift
@@ -266,7 +266,9 @@ extension NavigateRouteWithReroutingView {
             try await routeTracker.enableRerouting(using: reroutingParameters)
             
             // Update the tracker's voice guidance unit system to the current locale's.
-            routeTracker.voiceGuidanceUnitSystem = Locale.current.usesMetricSystem ? .metric : .imperial
+            routeTracker.voiceGuidanceUnitSystem = Locale.current.measurementSystem == .us
+            ? .imperial
+            : .metric
             
             return routeTracker
         }

--- a/Shared/Samples/Navigate route/NavigateRouteView.swift
+++ b/Shared/Samples/Navigate route/NavigateRouteView.swift
@@ -204,7 +204,9 @@ private extension NavigateRouteView {
             routeTracker = RouteTracker(routeResult: routeResult, routeIndex: 0, skipsCoincidentStops: true)
             guard let routeTracker else { return }
             
-            routeTracker.voiceGuidanceUnitSystem = Locale.current.usesMetricSystem ? .metric : .imperial
+            routeTracker.voiceGuidanceUnitSystem = Locale.current.measurementSystem == .us
+            ? .imperial
+            : .metric
             
             // Gets the route and its geometry from the route result.
             guard let firstRoute = routeResult.routes.first,

--- a/Shared/Samples/Navigate route/NavigateRouteView.swift
+++ b/Shared/Samples/Navigate route/NavigateRouteView.swift
@@ -354,7 +354,7 @@ private extension URL {
 }
 
 #Preview {
-    NavigationView {
+    NavigationStack {
         NavigateRouteView()
     }
 }

--- a/Shared/Samples/Orbit camera around object/OrbitCameraAroundObjectView.swift
+++ b/Shared/Samples/Orbit camera around object/OrbitCameraAroundObjectView.swift
@@ -80,23 +80,16 @@ struct OrbitCameraAroundObjectView: View {
         }
         let settingsContent = SettingsView(model: model)
         
-        if #available(iOS 16, *) {
-            button
-                .popover(isPresented: $settingsSheetIsPresented, arrowEdge: .bottom) {
-                    settingsContent
-                        .presentationDetents([.fraction(0.5)])
+        button
+            .popover(isPresented: $settingsSheetIsPresented, arrowEdge: .bottom) {
+                settingsContent
+                    .presentationDetents([.fraction(0.5)])
 #if targetEnvironment(macCatalyst)
-                        .frame(minWidth: 300, minHeight: 270)
+                    .frame(minWidth: 300, minHeight: 270)
 #else
-                        .frame(minWidth: 320, minHeight: 390)
+                    .frame(minWidth: 320, minHeight: 390)
 #endif
-                }
-        } else {
-            button
-                .sheet(isPresented: $settingsSheetIsPresented, detents: [.medium]) {
-                    settingsContent
-                }
-        }
+            }
     }
 }
 

--- a/Shared/Samples/Orbit camera around object/OrbitCameraAroundObjectView.swift
+++ b/Shared/Samples/Orbit camera around object/OrbitCameraAroundObjectView.swift
@@ -112,7 +112,7 @@ private extension OrbitCameraAroundObjectView {
         @State private var cameraDistanceIsInteractive = false
         
         var body: some View {
-            NavigationView {
+            NavigationStack {
                 List {
                     VStack {
                         Text("Camera Heading")
@@ -155,7 +155,6 @@ private extension OrbitCameraAroundObjectView {
                     }
                 }
             }
-            .navigationViewStyle(.stack)
             .onAppear {
                 planePitch.value = model.planeGraphic.attributes["PITCH"] as! Double
                 cameraHeading.value = model.cameraController.cameraHeadingOffset

--- a/Shared/Samples/Play KML tour/PlayKMLTourView.swift
+++ b/Shared/Samples/Play KML tour/PlayKMLTourView.swift
@@ -161,7 +161,7 @@ private extension URL {
 }
 
 #Preview {
-    NavigationView {
+    NavigationStack {
         PlayKMLTourView()
     }
 }

--- a/Shared/Samples/Query feature table/QueryFeatureTableView.swift
+++ b/Shared/Samples/Query feature table/QueryFeatureTableView.swift
@@ -117,7 +117,7 @@ private extension PortalItem.ID {
 }
 
 #Preview {
-    NavigationView {
+    NavigationStack {
         QueryFeatureTableView()
     }
 }

--- a/Shared/Samples/Run valve isolation trace/RunValveIsolationTraceView.swift
+++ b/Shared/Samples/Run valve isolation trace/RunValveIsolationTraceView.swift
@@ -86,14 +86,8 @@ struct RunValveIsolationTraceView: View {
                 }
             }
             .sheet(isPresented: $isConfigurationPresented) {
-                if #available(iOS 16, *) {
-                    NavigationStack {
-                        configurationView
-                    }
-                } else {
-                    NavigationView {
-                        configurationView
-                    }
+                NavigationStack {
+                    configurationView
                 }
             }
             .overlay(alignment: .center) {

--- a/Shared/Samples/Run valve isolation trace/RunValveIsolationTraceView.swift
+++ b/Shared/Samples/Run valve isolation trace/RunValveIsolationTraceView.swift
@@ -170,7 +170,6 @@ struct RunValveIsolationTraceView: View {
                 Button("Done") { isConfigurationPresented = false }
             }
         }
-        .navigationViewStyle(.stack)
     }
 }
 
@@ -187,7 +186,7 @@ extension RunValveIsolationTraceView.Model.TracingActivity {
 }
 
 #Preview {
-    NavigationView {
+    NavigationStack {
         RunValveIsolationTraceView()
     }
 }

--- a/Shared/Samples/Search for web map/SearchForWebMapView.swift
+++ b/Shared/Samples/Search for web map/SearchForWebMapView.swift
@@ -90,7 +90,7 @@ struct SearchForWebMapView: View {
 }
 
 #Preview {
-    NavigationView {
+    NavigationStack {
         SearchForWebMapView()
     }
 }

--- a/Shared/Samples/Set basemap/SetBasemapView.swift
+++ b/Shared/Samples/Set basemap/SetBasemapView.swift
@@ -55,7 +55,7 @@ struct SetBasemapView: View {
 }
 
 #Preview {
-    NavigationView {
+    NavigationStack {
         SetBasemapView()
     }
 }

--- a/Shared/Samples/Set feature request mode/SetFeatureRequestModeView.swift
+++ b/Shared/Samples/Set feature request mode/SetFeatureRequestModeView.swift
@@ -180,7 +180,7 @@ private extension URL {
 }
 
 #Preview {
-    NavigationView {
+    NavigationStack {
         SetFeatureRequestModeView()
     }
 }

--- a/Shared/Samples/Set max extent/SetMaxExtentView.swift
+++ b/Shared/Samples/Set max extent/SetMaxExtentView.swift
@@ -75,7 +75,7 @@ private extension Envelope {
 }
 
 #Preview {
-    NavigationView {
+    NavigationStack {
         SetMaxExtentView()
     }
 }

--- a/Shared/Samples/Set up location-driven geotriggers/SetUpLocationDrivenGeotriggersView.swift
+++ b/Shared/Samples/Set up location-driven geotriggers/SetUpLocationDrivenGeotriggersView.swift
@@ -152,7 +152,7 @@ extension SetUpLocationDrivenGeotriggersView {
 }
 
 #Preview {
-    NavigationView {
+    NavigationStack {
         SetUpLocationDrivenGeotriggersView()
     }
 }

--- a/Shared/Samples/Set visibility of subtype sublayer/SetVisibilityOfSubtypeSublayerView.swift
+++ b/Shared/Samples/Set visibility of subtype sublayer/SetVisibilityOfSubtypeSublayerView.swift
@@ -61,7 +61,7 @@ struct SetVisibilityOfSubtypeSublayerView: View {
 }
 
 #Preview {
-    NavigationView {
+    NavigationStack {
         SetVisibilityOfSubtypeSublayerView()
     }
 }

--- a/Shared/Samples/Show device location history/ShowDeviceLocationHistoryView.swift
+++ b/Shared/Samples/Show device location history/ShowDeviceLocationHistoryView.swift
@@ -210,7 +210,7 @@ private extension ShowDeviceLocationHistoryView {
 }
 
 #Preview {
-    NavigationView {
+    NavigationStack {
         ShowDeviceLocationHistoryView()
     }
 }

--- a/Shared/Samples/Show device location/ShowDeviceLocationView.swift
+++ b/Shared/Samples/Show device location/ShowDeviceLocationView.swift
@@ -147,7 +147,7 @@ private extension LocationDisplay.AutoPanMode {
 }
 
 #Preview {
-    NavigationView {
+    NavigationStack {
         ShowDeviceLocationView()
     }
 }

--- a/Shared/Samples/Show realistic light and shadows/ShowRealisticLightAndShadowsView.swift
+++ b/Shared/Samples/Show realistic light and shadows/ShowRealisticLightAndShadowsView.swift
@@ -142,7 +142,7 @@ private extension Date {
 }
 
 #Preview {
-    NavigationView {
+    NavigationStack {
         ShowRealisticLightAndShadowsView()
     }
 }

--- a/Shared/Samples/Show result of spatial operations/ShowResultOfSpatialOperationsView.swift
+++ b/Shared/Samples/Show result of spatial operations/ShowResultOfSpatialOperationsView.swift
@@ -174,7 +174,7 @@ private extension ShowResultOfSpatialOperationsView.Model {
 }
 
 #Preview {
-    NavigationView {
+    NavigationStack {
         ShowResultOfSpatialOperationsView()
     }
 }

--- a/Shared/Samples/Show utility associations/ShowUtilityAssociationsView.swift
+++ b/Shared/Samples/Show utility associations/ShowUtilityAssociationsView.swift
@@ -272,7 +272,7 @@ private extension Viewpoint {
 }
 
 #Preview {
-    NavigationView {
+    NavigationStack {
         ShowUtilityAssociationsView()
     }
 }

--- a/Shared/Samples/Show viewshed from point in scene/ShowViewshedFromPointInSceneView.swift
+++ b/Shared/Samples/Show viewshed from point in scene/ShowViewshedFromPointInSceneView.swift
@@ -50,7 +50,7 @@ struct ShowViewshedFromPointInSceneView: View {
 }
 
 #Preview {
-    NavigationView {
+    NavigationStack {
         ShowViewshedFromPointInSceneView()
     }
 }

--- a/Shared/Samples/Style symbols from mobile style file/StyleSymbolsFromMobileStyleFileView.swift
+++ b/Shared/Samples/Style symbols from mobile style file/StyleSymbolsFromMobileStyleFileView.swift
@@ -56,7 +56,7 @@ struct StyleSymbolsFromMobileStyleFileView: View {
     
     /// The list containing the symbol options.
     private var symbolOptionsList: some View {
-        NavigationView {
+        NavigationStack {
             SymbolOptionsListView(model: model)
                 .navigationTitle("Symbol")
                 .navigationBarTitleDisplayMode(.inline)
@@ -68,7 +68,6 @@ struct StyleSymbolsFromMobileStyleFileView: View {
                     }
                 }
         }
-        .navigationViewStyle(.stack)
     }
 }
 

--- a/Shared/Samples/Trace utility network/TraceUtilityNetworkView.swift
+++ b/Shared/Samples/Trace utility network/TraceUtilityNetworkView.swift
@@ -109,7 +109,7 @@ private extension Viewpoint {
 }
 
 #Preview {
-    NavigationView {
+    NavigationStack {
         TraceUtilityNetworkView()
     }
 }

--- a/Shared/Samples/Validate utility network topology/ValidateUtilityNetworkTopologyView.Views.swift
+++ b/Shared/Samples/Validate utility network topology/ValidateUtilityNetworkTopologyView.Views.swift
@@ -28,7 +28,7 @@ extension ValidateUtilityNetworkTopologyView {
         @Environment(\.dismiss) private var dismiss: DismissAction
         
         var body: some View {
-            NavigationView {
+            NavigationStack {
                 fieldValuePicker
                     .navigationTitle("Edit Feature")
                     .navigationBarTitleDisplayMode(.inline)
@@ -47,7 +47,6 @@ extension ValidateUtilityNetworkTopologyView {
                         }
                     }
             }
-            .navigationViewStyle(.stack)
         }
         
         /// The picker for the field value options.

--- a/Shared/Samples/Validate utility network topology/ValidateUtilityNetworkTopologyView.swift
+++ b/Shared/Samples/Validate utility network topology/ValidateUtilityNetworkTopologyView.swift
@@ -178,7 +178,7 @@ extension ValidateUtilityNetworkTopologyView {
 }
 
 #Preview {
-    NavigationView {
+    NavigationStack {
         ValidateUtilityNetworkTopologyView()
     }
 }

--- a/Shared/Supporting Files/Views/AboutView.swift
+++ b/Shared/Supporting Files/Views/AboutView.swift
@@ -16,14 +16,8 @@ import SwiftUI
 
 struct AboutView: View {
     var body: some View {
-        if #available(iOS 16, *) {
-            NavigationStack {
-                AboutList()
-            }
-        } else {
-            NavigationView {
-                AboutList()
-            }
+        NavigationStack {
+            AboutList()
         }
     }
 }

--- a/Shared/Supporting Files/Views/ContentView.swift
+++ b/Shared/Supporting Files/Views/ContentView.swift
@@ -19,19 +19,12 @@ struct ContentView: View {
     @State private var query = ""
     
     var body: some View {
-        if #available(iOS 16, *) {
-            NavigationSplitView {
-                NavigationStack {
-                    sidebar
-                }
-            } detail: {
-                NavigationStack {
-                    detail
-                }
-            }
-        } else {
-            NavigationView {
+        NavigationSplitView {
+            NavigationStack {
                 sidebar
+            }
+        } detail: {
+            NavigationStack {
                 detail
             }
         }

--- a/Shared/Supporting Files/Views/FavoritesView.swift
+++ b/Shared/Supporting Files/Views/FavoritesView.swift
@@ -80,7 +80,7 @@ private extension FavoritesView {
         }
         
         var body: some View {
-            NavigationView {
+            NavigationStack {
                 List {
                     ForEach(filteredSamples, id: \.name) { sample in
                         Button {

--- a/Shared/Supporting Files/Views/SampleDetailView.swift
+++ b/Shared/Supporting Files/Views/SampleDetailView.swift
@@ -94,14 +94,8 @@ struct SampleDetailView: View {
                     Image(systemName: "info.circle")
                 }
                 .sheet(isPresented: $isSampleInfoViewPresented) {
-                    if #available(iOS 16, *) {
-                        NavigationStack {
-                            SampleInfoView(sample: sample)
-                        }
-                    } else {
-                        NavigationView {
-                            SampleInfoView(sample: sample)
-                        }
+                    NavigationStack {
+                        SampleInfoView(sample: sample)
                     }
                 }
             }


### PR DESCRIPTION
## Description

This PR removes iOS 15 support from Sample Viewer and samples by bumping the minimum deployments and removing uses of any deprecated APIs, mostly `NavigationView`. There should be no functionality changes in this PR.

This will be merged after the `200.4.0` release here: #369

## Linked Issue(s)

- `swift/issues/5171`

## How To Test

- Ensure Sample Viewer and the modified samples work as expected. 
