### PR TITLE
[Fix] Category title cut off on Pro Max

### DIFF
--- a/Shared/Supporting Files/Views/CategoriesView.swift
+++ b/Shared/Supporting Files/Views/CategoriesView.swift
@@ -93,17 +93,29 @@ private extension CategoriesView {
                 .aspectRatio(contentMode: .fit)
                 .overlay {
                     Color(red: 0.24, green: 0.24, blue: 0.26, opacity: 0.6)
-                    Image("\(name.replacingOccurrences(of: " ", with: "-"))-icon")
-                        .resizable()
-                        .colorInvert()
-                        .padding(10)
-                        .frame(width: 50, height: 50)
-                        .background(.black.opacity(0.75))
-                        .clipShape(Circle())
-                    Text(name)
-                        .multilineTextAlignment(.center)
-                        .foregroundColor(.white)
-                        .offset(y: 45)
+                    
+                    GeometryReader { geometry in
+                        Group {
+                            Image("\(name.replacingOccurrences(of: " ", with: "-"))-icon")
+                                .resizable()
+                                .frame(
+                                    width: geometry.size.width * 0.17,
+                                    height: geometry.size.height * 0.17
+                                )
+                                .padding(geometry.size.width * 0.06)
+                                .colorInvert()
+                                .background(.black.opacity(0.75))
+                                .clipShape(Circle())
+                            
+                            Text(name)
+                                .font(.system(size: geometry.size.width * 0.1))
+                                .multilineTextAlignment(.center)
+                                .foregroundColor(.white)
+                                .offset(y: geometry.size.height * 0.31)
+                                .padding()
+                        }
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    }
                 }
                 .clipShape(RoundedRectangle(cornerRadius: 15))
         }


### PR DESCRIPTION
## Description

This PR fixes a bug where the title of the category would be cut off on iPhone Pro Max when in landscape mode. This fix scales the icon and title with the category tile size. As a result, the icon/title are now different sizes on iPad and Mac Catalyst.

## Linked Issue(s)

- `swift/issues/5250`

## How To Test

- Run on Pro Max in landscape mode to see if any of the text is cut off.
- Ensure that the icons/titles look good on other platforms.

## Screenshots

|Before|After|
|:-:|:-:|
|    <img src="https://github.com/Esri/arcgis-maps-sdk-swift-samples/assets/34120440/8b07edb1-9659-45c4-9241-af1bc16b00da" alt="Pro Max - Before">   |    <img src="https://github.com/Esri/arcgis-maps-sdk-swift-samples/assets/34120440/486a9d41-1fa0-49a3-908b-a0dbc98e1133" alt="Pro Max - After">    |
|    ![iPad - Before](https://github.com/Esri/arcgis-maps-sdk-swift-samples/assets/34120440/bdfccc2c-3e8a-45bc-92da-2140b6646fc8)    |    ![iPad - After](https://github.com/Esri/arcgis-maps-sdk-swift-samples/assets/34120440/a7a37b3d-4880-4a83-8797-b424cc065a3d)    |
|    <img width="1160" alt="Mac Catalyst" src="https://github.com/Esri/arcgis-maps-sdk-swift-samples/assets/34120440/ceae2063-f33b-48bf-8cb4-7cdd1a8d0970">    |    <img width="1160" alt="Screenshot 2024-04-22 at 2 56 15 PM" src="https://github.com/Esri/arcgis-maps-sdk-swift-samples/assets/34120440/bd37f89c-b7ec-4c47-b472-a0268384da75">    |

## To Discuss

- I am not totally sold on this solution but wasn't sure how else to do it, so let me know if you have any feedback!





