### PR TITLE
[Fix] `Add features with contingent values` cancel button

### DIFF
--- a/Shared/Samples/Add features with contingent values/AddFeaturesWithContingentValuesView.AddFeatureView.swift
+++ b/Shared/Samples/Add features with contingent values/AddFeaturesWithContingentValuesView.AddFeatureView.swift
@@ -123,6 +123,11 @@ extension AddFeaturesWithContingentValuesView {
                 // Add nil to allow for an empty option in the picker.
                 statusOptions.insert(nil, at: 0)
             }
+            .onDisappear {
+                selectedStatusName = nil
+                selectedProtectionName = nil
+                selectedBufferSize = nil
+            }
         }
     }
 }

--- a/Shared/Samples/Add features with contingent values/AddFeaturesWithContingentValuesView.Model.swift
+++ b/Shared/Samples/Add features with contingent values/AddFeaturesWithContingentValuesView.Model.swift
@@ -56,7 +56,7 @@ extension AddFeaturesWithContingentValuesView {
         private var featureTable: ArcGISFeatureTable?
         
         /// The feature in the feature table.
-        private(set) var feature: ArcGISFeature?
+        var feature: ArcGISFeature?
         
         /// A Boolean value indicating whether all the contingency constraints associated with the feature are valid.
         @Published private(set) var contingenciesAreValid = false

--- a/Shared/Samples/Add features with contingent values/AddFeaturesWithContingentValuesView.swift
+++ b/Shared/Samples/Add features with contingent values/AddFeaturesWithContingentValuesView.swift
@@ -98,6 +98,7 @@ struct AddFeaturesWithContingentValuesView: View {
                                     
                                     ToolbarItem(placement: .confirmationAction) {
                                         Button("Done") {
+                                            model.feature = nil
                                             addFeatureSheetIsPresented = false
                                         }
                                         .disabled(!model.contingenciesAreValid)
@@ -108,10 +109,7 @@ struct AddFeaturesWithContingentValuesView: View {
                     }
                     .task(id: addFeatureSheetIsPresented) {
                         // When the sheet closes, remove the feature if it is invalid.
-                        guard !addFeatureSheetIsPresented,
-                              !model.contingenciesAreValid,
-                              model.feature != nil
-                        else { return }
+                        guard !addFeatureSheetIsPresented, model.feature != nil else { return }
                         
                         do {
                             try await model.removeFeature()


### PR DESCRIPTION
## Description

This PR fixes an issue in the `Add features with contingent values` sample where the "Cancel" button on the "Add Bird Nest" sheet would not remove a feature if the sheet contained valid contingencies values. See feedback [here](https://github.com/Esri/arcgis-maps-sdk-swift-samples/pull/369#pullrequestreview-1992725338).

## Linked Issue(s)

- N/A (quick fix)

## How To Test

- Ensure both the "Cancel" and "Done" buttons in the sample work as expected.
