### PR TITLE
[Update] Add `Browse building floors` floor filter height adjustment

### DIFF
--- a/Shared/Samples/Browse building floors/BrowseBuildingFloorsView.swift
+++ b/Shared/Samples/Browse building floors/BrowseBuildingFloorsView.swift
@@ -38,14 +38,14 @@ struct BrowseBuildingFloorsView: View {
     )
     
     /// The height of the attribution bar at the bottom of the map view.
-    @State private var height: CGFloat?
+    @State private var attributionBarHeight: CGFloat?
     
     var body: some View {
         MapView(map: map)
             .onViewpointChanged(kind: .centerAndScale) { viewpoint = $0 }
             .onNavigatingChanged { isMapNavigating = $0 }
             .onAttributionBarHeightChanged { height in
-                withAnimation { self.height = height }
+                withAnimation { attributionBarHeight = height }
             }
             .errorAlert(presentingError: $error)
             .ignoresSafeArea(.keyboard, edges: .bottom)
@@ -63,7 +63,7 @@ struct BrowseBuildingFloorsView: View {
                         maxHeight: 400
                     )
                     .padding(.toolkitDefault)
-                    .padding(.bottom, height)
+                    .padding(.bottom, attributionBarHeight)
                 }
             }
             .task {

--- a/Shared/Samples/Browse building floors/BrowseBuildingFloorsView.swift
+++ b/Shared/Samples/Browse building floors/BrowseBuildingFloorsView.swift
@@ -37,10 +37,16 @@ struct BrowseBuildingFloorsView: View {
         )
     )
     
+    /// The height of the attribution bar at the bottom of the map view.
+    @State private var height: CGFloat?
+    
     var body: some View {
         MapView(map: map)
             .onViewpointChanged(kind: .centerAndScale) { viewpoint = $0 }
             .onNavigatingChanged { isMapNavigating = $0 }
+            .onAttributionBarHeightChanged { height in
+                withAnimation { self.height = height }
+            }
             .errorAlert(presentingError: $error)
             .ignoresSafeArea(.keyboard, edges: .bottom)
             .overlay(alignment: .bottomTrailing) {
@@ -57,7 +63,7 @@ struct BrowseBuildingFloorsView: View {
                         maxHeight: 400
                     )
                     .padding(.toolkitDefault)
-                    .padding(.bottom, 27)
+                    .padding(.bottom, height)
                 }
             }
             .task {


### PR DESCRIPTION
## Description

This PR updates the floor filter in the `Browse building floors` sample to adjust its position based on the attribution bar height.

## Linked Issue(s)

- `swift/issues/5280`

## How To Test

- Tap the attribution bar to see the floor filters adjust.
- Ensure the sample otherwise works as before.

## Screenshots

|Before|After|
|:-:|:-:|
|    <img src="https://github.com/Esri/arcgis-maps-sdk-swift-samples/assets/34120440/ecc71b7f-14d5-4dfc-90f4-4b45e7fdfa11" alt="Simulator Screenshot - iPhone 15 Pro - 2024-04-24 at 16 25 41" width="276">    |    <img src="https://github.com/Esri/arcgis-maps-sdk-swift-samples/assets/34120440/897b98df-1e56-4efe-a1ba-b686a706d4f2" alt="Simulator Screenshot - iPhone 15 Pro - 2024-04-24 at 16 33 50" width="276">    |
