### PR TITLE
[Update] `Edit with branch versioning` version creation

### DIFF
--- a/Shared/Samples/Edit with branch versioning/EditWithBranchVersioningView.Model.swift
+++ b/Shared/Samples/Edit with branch versioning/EditWithBranchVersioningView.Model.swift
@@ -38,7 +38,7 @@ extension EditWithBranchVersioningView {
         }()
         
         /// A geodatabase connected to the damage assessment feature service.
-        private let serviceGeodatabase = ServiceGeodatabase(url: .damageAssessmentFeatureService)
+        let serviceGeodatabase = ServiceGeodatabase(url: .damageAssessmentFeatureService)
         
         /// The feature layer for displaying the damaged building features.
         private(set) var featureLayer: FeatureLayer!

--- a/Shared/Samples/Edit with branch versioning/EditWithBranchVersioningView.swift
+++ b/Shared/Samples/Edit with branch versioning/EditWithBranchVersioningView.swift
@@ -25,9 +25,6 @@ struct EditWithBranchVersioningView: View {
     /// The parameters used to create a new version.
     @State private var versionParameters: ServiceVersionParameters?
     
-    /// The text representing the status of the sample.
-    @State private var statusText = ""
-    
     /// The asynchronous action currently being preformed.
     @State private var selectedAction: AsyncAction? = .setUp
     
@@ -102,17 +99,14 @@ struct EditWithBranchVersioningView: View {
                     do {
                         switch selectedAction {
                         case .setUp:
-                            statusText = "Loading service geodatabase…"
                             try await model.setUp()
                             
                             guard let versionName = model.existingVersionNames.first else { break }
-                            statusText = "Version: \(versionName)"
                         case .makeVersion:
-                            let name = try await model.createVersion(parameters: versionParameters!)
-                            statusText = "Created: \(name)"
+                            let version = try await model.createVersion(parameters: versionParameters!)
+                            try await model.switchToVersion(named: version)
                         case .switchToVersion(let version):
                             try await model.switchToVersion(named: version)
-                            statusText = "Version: \(version)"
                         case .updateFeature:
                             try await model.updateFeature()
                         case .selectFeature(let screenPoint, let mapPoint):
@@ -139,7 +133,7 @@ struct EditWithBranchVersioningView: View {
                 }
         }
         .overlay(alignment: .top) {
-            Text(statusText)
+            Text("Version: \(model.serviceGeodatabase.versionName)")
                 .multilineTextAlignment(.center)
                 .frame(maxWidth: .infinity, alignment: .center)
                 .padding(8)


### PR DESCRIPTION
## Description

This PR updates `Edit with branch versioning` to automatically switch to a branch when it is created. This is to match the other implementation of the other platforms. I updated the to status overlay to only show the current branch name for the same reason.

## Linked Issue(s)

- `swift/issues/5789`

## How To Test

- Create a branch and ensure you can edit a feature without having to switch branches.
