### PR TITLE
[Update] Use reticle in Snap geometry edits sample

### DIFF
--- a/Shared/Samples/Snap geometry edits/README.md
+++ b/Shared/Samples/Snap geometry edits/README.md
@@ -49,7 +49,7 @@ Snapping is used to maintain data integrity between different sources of data wh
 
 To snap to polygon and polyline layers, the recommended approach is to set the `FeatureLayer`'s feature tiling mode to `FeatureTilingMode.enabledWithFullResolutionWhenSupported` and use the default `ServiceFeatureTable` feature request mode `FeatureRequestMode.onInteractionCache`. Local data sources, such as geodatabases, always provide full resolution geometries. Point and multipoint feature layers are also always full resolution.
 
-Snapping can be used during interactive edits that move existing vertices using the `VertexTool`. It is also supported for adding new vertices for input devices with a hover event (such as a mouse move without a mouse button press). Using the magnifier to perform a vertex move allows users of touch devices to clearly see the visual cues for snapping.
+Snapping can be used during interactive edits that move existing vertices using the `VertexTool` or `ReticleVertexTool`. When adding new vertices, snapping also works with a hover event (such as a mouse move without a mouse button press). Using the `ReticleVertexTool` to add and move vertices allows users of touch screen devices to clearly see the visual cues for snapping.
 
 ## Tags
 

--- a/Shared/Samples/Snap geometry edits/README.md
+++ b/Shared/Samples/Snap geometry edits/README.md
@@ -35,6 +35,7 @@ To more clearly see how the vertex is snapped, long press to invoke the magnifie
 * GeometryEditorStyle
 * GraphicsOverlay
 * MapView
+* ReticleVertexTool
 * SnapSettings
 * SnapSource
 * SnapSourceSettings

--- a/Shared/Samples/Snap geometry edits/README.metadata.json
+++ b/Shared/Samples/Snap geometry edits/README.metadata.json
@@ -19,7 +19,7 @@
         "GeometryEditorStyle",
         "GraphicsOverlay",
         "MapView",
-        "ReticleVertexTool"
+        "ReticleVertexTool",
         "SnapSettings",
         "SnapSource",
         "SnapSourceSettings"
@@ -32,7 +32,7 @@
         "GeometryEditorStyle",
         "GraphicsOverlay",
         "MapView",
-        "ReticleVertexTool"
+        "ReticleVertexTool",
         "SnapSettings",
         "SnapSource",
         "SnapSourceSettings"

--- a/Shared/Samples/Snap geometry edits/README.metadata.json
+++ b/Shared/Samples/Snap geometry edits/README.metadata.json
@@ -19,6 +19,7 @@
         "GeometryEditorStyle",
         "GraphicsOverlay",
         "MapView",
+        "ReticleVertexTool"
         "SnapSettings",
         "SnapSource",
         "SnapSourceSettings"
@@ -31,6 +32,7 @@
         "GeometryEditorStyle",
         "GraphicsOverlay",
         "MapView",
+        "ReticleVertexTool"
         "SnapSettings",
         "SnapSource",
         "SnapSourceSettings"

--- a/Shared/Samples/Snap geometry edits/README.metadata.json
+++ b/Shared/Samples/Snap geometry edits/README.metadata.json
@@ -19,7 +19,6 @@
         "GeometryEditorStyle",
         "GraphicsOverlay",
         "MapView",
-        "ReticleVertexTool",
         "SnapSettings",
         "SnapSource",
         "SnapSourceSettings"
@@ -32,7 +31,6 @@
         "GeometryEditorStyle",
         "GraphicsOverlay",
         "MapView",
-        "ReticleVertexTool",
         "SnapSettings",
         "SnapSource",
         "SnapSourceSettings"

--- a/Shared/Samples/Snap geometry edits/README.metadata.json
+++ b/Shared/Samples/Snap geometry edits/README.metadata.json
@@ -19,6 +19,7 @@
         "GeometryEditorStyle",
         "GraphicsOverlay",
         "MapView",
+        "ReticleVertexTool",
         "SnapSettings",
         "SnapSource",
         "SnapSourceSettings"
@@ -31,6 +32,7 @@
         "GeometryEditorStyle",
         "GraphicsOverlay",
         "MapView",
+        "ReticleVertexTool",
         "SnapSettings",
         "SnapSource",
         "SnapSourceSettings"

--- a/Shared/Samples/Snap geometry edits/SnapGeometryEditsView.GeometryEditorMenu.swift
+++ b/Shared/Samples/Snap geometry edits/SnapGeometryEditsView.GeometryEditorMenu.swift
@@ -29,7 +29,7 @@ extension SnapGeometryEditsView {
         
         /// The geometry editor tool used to edit geometries for the most optimal
         /// snapping experience based on the device type.
-        private var geometryEditorTool: GeometryEditorTool {
+        private var adaptiveVertexTool: GeometryEditorTool {
 #if targetEnvironment(macCatalyst)
             VertexTool()
 #else
@@ -96,19 +96,19 @@ extension SnapGeometryEditsView {
         private var mainMenuContent: some View {
             VStack {
                 Button("New Point", systemImage: "smallcircle.filled.circle") {
-                    model.startEditing(with: geometryEditorTool, geometryType: Point.self)
+                    model.startEditing(with: adaptiveVertexTool, geometryType: Point.self)
                 }
                 
                 Button("New Line", systemImage: "line.diagonal") {
-                    model.startEditing(with: geometryEditorTool, geometryType: Polyline.self)
+                    model.startEditing(with: adaptiveVertexTool, geometryType: Polyline.self)
                 }
                 
                 Button("New Area", systemImage: "skew") {
-                    model.startEditing(with: geometryEditorTool, geometryType: Polygon.self)
+                    model.startEditing(with: adaptiveVertexTool, geometryType: Polygon.self)
                 }
                 
                 Button("New Multipoint", systemImage: "hand.point.up.braille") {
-                    model.startEditing(with: geometryEditorTool, geometryType: Multipoint.self)
+                    model.startEditing(with: adaptiveVertexTool, geometryType: Multipoint.self)
                 }
                 
                 Button("New Freehand Line", systemImage: "scribble") {

--- a/Shared/Samples/Snap geometry edits/SnapGeometryEditsView.GeometryEditorMenu.swift
+++ b/Shared/Samples/Snap geometry edits/SnapGeometryEditsView.GeometryEditorMenu.swift
@@ -27,6 +27,16 @@ extension SnapGeometryEditsView {
         /// The current geometry of the geometry editor.
         @State private var geometry: Geometry?
         
+        /// The geometry editor tool used to edit geometries for the most optimal
+        /// snapping experience based on the device type.
+        private var geometryEditorTool: GeometryEditorTool {
+#if targetEnvironment(macCatalyst)
+            VertexTool()
+#else
+            ReticleVertexTool()
+#endif
+        }
+        
         /// A Boolean value indicating if the geometry editor can perform an undo.
         private var canUndo: Bool {
             return model.geometryEditor.canUndo
@@ -86,19 +96,19 @@ extension SnapGeometryEditsView {
         private var mainMenuContent: some View {
             VStack {
                 Button("New Point", systemImage: "smallcircle.filled.circle") {
-                    model.startEditing(with: VertexTool(), geometryType: Point.self)
+                    model.startEditing(with: geometryEditorTool, geometryType: Point.self)
                 }
                 
                 Button("New Line", systemImage: "line.diagonal") {
-                    model.startEditing(with: VertexTool(), geometryType: Polyline.self)
+                    model.startEditing(with: geometryEditorTool, geometryType: Polyline.self)
                 }
                 
                 Button("New Area", systemImage: "skew") {
-                    model.startEditing(with: VertexTool(), geometryType: Polygon.self)
+                    model.startEditing(with: geometryEditorTool, geometryType: Polygon.self)
                 }
                 
                 Button("New Multipoint", systemImage: "hand.point.up.braille") {
-                    model.startEditing(with: VertexTool(), geometryType: Multipoint.self)
+                    model.startEditing(with: geometryEditorTool, geometryType: Multipoint.self)
                 }
                 
                 Button("New Freehand Line", systemImage: "scribble") {

--- a/Shared/Samples/Snap geometry edits/SnapGeometryEditsView.GeometryEditorModel.swift
+++ b/Shared/Samples/Snap geometry edits/SnapGeometryEditsView.GeometryEditorModel.swift
@@ -101,6 +101,8 @@ extension SnapGeometryEditsView {
                 tool.configuration.scaleMode = scaleMode
             case let tool as VertexTool:
                 tool.configuration.scaleMode = scaleMode
+            case _ as ReticleVertexTool:
+                break
             default:
                 fatalError("Unexpected tool type")
             }


### PR DESCRIPTION
## Description

This PR updates `Snap geometry edits`
URL to README: https://github.com/Esri/arcgis-maps-sdk-swift-samples/tree/destiny/Use-reticle-vertex-tool-in-Snap-geometry-edits-sample/Shared/Samples/Snap%20geometry%20edits#readme

This PR uses the reticle vertex tool on touch screen devices.

## Linked Issue(s)

- `swift/issues/5730`

## Discussion
Should `ReticleVertexTool` be added to the relevant_apis metadata? I added it but it caused an inconsistent metadata error.