### PR TITLE
[Fix] Remove workaround for toolbar bug in AR samples

### DIFF
--- a/Shared/Samples/Augment reality to navigate route/AugmentRealityToNavigateRouteView.swift
+++ b/Shared/Samples/Augment reality to navigate route/AugmentRealityToNavigateRouteView.swift
@@ -64,32 +64,29 @@ struct AugmentRealityToNavigateRouteView: View {
                     try? await elevationSource.load()
                 }
         } else {
-            VStack(spacing: 0) {
-                WorldScaleSceneView { _ in
-                    SceneView(scene: scene, graphicsOverlays: [graphicsOverlay])
+            WorldScaleSceneView { _ in
+                SceneView(scene: scene, graphicsOverlays: [graphicsOverlay])
+            }
+            .calibrationButtonAlignment(.bottomLeading)
+            .onCalibratingChanged { isPresented in
+                scene.baseSurface.opacity = isPresented ? 0.6 : 0
+            }
+            .task {
+                try? await locationDataSource.start()
+                
+                for await location in locationDataSource.locations {
+                    try? await routeDataModel.routeTracker?.track(location)
                 }
-                .calibrationButtonAlignment(.bottomLeading)
-                .onCalibratingChanged { isPresented in
-                    scene.baseSurface.opacity = isPresented ? 0.6 : 0
-                }
-                .task {
-                    try? await locationDataSource.start()
-                    
-                    for await location in locationDataSource.locations {
-                        try? await routeDataModel.routeTracker?.track(location)
-                    }
-                }
-                .overlay(alignment: .top) {
-                    Text(statusText)
-                        .multilineTextAlignment(.center)
-                        .frame(maxWidth: .infinity, alignment: .center)
-                        .padding(8)
-                        .background(.regularMaterial, ignoresSafeAreaEdges: .horizontal)
-                }
-                .onDisappear {
-                    Task { await locationDataSource.stop() }
-                }
-                Divider()
+            }
+            .overlay(alignment: .top) {
+                Text(statusText)
+                    .multilineTextAlignment(.center)
+                    .frame(maxWidth: .infinity, alignment: .center)
+                    .padding(8)
+                    .background(.regularMaterial, ignoresSafeAreaEdges: .horizontal)
+            }
+            .onDisappear {
+                Task { await locationDataSource.stop() }
             }
             .toolbar {
                 ToolbarItemGroup(placement: .bottomBar) {
@@ -106,6 +103,7 @@ struct AugmentRealityToNavigateRouteView: View {
                     .disabled(isNavigating)
                 }
             }
+            .toolbarBackground(.visible, for: .bottomBar)
         }
     }
     

--- a/Shared/Samples/Augment reality to show hidden infrastructure/AugmentRealityToShowHiddenInfrastructureView.ARSceneView.swift
+++ b/Shared/Samples/Augment reality to show hidden infrastructure/AugmentRealityToShowHiddenInfrastructureView.ARSceneView.swift
@@ -45,7 +45,7 @@ extension AugmentRealityToShowHiddenInfrastructureView {
                     settingsMenu
                 }
             }
-            .toolbar(.visible, for: .bottomBar)
+            .toolbarBackground(.visible, for: .bottomBar)
         }
         
         /// The settings menu.

--- a/Shared/Samples/Augment reality to show hidden infrastructure/AugmentRealityToShowHiddenInfrastructureView.ARSceneView.swift
+++ b/Shared/Samples/Augment reality to show hidden infrastructure/AugmentRealityToShowHiddenInfrastructureView.ARSceneView.swift
@@ -29,26 +29,23 @@ extension AugmentRealityToShowHiddenInfrastructureView {
         @State private var leadersAreVisible = true
         
         var body: some View {
-            VStack(spacing: 0) {
-                WorldScaleSceneView { _ in
-                    SceneView(scene: model.scene, graphicsOverlays: [
-                        model.pipeGraphicsOverlay,
-                        model.shadowGraphicsOverlay,
-                        model.leaderGraphicsOverlay
-                    ])
-                }
-                .calibrationButtonAlignment(.bottomLeading)
-                .onCalibratingChanged { newCalibrating in
-                    model.scene.baseSurface.opacity = newCalibrating ? 0.6 : 0
-                }
-                
-                Divider()
+            WorldScaleSceneView { _ in
+                SceneView(scene: model.scene, graphicsOverlays: [
+                    model.pipeGraphicsOverlay,
+                    model.shadowGraphicsOverlay,
+                    model.leaderGraphicsOverlay
+                ])
+            }
+            .calibrationButtonAlignment(.bottomLeading)
+            .onCalibratingChanged { newCalibrating in
+                model.scene.baseSurface.opacity = newCalibrating ? 0.6 : 0
             }
             .toolbar {
                 ToolbarItem(placement: .bottomBar) {
                     settingsMenu
                 }
             }
+            .toolbar(.visible, for: .bottomBar)
         }
         
         /// The settings menu.


### PR DESCRIPTION
## Description

This PR removes the workaround for an issue in the AR samples where AR content would cover the toolbar.

## Linked Issue(s)

- `swift/issues/5112`

## How To Test
- Use the `Augment reality to collect data`, `Augment reality to navigate route`, or  `Augment reality to show hidden infrastructure` samples and verify that AR content does not cover the toolbar.
- Test on an iOS 16 device to verify fix on all iOS versions.

## Screenshots

|Before|After|
<img src="https://github.com/user-attachments/assets/acc20863-fb42-46f6-8058-7b724cd7196d" width="300"> <img src="https://github.com/user-attachments/assets/55939392-050a-42aa-ada9-b6693d3507d4" width="400">
