### PR TITLE
[Update] `Identify features in WMS layer` callout dismissal

### DIFF
--- a/Shared/Samples/Identify features in WMS layer/IdentifyFeaturesInWMSLayerView.swift
+++ b/Shared/Samples/Identify features in WMS layer/IdentifyFeaturesInWMSLayerView.swift
@@ -69,6 +69,8 @@ struct IdentifyFeaturesInWMSLayerView: View {
                         guard let screenPoint = tapScreenPoint else {
                             return
                         }
+                        calloutPlacement = nil
+                        
                         // Identify feature on water info layer.
                         let identifyResult = try await mapViewProxy.identify(
                             on: waterInfoLayer,
@@ -83,9 +85,6 @@ struct IdentifyFeaturesInWMSLayerView: View {
                            let location = mapViewProxy.location(fromScreenPoint: screenPoint) {
                             webViewText = htmlText
                             calloutPlacement = .location(location)
-                        } else {
-                            webViewText = ""
-                            calloutPlacement = nil
                         }
                     } catch {
                         self.error = error


### PR DESCRIPTION
## Description

This PR updates `Identify features in WMS layer` to dismiss the callout before async identify operation, so that the sample is more responsive.  

## How To Test

- Ensure the sample otherwise works as before.