### PR TITLE
[Fix] Strict concurrency warnings

### DIFF
--- a/Shared/Samples/Create and save KML file/CreateAndSaveKMLView.swift
+++ b/Shared/Samples/Create and save KML file/CreateAndSaveKMLView.swift
@@ -79,7 +79,7 @@ final class KMZFile: FileDocument {
     /// The temporary URL to the KMZ file.
     private var temporaryDocumentURL: URL?
     
-    static var readableContentTypes = [UTType.kmz]
+    static let readableContentTypes = [UTType.kmz]
     
     /// Creates a KMZ file with a KML document.
     /// - Parameter document: The KML document that is used when creating the KMZ file.

--- a/Shared/Samples/Create and save KML file/CreateAndSaveKMLView.swift
+++ b/Shared/Samples/Create and save KML file/CreateAndSaveKMLView.swift
@@ -79,7 +79,7 @@ final class KMZFile: FileDocument {
     /// The temporary URL to the KMZ file.
     private var temporaryDocumentURL: URL?
     
-    static let readableContentTypes = [UTType.kmz]
+    static var readableContentTypes: [UTType] { [UTType.kmz] }
     
     /// Creates a KMZ file with a KML document.
     /// - Parameter document: The KML document that is used when creating the KMZ file.

--- a/Shared/Samples/Create and save KML file/CreateAndSaveKMLView.swift
+++ b/Shared/Samples/Create and save KML file/CreateAndSaveKMLView.swift
@@ -79,7 +79,7 @@ final class KMZFile: FileDocument {
     /// The temporary URL to the KMZ file.
     private var temporaryDocumentURL: URL?
     
-    static var readableContentTypes: [UTType] { [UTType.kmz] }
+    static var readableContentTypes: [UTType] { [.kmz] }
     
     /// Creates a KMZ file with a KML document.
     /// - Parameter document: The KML document that is used when creating the KMZ file.

--- a/Shared/Samples/Create mobile geodatabase/CreateMobileGeodatabaseView.Model.swift
+++ b/Shared/Samples/Create mobile geodatabase/CreateMobileGeodatabaseView.Model.swift
@@ -168,7 +168,7 @@ extension CreateMobileGeodatabaseView {
 
 extension CreateMobileGeodatabaseView.GeodatabaseFile: FileDocument {
     /// The file and data types that the document reads from.
-    static var readableContentTypes = [UTType.geodatabase]
+    static let readableContentTypes = [UTType.geodatabase]
     
     /// Creates a document and initializes it with the contents of a file.
     convenience init(configuration: ReadConfiguration) throws {

--- a/Shared/Samples/Create mobile geodatabase/CreateMobileGeodatabaseView.Model.swift
+++ b/Shared/Samples/Create mobile geodatabase/CreateMobileGeodatabaseView.Model.swift
@@ -168,7 +168,7 @@ extension CreateMobileGeodatabaseView {
 
 extension CreateMobileGeodatabaseView.GeodatabaseFile: FileDocument {
     /// The file and data types that the document reads from.
-    static let readableContentTypes = [UTType.geodatabase]
+    static var readableContentTypes: [UTType] { [UTType.geodatabase] }
     
     /// Creates a document and initializes it with the contents of a file.
     convenience init(configuration: ReadConfiguration) throws {

--- a/Shared/Samples/Create mobile geodatabase/CreateMobileGeodatabaseView.Model.swift
+++ b/Shared/Samples/Create mobile geodatabase/CreateMobileGeodatabaseView.Model.swift
@@ -168,7 +168,7 @@ extension CreateMobileGeodatabaseView {
 
 extension CreateMobileGeodatabaseView.GeodatabaseFile: FileDocument {
     /// The file and data types that the document reads from.
-    static var readableContentTypes: [UTType] { [UTType.geodatabase] }
+    static var readableContentTypes: [UTType] { [.geodatabase] }
     
     /// Creates a document and initializes it with the contents of a file.
     convenience init(configuration: ReadConfiguration) throws {

--- a/Shared/Samples/Show grid/ShowGridView.swift
+++ b/Shared/Samples/Show grid/ShowGridView.swift
@@ -251,15 +251,17 @@ private extension ShowGridView {
 }
 
 private extension ArcGIS.Grid.LabelPosition {
-    static var allCases: [Self] = [
-        .allSides,
-        .center,
-        .topLeft,
-        .topRight,
-        .bottomLeft,
-        .bottomRight,
-        .geographic
-    ]
+    static var allCases: [Self] {
+        return [
+            .allSides,
+            .center,
+            .topLeft,
+            .topRight,
+            .bottomLeft,
+            .bottomRight,
+            .geographic
+        ]
+    }
     
     var label: String {
         switch self {
@@ -276,7 +278,7 @@ private extension ArcGIS.Grid.LabelPosition {
 }
 
 private extension LatitudeLongitudeGrid.LabelFormat {
-    static var allCases: [Self] = [.decimalDegrees, .degreesMinutesSeconds]
+    static var allCases: [Self] { [.decimalDegrees, .degreesMinutesSeconds] }
     
     var label: String {
         switch self {
@@ -288,7 +290,7 @@ private extension LatitudeLongitudeGrid.LabelFormat {
 }
 
 private extension MGRSGrid.LabelUnit {
-    static var allCases: [Self] = [.kilometersMeters, .meters]
+    static var allCases: [Self] { [.kilometersMeters, .meters] }
     
     var label: String {
         switch self {
@@ -300,7 +302,7 @@ private extension MGRSGrid.LabelUnit {
 }
 
 private extension USNGGrid.LabelUnit {
-    static var allCases: [Self] = [.kilometersMeters, .meters]
+    static var allCases: [Self] { [.kilometersMeters, .meters] }
     
     var label: String {
         switch self {

--- a/Shared/Supporting Files/Extensions/String.swift
+++ b/Shared/Supporting Files/Extensions/String.swift
@@ -16,5 +16,5 @@ import Foundation
 
 extension String {
     /// The key to read and write the names of the favorite samples to the user defaults.
-    static var favoriteSampleNames = "favoriteSampleNames"
+    static var favoriteSampleNames: String { "favoriteSampleNames" }
 }

--- a/Shared/Supporting Files/Models/Sample.swift
+++ b/Shared/Supporting Files/Models/Sample.swift
@@ -15,7 +15,7 @@
 import SwiftUI
 
 /// A type that represents a sample in the sample viewer.
-protocol Sample {
+protocol Sample: Sendable {
     /// The name of the sample.
     var name: String { get }
     


### PR DESCRIPTION
## Description

Fix some easy to fix concurrency warnings. Mostly just `static var = ` -> `static var` computed

To test, enable strict concurrency = complete from build settings.

|Warnings|
|-|
|![iShot_2024-07-02_16 05 04](https://github.com/Esri/arcgis-maps-sdk-swift-samples/assets/9660181/7a55c894-4d10-4b87-b411-88dcc504682f)|
|![iShot_2024-07-02_16 05 54](https://github.com/Esri/arcgis-maps-sdk-swift-samples/assets/9660181/9fc7a28e-c33c-404a-87c0-c1e282323668)|
|![iShot_2024-07-02_16 08 36](https://github.com/Esri/arcgis-maps-sdk-swift-samples/assets/9660181/caa62e4e-4b8f-4a9d-b6b4-9d85f5e45d4a)|
