### PR TITLE
[Fix] Editing mode bug in favorites view

### DIFF
--- a/Shared/Supporting Files/Views/FavoritesView.swift
+++ b/Shared/Supporting Files/Views/FavoritesView.swift
@@ -16,7 +16,7 @@ import SwiftUI
 
 struct FavoritesView: View {
     /// The editing mode of the environment.
-    @State private var editMode: EditMode = .inactive
+    @Environment(\.editMode) private var editMode
     
     /// A Boolean value indicating whether the add favorite sheet is showing.
     @State private var addFavoriteSheetIsShowing = false
@@ -57,9 +57,8 @@ struct FavoritesView: View {
                 }
             }
         }
-        .environment(\.editMode, $editMode)
         .onDisappear {
-            editMode = .inactive
+            editMode?.wrappedValue = .inactive
         }
     }
 }

--- a/Shared/Supporting Files/Views/FavoritesView.swift
+++ b/Shared/Supporting Files/Views/FavoritesView.swift
@@ -16,7 +16,7 @@ import SwiftUI
 
 struct FavoritesView: View {
     /// The editing mode of the environment.
-    @Environment(\.editMode) private var editMode
+    @State private var editMode: EditMode = .inactive
     
     /// A Boolean value indicating whether the add favorite sheet is showing.
     @State private var addFavoriteSheetIsShowing = false
@@ -57,8 +57,9 @@ struct FavoritesView: View {
                 }
             }
         }
+        .environment(\.editMode, $editMode)
         .onDisappear {
-            editMode?.wrappedValue = .inactive
+            editMode = .inactive
         }
     }
 }

--- a/Shared/Supporting Files/Views/FavoritesView.swift
+++ b/Shared/Supporting Files/Views/FavoritesView.swift
@@ -15,6 +15,9 @@
 import SwiftUI
 
 struct FavoritesView: View {
+    /// The editing mode of the environment.
+    @Environment(\.editMode) private var editMode
+    
     /// A Boolean value indicating whether the add favorite sheet is showing.
     @State private var addFavoriteSheetIsShowing = false
     
@@ -53,6 +56,9 @@ struct FavoritesView: View {
                     AddFavoriteView()
                 }
             }
+        }
+        .onDisappear {
+            editMode?.wrappedValue = .inactive
         }
     }
 }


### PR DESCRIPTION
## Description

This PR fixes a bug where the "Edit" button in the Favorites view causes other samples to be untappable. The fix sets the environment editing mode to `.inactive` when the Favorites view is dismissed so that other views that show a list of samples are not displayed with an `.active` editing mode. 

## Linked Issue(s)

- `swift/issues/5405`

## How To Test
- Enter the Favorites category in the Sample Viewer.
- Tap the "Edit" button and back out of the category.
- Enter another category and verify that the samples can be opened.
