### PR TITLE
[Fix] `Augment reality to show hidden infrastructure` scene view crash

### DIFF
--- a/Shared/Samples/Augment reality to show hidden infrastructure/AugmentRealityToShowHiddenInfrastructureView.ARSceneView.swift
+++ b/Shared/Samples/Augment reality to show hidden infrastructure/AugmentRealityToShowHiddenInfrastructureView.ARSceneView.swift
@@ -74,7 +74,7 @@ extension AugmentRealityToShowHiddenInfrastructureView {
     class SceneModel: ObservableObject {
         /// A scene with an imagery basemap style and an elevation surface.
         let scene: ArcGIS.Scene = {
-            let scene = Scene(basemapStyle: .arcGISImagery)
+            let scene = Scene(basemapStyle: .arcGISImageryStandard)
             
             // Create a surface with an elevation source and set it to the scene's base surface.
             let surface = Surface()


### PR DESCRIPTION
## Description

This PR implements a workaround for a bug in the `Augment reality to show hidden infrastructure` sample where it would intermittently crash when quickly switching between the map and scene view. The fix uses a basemap style without vector titles.

## Linked Issue(s)

- `ping/issues/1650`

## How To Test

- Ensure you can quickly switch between the map and scene view several times without crashing.
