### PR TITLE
[Update] Add Elmid support to NMEA sample

### DIFF
--- a/Shared/Samples/Show device location with NMEA data sources/README.md
+++ b/Shared/Samples/Show device location with NMEA data sources/README.md
@@ -56,6 +56,7 @@ Below is a list of protocol strings for commonly used GNSS external accessories.
 ### Supported by this sample
 
 * com.bad-elf.gps
+* com.emlid.nmea
 * com.eos-gnss.positioningsource
 * com.geneq.sxbluegpssource
 
@@ -63,7 +64,6 @@ Below is a list of protocol strings for commonly used GNSS external accessories.
 
 * com.amanenterprises.nmeasource
 * com.dualav.xgps150
-* com.emlid.nmea
 * com.garmin.pvt
 * com.junipersys.geode
 * com.leica-geosystems.zeno.gnss

--- a/Shared/Samples/Show device location with NMEA data sources/ShowDeviceLocationWithNMEADataSourcesView.Model.swift
+++ b/Shared/Samples/Show device location with NMEA data sources/ShowDeviceLocationWithNMEADataSourcesView.Model.swift
@@ -57,6 +57,7 @@ extension ShowDeviceLocationWithNMEADataSourcesView {
         /// communicate with external accessory hardware.
         private let supportedProtocolStrings: Set = [
             "com.bad-elf.gps",
+            "com.emlid.nmea",
             "com.eos-gnss.positioningsource",
             "com.geneq.sxbluegpssource"
         ]

--- a/iOS/Info.plist
+++ b/iOS/Info.plist
@@ -80,6 +80,7 @@
 	<key>UISupportedExternalAccessoryProtocols</key>
 	<array>
 		<string>com.bad-elf.gps</string>
+		<string>com.emlid.nmea</string>
 		<string>com.eos-gnss.positioningsource</string>
 		<string>com.geneq.sxbluegpssource</string>
 	</array>


### PR DESCRIPTION
## Description

This PR add support for Emlid devices to the `Show device location with NMEA data sources` sample.

## Linked Issue(s)

- `swift/issues/5042`
