### PR TITLE
[Fix] `Play KML tour` category

### DIFF
--- a/Shared/Samples/Play KML tour/README.metadata.json
+++ b/Shared/Samples/Play KML tour/README.metadata.json
@@ -1,5 +1,5 @@
 {
-    "category": "Layers",
+    "category": "Visualization",
     "description": "Play tours in KML files.",
     "ignore": false,
     "images": [


### PR DESCRIPTION
## Description

This PR updates the `Play KML tour` category to match the design and [Kotlin implementation](https://github.com/Esri/arcgis-maps-sdk-kotlin-samples/blob/main/play-kml-tour/README.metadata.json).


