### PR TITLE
[Fix] `Show service area` time breaks steppers

### DIFF
--- a/Shared/Samples/Show service area/ShowServiceAreaView.swift
+++ b/Shared/Samples/Show service area/ShowServiceAreaView.swift
@@ -138,7 +138,7 @@ private extension ShowServiceAreaView {
             return facilitiesGraphicsOverlay
         }()
         
-       private let barriersGraphicsOverlay: GraphicsOverlay = {
+        private let barriersGraphicsOverlay: GraphicsOverlay = {
             let barriersGraphicsOverlay = GraphicsOverlay()
             let barrierSymbol = SimpleFillSymbol(style: .diagonalCross, color: .red, outline: nil)
             // Sets symbol on barrier graphics overlay using renderer.
@@ -146,7 +146,7 @@ private extension ShowServiceAreaView {
             return barriersGraphicsOverlay
         }()
         
-       private let serviceAreaGraphicsOverlay = GraphicsOverlay()
+        private let serviceAreaGraphicsOverlay = GraphicsOverlay()
         
         /// The graphics overlays used by this model.
         var graphicsOverlays: [GraphicsOverlay] {

--- a/Shared/Samples/Show service area/ShowServiceAreaView.swift
+++ b/Shared/Samples/Show service area/ShowServiceAreaView.swift
@@ -28,6 +28,8 @@ struct ShowServiceAreaView: View {
     @State private var firstTimeBreak: Int = 3
     /// Second time break property set in second stepper.
     @State private var secondTimeBreak: Int = 8
+    /// A Boolean value indicating whether the time breaks settings are presented.
+    @State private var settingsArePresented = false
     
     /// The data model for the sample.
     @StateObject private var model = Model()
@@ -51,11 +53,25 @@ struct ShowServiceAreaView: View {
                     }
                     .pickerStyle(.segmented)
                     Spacer()
-                    Menu {
-                        Stepper("Second: \(secondTimeBreak)", value: $secondTimeBreak, in: 1...15)
-                        Stepper("First: \(firstTimeBreak)", value: $firstTimeBreak, in: 1...15)
-                    } label: {
-                        Label("Time Breaks", systemImage: "gear")
+                    Button("Time Breaks", systemImage: "gear") {
+                        settingsArePresented = true
+                    }
+                    .popover(isPresented: $settingsArePresented) {
+                        NavigationStack {
+                            Form {
+                                Stepper("First: \(firstTimeBreak)", value: $firstTimeBreak, in: 1...15)
+                                Stepper("Second: \(secondTimeBreak)", value: $secondTimeBreak, in: 1...15)
+                            }
+                            .navigationTitle("Time Breaks")
+                            .navigationBarTitleDisplayMode(.inline)
+                            .toolbar {
+                                ToolbarItem(placement: .confirmationAction) {
+                                    Button("Done") { settingsArePresented = false }
+                                }
+                            }
+                        }
+                        .presentationDetents([.fraction(0.25)])
+                        .frame(idealWidth: 320, idealHeight: 160)
                     }
                     Spacer()
                     Button("Service Area") {


### PR DESCRIPTION
## Description

This PR fixes a bug in the `Show service area` sample where the time break steppers (or sliders) would not work on iOS/iPadOS 16. The best I could come up with was replacing the `Menu` with a `popover`. Let me know if you think of a better solution, though.

## Linked Issue(s)

- `swift/issues/5776`

## How To Test

- Ensure the sample still works as expected.

## Screenshots

|Before|After|
|:-:|:-:|
|    ![Simulator Screenshot - iPhone 14 Pro - 2024-07-22 at 14 27 18](https://github.com/user-attachments/assets/ab6dc933-f596-4d0d-b1b4-07473482bed0)    |    ![Simulator Screenshot - iPhone 14 Pro - 2024-07-22 at 16 38 08](https://github.com/user-attachments/assets/d4cb3af7-49c4-4d6b-abaa-a7084a0497e0)    |

