### PR TITLE
[Fix] `Snap geometry edits` snap settings

### DIFF
--- a/Shared/Samples/Snap geometry edits/SnapGeometryEditsView.swift
+++ b/Shared/Samples/Snap geometry edits/SnapGeometryEditsView.swift
@@ -37,8 +37,8 @@ struct SnapGeometryEditsView: View {
     /// The error shown in the error alert.
     @State private var error: Error?
     
-    /// A Boolean value indicating whether all the operational layers are loaded.
-    @State private var layersAreLoaded = false
+    /// A Boolean value indicating whether all the snap sources on the map view are loaded.
+    @State private var snapSourcesAreLoaded = false
     
     /// A Boolean value indicating whether the snap settings are presented.
     @State private var showsSnapSettings = false
@@ -46,9 +46,9 @@ struct SnapGeometryEditsView: View {
     var body: some View {
         MapView(map: map, graphicsOverlays: [model.geometryOverlay])
             .geometryEditor(model.geometryEditor)
-            .task {
-                // Load every layer in the web map when the sample starts.
-                layersAreLoaded = await map.operationalLayers.load()
+            .onDrawStatusChanged { drawStatus in
+                guard !snapSourcesAreLoaded else { return }
+                snapSourcesAreLoaded = drawStatus == .completed
             }
             .toolbar {
                 ToolbarItemGroup(placement: .bottomBar) {
@@ -74,7 +74,7 @@ struct SnapGeometryEditsView: View {
                         .presentationDetents([.fraction(0.6)])
                         .frame(idealWidth: 320, idealHeight: 380)
                     }
-                    .disabled(!layersAreLoaded)
+                    .disabled(!snapSourcesAreLoaded)
                 }
             }
             .errorAlert(presentingError: $error)


### PR DESCRIPTION
## Description

This PR fixes a bug in `Snap geometry edits` where not all the  "Individual Source Snapping" toggles would show up if "Snap Settings" was pressed before the map view was finished drawing. The fix enables the button after the map view has finished drawing instead of after the operational layers have loaded.

## Linked Issue(s)

- `swift/issues/5775`

## How To Test

- Tap "Snap Settings" right after it becomes enabled to ensure all the toggles show up.

## Screenshots

|Before|After|
|:-:|:-:|
|    ![Simulator Screenshot - iPhone 15 Pro - 2024-07-22 at 14 29 24](https://github.com/user-attachments/assets/57ad5557-625c-4267-977b-ff03d8166a63)    |    ![Simulator Screenshot - iPhone 15 Pro - 2024-07-22 at 18 11 22](https://github.com/user-attachments/assets/cdde0105-97a2-4ad6-b68e-fe03c55a69b2)    |

