### PR TITLE
[Fix] Editing bug in `Create and edit geometries`

### DIFF
--- a/Shared/Samples/Create and edit geometries/CreateAndEditGeometriesView.swift
+++ b/Shared/Samples/Create and edit geometries/CreateAndEditGeometriesView.swift
@@ -409,6 +409,7 @@ private class GeometryEditorModel: ObservableObject {
         geometryEditor.stop()
         isStarted = false
         selectedGraphic?.isVisible = true
+        selectedGraphic = nil
     }
     
     /// Returns the symbology for graphics saved to the graphics overlay.


### PR DESCRIPTION
## Description

This PR fixes a bug in the `Create and edit geometries` sample introduced in #452 by setting the selected graphic to `nil` when editing is cancelled. Otherwise the model still has the selected graphic set which causes unexpected behavior when adding a new graphic, resulting in the previously selected graphic to disappear.
