### PR TITLE
[Fix] Resolve the Task introduced retain cycle

### DIFF
--- a/Shared/Samples/Create and edit geometries/CreateAndEditGeometriesView.swift
+++ b/Shared/Samples/Create and edit geometries/CreateAndEditGeometriesView.swift
@@ -37,7 +37,7 @@ struct CreateAndEditGeometriesView: View {
 }
 
 /// A view that provides a menu for geometry editor functionality.
-struct GeometryEditorMenu: View {
+private struct GeometryEditorMenu: View {
     /// The model for the menu.
     @ObservedObject var model: GeometryEditorModel
     
@@ -74,7 +74,7 @@ struct GeometryEditorMenu: View {
     }
 }
 
-extension GeometryEditorMenu {
+private extension GeometryEditorMenu {
     /// The content of the main menu.
     private var mainMenuContent: some View {
         VStack {
@@ -226,40 +226,40 @@ extension GeometryEditorMenu {
     }
 }
 
-extension GeometryEditorMenu {
+private extension GeometryEditorMenu {
     /// A Boolean value indicating whether the selection can be deleted.
     ///
     /// In some instances deleting the selection may be invalid. One example would be the mid vertex
     /// of a line.
-    var deleteButtonIsDisabled: Bool {
+    private var deleteButtonIsDisabled: Bool {
         guard let selectedElement else { return true }
         return !selectedElement.canBeDeleted
     }
     
     /// A Boolean value indicating if the geometry editor can perform an undo.
-    var canUndo: Bool {
+    private var canUndo: Bool {
         return model.geometryEditor.canUndo
     }
     
     /// A Boolean value indicating if the geometry editor can perform a redo.
-    var canRedo: Bool {
+    private var canRedo: Bool {
         return model.geometryEditor.canRedo
     }
     
     /// A Boolean value indicating if the geometry can be saved to a graphics overlay.
-    var canSave: Bool {
+    private var canSave: Bool {
         return geometry?.sketchIsValid ?? false
     }
     
     /// A Boolean value indicating if the geometry can be cleared from the geometry editor.
-    var canClearCurrentSketch: Bool {
+    private var canClearCurrentSketch: Bool {
         return geometry.map { !$0.isEmpty } ?? false
     }
 }
 
 /// An object that acts as a view model for the geometry editor menu.
 @MainActor
-class GeometryEditorModel: ObservableObject {
+private class GeometryEditorModel: ObservableObject {
     /// The geometry editor.
     let geometryEditor = GeometryEditor()
     
@@ -270,7 +270,7 @@ class GeometryEditorModel: ObservableObject {
     @Published private(set) var canClearSavedSketches = false
     
     /// A Boolean value indicating if the geometry editor has started.
-    @Published var isStarted = false
+    @Published private(set) var isStarted = false
     
     /// A Boolean value indicating if the scale mode is uniform.
     @Published var shouldUniformScale = false {
@@ -330,7 +330,7 @@ class GeometryEditorModel: ObservableObject {
     /// - Parameters:
     ///   - tool: The geometry editor tool.
     ///   - scaleMode: Preserve the original aspect ratio or scale freely.
-    func configureGeometryEditorTool(_ tool: GeometryEditorTool, scaleMode: GeometryEditorScaleMode) {
+    private func configureGeometryEditorTool(_ tool: GeometryEditorTool, scaleMode: GeometryEditorScaleMode) {
         switch tool {
         case let tool as FreehandTool:
             tool.configuration.scaleMode = scaleMode

--- a/Shared/Samples/Create and edit geometries/CreateAndEditGeometriesView.swift
+++ b/Shared/Samples/Create and edit geometries/CreateAndEditGeometriesView.swift
@@ -285,7 +285,7 @@ private class GeometryEditorModel: ObservableObject {
     }
     
     /// Saves the current geometry to the graphics overlay and stops editing.
-    /// - Precondition: Whether or not the geometry is from a valid sketch.
+    /// - Precondition: Geometry's sketch must be valid.
     func save() {
         precondition(geometryEditor.geometry?.sketchIsValid ?? false)
         let geometry = geometryEditor.geometry!

--- a/Shared/Samples/Create and edit geometries/CreateAndEditGeometriesView.swift
+++ b/Shared/Samples/Create and edit geometries/CreateAndEditGeometriesView.swift
@@ -55,21 +55,21 @@ private struct GeometryEditorMenu: View {
             } else {
                 // If the geometry editor is started, show the edit menu.
                 editMenuContent
+                    .task {
+                        for await geometry in model.geometryEditor.$geometry {
+                            // Update geometry when there is an update.
+                            self.geometry = geometry
+                        }
+                    }
+                    .task {
+                        for await element in model.geometryEditor.$selectedElement {
+                            // Update selected element when there is an update.
+                            selectedElement = element
+                        }
+                    }
             }
         } label: {
             Label("Geometry Editor", systemImage: "pencil.tip.crop.circle")
-        }
-        .task {
-            for await geometry in model.geometryEditor.$geometry {
-                // Update geometry when there is an update.
-                self.geometry = geometry
-            }
-        }
-        .task {
-            for await element in model.geometryEditor.$selectedElement {
-                // Update selected element when there is an update.
-                selectedElement = element
-            }
         }
     }
 }

--- a/Shared/Samples/Create and edit geometries/CreateAndEditGeometriesView.swift
+++ b/Shared/Samples/Create and edit geometries/CreateAndEditGeometriesView.swift
@@ -76,7 +76,7 @@ private struct GeometryEditorMenu: View {
 
 private extension GeometryEditorMenu {
     /// The content of the main menu.
-    private var mainMenuContent: some View {
+    var mainMenuContent: some View {
         VStack {
             Button {
                 model.startEditing(with: VertexTool(), geometryType: Point.self)
@@ -176,7 +176,7 @@ private extension GeometryEditorMenu {
     }
     
     /// The content of the editing menu.
-    private var editMenuContent: some View {
+    var editMenuContent: some View {
         VStack {
             Button {
                 model.geometryEditor.undo()
@@ -231,28 +231,28 @@ private extension GeometryEditorMenu {
     ///
     /// In some instances deleting the selection may be invalid. One example would be the mid vertex
     /// of a line.
-    private var deleteButtonIsDisabled: Bool {
+    var deleteButtonIsDisabled: Bool {
         guard let selectedElement else { return true }
         return !selectedElement.canBeDeleted
     }
     
     /// A Boolean value indicating if the geometry editor can perform an undo.
-    private var canUndo: Bool {
+    var canUndo: Bool {
         return model.geometryEditor.canUndo
     }
     
     /// A Boolean value indicating if the geometry editor can perform a redo.
-    private var canRedo: Bool {
+    var canRedo: Bool {
         return model.geometryEditor.canRedo
     }
     
     /// A Boolean value indicating if the geometry can be saved to a graphics overlay.
-    private var canSave: Bool {
+    var canSave: Bool {
         return geometry?.sketchIsValid ?? false
     }
     
     /// A Boolean value indicating if the geometry can be cleared from the geometry editor.
-    private var canClearCurrentSketch: Bool {
+    var canClearCurrentSketch: Bool {
         return geometry.map { !$0.isEmpty } ?? false
     }
 }

--- a/Shared/Samples/Create and edit geometries/CreateAndEditGeometriesView.swift
+++ b/Shared/Samples/Create and edit geometries/CreateAndEditGeometriesView.swift
@@ -199,7 +199,7 @@ private extension GeometryEditorMenu {
             }
             .disabled(deleteButtonIsDisabled)
             
-            Toggle("Uniform Scale", isOn: $model.shouldUniformScale)
+            Toggle("Uniform Scale", isOn: $model.isUniformScale)
             
             Button(role: .destructive) {
                 model.geometryEditor.clearGeometry()
@@ -273,7 +273,7 @@ private class GeometryEditorModel: ObservableObject {
     @Published private(set) var isStarted = false
     
     /// A Boolean value indicating if the scale mode is uniform.
-    @Published var shouldUniformScale = false {
+    @Published var isUniformScale = false {
         didSet {
             configureGeometryEditorTool(geometryEditor.tool, scaleMode: scaleMode)
         }
@@ -281,7 +281,7 @@ private class GeometryEditorModel: ObservableObject {
     
     /// The scale mode to be set on the geometry editor.
     private var scaleMode: GeometryEditorScaleMode {
-        shouldUniformScale ? .uniform : .stretch
+        isUniformScale ? .uniform : .stretch
     }
     
     /// Saves the current geometry to the graphics overlay and stops editing.


### PR DESCRIPTION
## Description

This PR fixes the retain cycle discussed in #153 .

## Linked Issue(s)

- #153 

## How To Test

use `deinit` to see if the model is deallocated after sample is closed.

```swift
deinit {
    print("✅ cleared")
}
```
