### PR TITLE
[Update] Add `NSLocationUsageDescription` for Mac Catalyst app

### DIFF
--- a/iOS/Info.plist
+++ b/iOS/Info.plist
@@ -81,6 +81,8 @@
 		<string>com.eos-gnss.positioningsource</string>
 		<string>com.geneq.sxbluegpssource</string>
 	</array>
+	<key>NSLocationUsageDescription</key>
+	<string>Your location is used to show your position on the map on Mac Catalyst.</string>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/iOS/Info.plist
+++ b/iOS/Info.plist
@@ -52,6 +52,8 @@
 	</dict>
 	<key>NSCameraUsageDescription</key>
 	<string>This app uses augmented reality to overlay imagery over your real-world environment. Camera access is required for this functionality.</string>
+	<key>NSLocationUsageDescription</key>
+	<string>Your location is used to show your position on the map on Mac Catalyst.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>Your location is used to show your position on the map.</string>
 	<key>UIApplicationSceneManifest</key>
@@ -81,8 +83,6 @@
 		<string>com.eos-gnss.positioningsource</string>
 		<string>com.geneq.sxbluegpssource</string>
 	</array>
-	<key>NSLocationUsageDescription</key>
-	<string>Your location is used to show your position on the map on Mac Catalyst.</string>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>


### PR DESCRIPTION
## Description

App Store Connect review rejected with the following comment

> If the macOS app requests access to location data, include the [NSLocationUsageDescription](https://developer.apple.com/documentation/bundleresources/information_property_list/nslocationusagedescription?language=occ) key on the info.plist. The [NSLocationWhenInUseUsageDescription](https://developer.apple.com/documentation/bundleresources/information_property_list/nslocationwheninuseusagedescription) key is only for iOS apps.

Include this key to make ASC reviewers happy. 🫤

## To Discuss

From reading this article: https://developer.apple.com/documentation/corelocation/requesting_authorization_to_use_location_services

> On macOS, When in Use and Always authorizations are functionally equivalent. Because macOS apps continue to run in the background after their initial launch, they are always in use. If you create your Mac app using Mac Catalyst, request authorization based on the needs of your iOS app.

It's not clear whether this key is needed or not for Mac Catalyst. Hope this change won't affect our next iOS submission, as the key was deprecated for iOS.