### PR TITLE
[Update] Add `redirect_from` link to Create and edit geometries

### DIFF
--- a/Shared/Samples/Create and edit geometries/README.metadata.json
+++ b/Shared/Samples/Create and edit geometries/README.metadata.json
@@ -20,7 +20,9 @@
         "GraphicsOverlay",
         "MapView"
     ],
-    "redirect_from": [],
+    "redirect_from": [
+        "/swift/sample-code/sketch-on-map/"
+    ],
     "relevant_apis": [
         "Geometry",
         "GeometryBuilder",


### PR DESCRIPTION


## Description

This PR updates `Create and edit geometries`, adds missing redirect from link for https://developers.arcgis.com/swift/sample-code/sketch-on-map/

## Linked Issue(s)

- Close #376 

## How To Test

See tomorrow in next site build.
