### PR TITLE
[Fix] Set vertex tool in `Create and edit geometries`

### DIFF
--- a/Shared/Samples/Create and edit geometries/CreateAndEditGeometriesView.swift
+++ b/Shared/Samples/Create and edit geometries/CreateAndEditGeometriesView.swift
@@ -465,6 +465,14 @@ private class GeometryEditorModel: ObservableObject {
         selectedGraphic = graphic
         graphic.isVisible = false
         let geometry = graphic.geometry!
+        
+        switch geometry {
+        case is Point, is Multipoint:
+            geometryEditor.tool = VertexTool()
+        default:
+            break
+        }
+        
         geometryEditor.start(withInitial: geometry)
         isStarted = true
     }


### PR DESCRIPTION
## Description

This PR sets the vertex tool in the `Create and edit geometries` sample based on [this](https://github.com/Esri/arcgis-maps-sdk-swift-samples/pull/452#discussion_r1688506167) feedback.

## How To Test

Use a shape tool and then try to edit a `Point` or `Multipoint` geometry.