### PR TITLE
[Setup] Change the product name per App Store reviewer request

### DIFF
--- a/Samples.xcodeproj/project.pbxproj
+++ b/Samples.xcodeproj/project.pbxproj
@@ -772,7 +772,7 @@
 		00E5400C27F3CCA100CF66D5 /* SamplesApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SamplesApp.swift; sourceTree = "<group>"; };
 		00E5400D27F3CCA100CF66D5 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		00E5400E27F3CCA200CF66D5 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
-		00E5401327F3CCA200CF66D5 /* Samples.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Samples.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		00E5401327F3CCA200CF66D5 /* ArcGIS Maps SDK Samples.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "ArcGIS Maps SDK Samples.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		00E5402A27F775EA00CF66D5 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		00E7C1592BBE1BF000B85D69 /* SnapGeometryEditsView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SnapGeometryEditsView.swift; sourceTree = "<group>"; };
 		00F279D52AF418DC00CECAF8 /* AddDynamicEntityLayerView.VehicleCallout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddDynamicEntityLayerView.VehicleCallout.swift; sourceTree = "<group>"; };
@@ -1446,7 +1446,7 @@
 		00E5401427F3CCA200CF66D5 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				00E5401327F3CCA200CF66D5 /* Samples.app */,
+				00E5401327F3CCA200CF66D5 /* ArcGIS Maps SDK Samples.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -2803,7 +2803,7 @@
 				00C43AEC2947DC350099AE34 /* ArcGISToolkit */,
 			);
 			productName = "arcgis-swift-sdk-samples (iOS)";
-			productReference = 00E5401327F3CCA200CF66D5 /* Samples.app */;
+			productReference = 00E5401327F3CCA200CF66D5 /* ArcGIS Maps SDK Samples.app */;
 			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */
@@ -3362,7 +3362,7 @@
 				);
 				MARKETING_VERSION = 200.4.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.esri.arcgis-swift-sdk-samples";
-				PRODUCT_NAME = Samples;
+				PRODUCT_NAME = "ArcGIS Maps SDK Samples";
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = YES;
@@ -3393,7 +3393,7 @@
 				);
 				MARKETING_VERSION = 200.4.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.esri.arcgis-swift-sdk-samples";
-				PRODUCT_NAME = Samples;
+				PRODUCT_NAME = "ArcGIS Maps SDK Samples";
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = YES;

--- a/Samples.xcodeproj/xcshareddata/xcschemes/Samples.xcscheme
+++ b/Samples.xcodeproj/xcshareddata/xcschemes/Samples.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "00E5401227F3CCA200CF66D5"
-               BuildableName = "Samples.app"
+               BuildableName = "ArcGIS Maps SDK Samples.app"
                BlueprintName = "Samples"
                ReferencedContainer = "container:Samples.xcodeproj">
             </BuildableReference>
@@ -45,7 +45,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "00E5401227F3CCA200CF66D5"
-            BuildableName = "Samples.app"
+            BuildableName = "ArcGIS Maps SDK Samples.app"
             BlueprintName = "Samples"
             ReferencedContainer = "container:Samples.xcodeproj">
          </BuildableReference>
@@ -62,7 +62,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "00E5401227F3CCA200CF66D5"
-            BuildableName = "Samples.app"
+            BuildableName = "ArcGIS Maps SDK Samples.app"
             BlueprintName = "Samples"
             ReferencedContainer = "container:Samples.xcodeproj">
          </BuildableReference>


### PR DESCRIPTION
## Description

This PR changes the "Product Name" of the "Samples" target to "ArcGIS Maps SDK Samples", after the "App Information" > "Name" is changed from "ArcGIS Maps Swift Samples" to "ArcGIS Maps SDK Samples", per App Store reviewer request.

> Guideline 5.2.5 - Legal - Intellectual Property. 
> Your app's metadata includes content that is similar to designs or terms used for Apple products and services and may cause confusion for users. Specifically, your metadata includes:
> - Terms for Swift in the app name in an inappropriate manner.
> - Terms for Swift in the app name that displays on the device. 

and…

> Guideline 2.3.8 - Performance
> We noticed that your app name to be displayed on the App Store does not sufficiently match the name of the app displayed when installed on macOS.
> - App Store Connect Name: ArcGIS Maps Swift Samples
> - App Name when Installed: Samples
> - App Name when Launched: Samples
> - App Name in About/Quit Menu: Samples

We decided to make all the name consistent on iOS and macOS, by renaming the App Store listing and the changing the project's product name to "ArcGIS Maps SDK Samples".

## Linked Issue(s)

- `swift/issues/5372`
- `swift/issues/5417`

## How To Test

Build and run the app, see all the displayed names are now "ArcGIS Maps SDK Samples". Search the directory to see if there is any remaining "Samples.app" text anywhere.

