### PR TITLE
[Fix] Remove `Create dynamic basemap gallery` hashable conformance

### DIFF
--- a/Shared/Samples/Create dynamic basemap gallery/CreateDynamicBasemapGalleryView.Views.swift
+++ b/Shared/Samples/Create dynamic basemap gallery/CreateDynamicBasemapGalleryView.Views.swift
@@ -69,19 +69,6 @@ extension CreateDynamicBasemapGalleryView {
     }
 }
 
-extension BasemapStyleLanguage: Hashable {
-    public func hash(into hasher: inout Hasher) {
-        switch self {
-        case .strategic(let strategy):
-            hasher.combine(strategy)
-        case .specific(let language):
-            hasher.combine(language)
-        @unknown default:
-            fatalError("Unknown basemap style language.")
-        }
-    }
-}
-
 private extension BasemapStyleLanguage {
     /// A human-readable label for the basemap style language.
     var label: String? {


### PR DESCRIPTION
## Description

This PR updates `Create dynamic basemap gallery` to remove the `BasemapStyleLanguage` hashable conformance as it was added at the API level.

## Linked Issue(s)

- `swift/issues/5801`

## How To Test

- Ensure the project builds using swift daily `200.5.0-4310`.
