### PR TITLE
[Fix] Add navigation bar back button to samples

### DIFF
--- a/Shared/Samples/Augment reality to show hidden infrastructure/AugmentRealityToShowHiddenInfrastructureView.swift
+++ b/Shared/Samples/Augment reality to show hidden infrastructure/AugmentRealityToShowHiddenInfrastructureView.swift
@@ -104,12 +104,14 @@ struct AugmentRealityToShowHiddenInfrastructureView: View {
         .disabled(!geometryEditorCanUndo && !canDelete)
         Spacer()
         
-        NavigationLink {
-            ARPipesSceneView(model: model.sceneModel)
-        } label: {
-            Image(systemName: "camera")
+        NavigationStack {
+            NavigationLink {
+                ARPipesSceneView(model: model.sceneModel)
+            } label: {
+                Image(systemName: "camera")
+            }
+            .disabled(geometryEditorCanUndo || !canDelete)
         }
-        .disabled(geometryEditorCanUndo || !canDelete)
         Spacer()
         
         Button("Done", systemImage: "checkmark") {

--- a/Shared/Samples/Search for web map/SearchForWebMapView.swift
+++ b/Shared/Samples/Search for web map/SearchForWebMapView.swift
@@ -29,63 +29,65 @@ struct SearchForWebMapView: View {
     @State private var error: Error?
     
     var body: some View {
-        ScrollView {
-            LazyVStack {
-                ForEach(model.portalItems, id: \.id) { item in
-                    NavigationLink {
-                        SafeMapView(map: Map(item: item))
-                            .navigationTitle(item.title)
-                    } label: {
-                        PortalItemRowView(item: item)
-                    }
-                    .buttonStyle(.plain)
-                    .task {
-                        // Load the next results when the last item is reached.
-                        guard item.id == model.portalItems.last?.id else { return }
-                        
-                        resultsAreLoading = true
-                        defer { resultsAreLoading = false }
-                        
-                        do {
-                            try await model.findNextItems()
-                        } catch {
-                            self.error = error
+        NavigationStack {
+            ScrollView {
+                LazyVStack {
+                    ForEach(model.portalItems, id: \.id) { item in
+                        NavigationLink {
+                            SafeMapView(map: Map(item: item))
+                                .navigationTitle(item.title)
+                        } label: {
+                            PortalItemRowView(item: item)
+                        }
+                        .buttonStyle(.plain)
+                        .task {
+                            // Load the next results when the last item is reached.
+                            guard item.id == model.portalItems.last?.id else { return }
+                            
+                            resultsAreLoading = true
+                            defer { resultsAreLoading = false }
+                            
+                            do {
+                                try await model.findNextItems()
+                            } catch {
+                                self.error = error
+                            }
                         }
                     }
-                }
-                
-                if resultsAreLoading {
-                    ProgressView()
+                    
+                    if resultsAreLoading {
+                        ProgressView()
+                            .padding()
+                    } else if !query.isEmpty && model.portalItems.isEmpty {
+                        VStack {
+                            Text("No Results")
+                                .font(.headline)
+                            Text("Check spelling or try a new search.")
+                                .font(.footnote)
+                        }
                         .padding()
-                } else if !query.isEmpty && model.portalItems.isEmpty {
-                    VStack {
-                        Text("No Results")
-                            .font(.headline)
-                        Text("Check spelling or try a new search.")
-                            .font(.footnote)
                     }
-                    .padding()
                 }
             }
-        }
-        .background(Color(.secondarySystemBackground))
-        .searchable(
-            text: $query,
-            placement: .navigationBarDrawer(displayMode: .always),
-            prompt: "Web Maps"
-        )
-        .task(id: query) {
-            // Load new results when the query changes.
-            resultsAreLoading = true
-            defer { resultsAreLoading = false }
-            
-            do {
-                try await model.findItems(for: query)
-            } catch {
-                self.error = error
+            .background(Color(.secondarySystemBackground))
+            .searchable(
+                text: $query,
+                placement: .navigationBarDrawer(displayMode: .always),
+                prompt: "Web Maps"
+            )
+            .task(id: query) {
+                // Load new results when the query changes.
+                resultsAreLoading = true
+                defer { resultsAreLoading = false }
+                
+                do {
+                    try await model.findItems(for: query)
+                } catch {
+                    self.error = error
+                }
             }
+            .errorAlert(presentingError: $error)
         }
-        .errorAlert(presentingError: $error)
     }
 }
 


### PR DESCRIPTION
## Description

This PR adds a navigation bar back button to the following samples:
- `Augment reality to show hidden infrastructure`
- `Search for web map` 

## Linked Issue(s)

- `swift/issues/5798`

## How To Test
- Verify back button appears in samples.

## Screenshots

`Augment reality to show hidden infrastructure`

<img src="https://github.com/user-attachments/assets/b0d74bb2-e365-4c6f-bf80-370a76be36ab" width="400">


`Search for web map` 

<img src="https://github.com/user-attachments/assets/b5fec554-731d-41ba-8987-8c041d517e52" width="300">  <img src="https://github.com/user-attachments/assets/669ebc2b-7b97-430d-aa9e-4942f9343eb2" width="300">

