### PR TITLE
[Update] Remove apk update from Dockerfile 

### DIFF
--- a/Scripts/CI/Dockerfile
+++ b/Scripts/CI/Dockerfile
@@ -25,7 +25,7 @@ ADD readme_checker.py /readme_checker.py
 
 # Install dependencies.
 RUN echo "**** Install Ruby and mdl ****" && \
-    apk add --no-cache ruby ruby-dev && \
+    apk add --no-cache ruby-full && \
     gem install mdl --no-document && \
     echo "**** Install Python ****" && \
     apk add --no-cache python3 && \


### PR DESCRIPTION
## Description

Remove `--update` to not use the latest apk index, so that we don't run into problem when the latest apk dependency is incorrect, as shown in #417.

## How To Test

Try in your own docker instance or generally reason about this change for a Debian-like environment. It may or may not solve the error we see in #417, but hopefully it does.

