### PR TITLE
[Update] Use `LabeledContent` in samples

### DIFF
--- a/Shared/Samples/Add dynamic entity layer/AddDynamicEntityLayerView.SettingsView.swift
+++ b/Shared/Samples/Add dynamic entity layer/AddDynamicEntityLayerView.SettingsView.swift
@@ -36,12 +36,10 @@ extension AddDynamicEntityLayerView {
                     
                     Section("Observations") {
                         VStack {
-                            HStack {
-                                Text("Observations per track")
-                                Spacer()
-                                Text(model.maximumObservations.formatted())
-                                    .foregroundStyle(.secondary)
-                            }
+                            LabeledContent(
+                                "Observations per track",
+                                value: model.maximumObservations.formatted()
+                            )
                             Slider(value: $model.maximumObservations, in: model.maxObservationRange, step: 1)
                         }
                         HStack {

--- a/Shared/Samples/Add features with contingent values/AddFeaturesWithContingentValuesView.AddFeatureView.swift
+++ b/Shared/Samples/Add features with contingent values/AddFeaturesWithContingentValuesView.AddFeatureView.swift
@@ -87,11 +87,11 @@ extension AddFeaturesWithContingentValuesView {
                     }
                     
                     VStack {
-                        HStack {
-                            Text("Exclusion Area Buffer Size")
-                            Spacer()
-                            Text("\(Int(selectedBufferSize ?? 0))")
-                        }
+                        LabeledContent(
+                            "Exclusion Area Buffer Size",
+                            value: selectedBufferSize ?? 0,
+                            format: .number.precision(.fractionLength(0))
+                        )
                         
                         Slider(
                             value: Binding(

--- a/Shared/Samples/Animate 3D graphic/Animate3DGraphicView.swift
+++ b/Shared/Samples/Animate 3D graphic/Animate3DGraphicView.swift
@@ -35,11 +35,11 @@ struct Animate3DGraphicView: View {
             VStack {
                 HStack {
                     Spacer()
-                    VStack {
-                        StatRow("Altitude", value: model.animation.currentFrame.altitude.formatted(.length))
-                        StatRow("Heading", value: model.animation.currentFrame.heading.formatted(.angle))
-                        StatRow("Pitch", value: model.animation.currentFrame.pitch.formatted(.angle))
-                        StatRow("Roll", value: model.animation.currentFrame.roll.formatted(.angle))
+                    VStack(spacing: 3) {
+                        LabeledContent("Altitude", value: model.animation.currentFrame.altitude, format: .length)
+                        LabeledContent("Heading", value: model.animation.currentFrame.heading, format: .angle)
+                        LabeledContent("Pitch", value: model.animation.currentFrame.pitch, format: .angle)
+                        LabeledContent("Roll", value: model.animation.currentFrame.roll, format: .angle)
                     }
                     .frame(width: 170, height: 100)
                     .padding([.leading, .trailing])
@@ -103,7 +103,7 @@ struct Animate3DGraphicView: View {
         List {
             Section("Mission") {
                 VStack {
-                    StatRow("Progress", value: model.animation.progress.formatted(.rounded))
+                    LabeledContent("Progress", value: model.animation.progress, format: .rounded)
                     ProgressView(value: model.animation.progress)
                 }
                 .padding(.vertical)
@@ -135,7 +135,7 @@ struct Animate3DGraphicView: View {
             Section {
                 ForEach(CameraProperty.allCases, id: \.self) { property in
                     VStack {
-                        StatRow(property.label, value: model.cameraPropertyTexts[property] ?? "")
+                        LabeledContent(property.label, value: model.cameraPropertyTexts[property] ?? "")
                         Slider(value: cameraPropertyBinding(for: property), in: property.range, step: 1)
                             .padding(.horizontal)
                     }
@@ -160,27 +160,6 @@ extension Animate3DGraphicView {
         case .distance: return $model.cameraController.cameraDistance
         case .heading: return $model.cameraController.cameraHeadingOffset
         case .pitch: return $model.cameraController.cameraPitchOffset
-        }
-    }
-    
-    /// A view for displaying a statistic name and value in a row.
-    struct StatRow: View {
-        /// The name of the statistic.
-        var label: String
-        /// The formatted value of the statistic.
-        var value: String
-        
-        init(_ label: String, value: String) {
-            self.label = label
-            self.value = value
-        }
-        
-        var body: some View {
-            HStack {
-                Text(label)
-                Spacer()
-                Text(value)
-            }
         }
     }
 }

--- a/Shared/Samples/Change map view background/ChangeMapViewBackgroundView.SettingsView.swift
+++ b/Shared/Samples/Change map view background/ChangeMapViewBackgroundView.SettingsView.swift
@@ -28,22 +28,11 @@ extension ChangeMapViewBackgroundView {
                     ColorPicker("Color", selection: $model.color)
                     ColorPicker("Line Color", selection: $model.lineColor)
                     VStack {
-                        HStack {
-                            Text("Line Width")
-                            Spacer()
-                            Text(model.lineWidth.formatted())
-                                .foregroundStyle(.secondary)
-                        }
+                        LabeledContent("Line Width", value: model.lineWidth.formatted())
                         Slider(value: $model.lineWidth, in: model.lineWidthRange, step: 1)
                     }
                     VStack {
-                        HStack {
-                            Text("Grid Size")
-                            Spacer()
-                            Text(model.size.formatted())
-                                .foregroundStyle(.secondary)
-                        }
-                        Spacer()
+                        LabeledContent("Grid Size", value: model.size.formatted())
                         Slider(value: $model.size, in: model.sizeRange, step: 1)
                     }
                 }

--- a/Shared/Samples/Configure clusters/ConfigureClustersView.SettingsView.swift
+++ b/Shared/Samples/Configure clusters/ConfigureClustersView.SettingsView.swift
@@ -58,12 +58,11 @@ extension ConfigureClustersView {
                             model.maxScale = Double(newMaxScale)
                         }
                         
-                        HStack {
-                            Text("Current Map Scale")
-                            Spacer()
-                            Text(mapViewScale, format: .number.precision(.fractionLength(0)))
-                                .foregroundStyle(.secondary)
-                        }
+                        LabeledContent(
+                            "Current Map Scale",
+                            value: mapViewScale,
+                            format: .number.precision(.fractionLength(0))
+                        )
                     }
                 }
                 .navigationTitle("Clustering Settings")

--- a/Shared/Samples/Create load report/CreateLoadReportView.Views.swift
+++ b/Shared/Samples/Create load report/CreateLoadReportView.Views.swift
@@ -32,9 +32,10 @@ extension CreateLoadReportView {
                                 .onTapGesture {
                                     model.deletePhase(phase)
                                 }
-                            Text("Phase: \(phase.name)")
-                            Spacer()
-                            Text(model.summaryForPhase(phase))
+                            LabeledContent(
+                                "Phase: \(phase.name)",
+                                value: model.summaryForPhase(phase)
+                            )
                         }
                     }
                     .onDelete { indexSet in

--- a/Shared/Samples/Densify and generalize geometry/DensifyAndGeneralizeGeometryView.SettingsView.swift
+++ b/Shared/Samples/Densify and generalize geometry/DensifyAndGeneralizeGeometryView.SettingsView.swift
@@ -32,11 +32,11 @@ extension DensifyAndGeneralizeGeometryView {
                             model.updateGraphics()
                         }
                     VStack {
-                        HStack {
-                            Text("Max Deviation")
-                            Spacer()
-                            Text(String(Int(model.maxDeviation)))
-                        }
+                        LabeledContent(
+                            "Max Deviation",
+                            value: model.maxDeviation,
+                            format: .number.precision(.fractionLength(0))
+                        )
                         Slider(value: $model.maxDeviation, in: 1...250)
                             .onChange(of: model.maxDeviation) { _ in
                                 model.updateGraphics()
@@ -50,11 +50,11 @@ extension DensifyAndGeneralizeGeometryView {
                             model.updateGraphics()
                         }
                     VStack {
-                        HStack {
-                            Text("Max Segment Length")
-                            Spacer()
-                            Text(String(Int(model.maxSegmentLength)))
-                        }
+                        LabeledContent(
+                            "Max Segment Length",
+                            value: model.maxSegmentLength,
+                            format: .number.precision(.fractionLength(0))
+                        )
                         Slider(value: $model.maxSegmentLength, in: 50...500)
                             .onChange(of: model.maxSegmentLength) { _ in
                                 model.updateGraphics()

--- a/Shared/Samples/Generate offline map with custom parameters/GenerateOfflineMapWithCustomParametersView.CustomParameters.swift
+++ b/Shared/Samples/Generate offline map with custom parameters/GenerateOfflineMapWithCustomParametersView.CustomParameters.swift
@@ -70,26 +70,29 @@ extension GenerateOfflineMapWithCustomParametersView {
                 Form {
                     Section("Adjust Basemap") {
                         VStack {
-                            Text("Min Scale Level")
-                                .badge(
-                                    Text(minScaleLevel, format: .number.precision(.fractionLength(0)))
-                                )
+                            LabeledContent(
+                                "Min Scale Level",
+                                value: minScaleLevel,
+                                format: .number.precision(.fractionLength(0))
+                            )
                             Slider(value: $minScaleLevel, in: scaleLevelRange, step: 1)
                         }
                         
                         VStack {
-                            Text("Max Scale Level")
-                                .badge(
-                                    Text(maxScaleLevel, format: .number.precision(.fractionLength(0)))
-                                )
+                            LabeledContent(
+                                "Max Scale Level",
+                                value: maxScaleLevel,
+                                format: .number.precision(.fractionLength(0))
+                            )
                             Slider(value: $maxScaleLevel, in: scaleLevelRange, step: 1.0)
                         }
                         
                         VStack {
-                            Text("Extent Buffer Distance")
-                                .badge(
-                                    Text(basemapExtentBufferDistance, format: .number.precision(.fractionLength(0)))
-                                )
+                            LabeledContent(
+                                "Extent Buffer Distance",
+                                value: basemapExtentBufferDistance,
+                                format: .number.precision(.fractionLength(0))
+                            )
                             Slider(value: $basemapExtentBufferDistance, in: basemapExtentBufferRange)
                         }
                     }
@@ -101,10 +104,11 @@ extension GenerateOfflineMapWithCustomParametersView {
                     
                     Section("Filter Feature Layer") {
                         VStack {
-                            Text("Min Hydrant Flow Rate")
-                                .badge(
-                                    Text(minHydrantFlowRate, format: .number.precision(.fractionLength(0)))
-                                )
+                            LabeledContent(
+                                "Min Hydrant Flow Rate",
+                                value: minHydrantFlowRate,
+                                format: .number.precision(.fractionLength(0))
+                            )
                             Slider(value: $minHydrantFlowRate, in: hydrantFlowRateRange, step: 1.0)
                         }
                     }

--- a/Shared/Samples/Orbit camera around object/OrbitCameraAroundObjectView.swift
+++ b/Shared/Samples/Orbit camera around object/OrbitCameraAroundObjectView.swift
@@ -108,10 +108,7 @@ private extension OrbitCameraAroundObjectView {
             NavigationStack {
                 List {
                     VStack {
-                        Text("Camera Heading")
-                            .badge(
-                                Text(cameraHeading, format: .degrees)
-                            )
+                        LabeledContent("Camera Heading", value: cameraHeading, format: .degrees)
                         
                         Slider(value: $cameraHeading.value, in: -45...45)
                             .onChange(of: cameraHeading.value) { newValue in
@@ -120,10 +117,7 @@ private extension OrbitCameraAroundObjectView {
                     }
                     
                     VStack {
-                        Text("Plane Pitch")
-                            .badge(
-                                Text(planePitch, format: .degrees)
-                            )
+                        LabeledContent("Plane Pitch", value: planePitch, format: .degrees)
                         
                         Slider(value: $planePitch.value, in: -90...90)
                             .onChange(of: planePitch.value) { newValue in

--- a/Shared/Samples/Set visibility of subtype sublayer/SetVisibilityOfSubtypeSublayerView.Views.swift
+++ b/Shared/Samples/Set visibility of subtype sublayer/SetVisibilityOfSubtypeSublayerView.Views.swift
@@ -42,12 +42,7 @@ extension SetVisibilityOfSubtypeSublayerView {
                         }
                 }
                 Section("Sublayer Minimum Scale") {
-                    HStack {
-                        Text("Minimum Scale")
-                        Spacer()
-                        Text(model.minimumScaleText)
-                            .foregroundStyle(.secondary)
-                    }
+                    LabeledContent("Minimum Scale", value: model.minimumScaleText)
                     HStack {
                         Button("Set Current to Minimum Scale") {
                             model.setMinimumScale()

--- a/Shared/Samples/Show viewshed from point in scene/ShowViewshedFromPointInSceneView.ViewshedSettingsView.swift
+++ b/Shared/Samples/Show viewshed from point in scene/ShowViewshedFromPointInSceneView.ViewshedSettingsView.swift
@@ -66,15 +66,14 @@ extension ShowViewshedFromPointInSceneView {
         
         var body: some View {
             VStack {
-                HStack {
-                    Text(label)
-                    Spacer()
-                    Text(
-                        Measurement(value: measurementValue, unit: unit),
-                        format: .measurement(width: .narrow, numberFormatStyle: .number.precision(.fractionLength(0)))
+                LabeledContent(
+                    label,
+                    value: Measurement(value: measurementValue, unit: unit),
+                    format: .measurement(
+                        width: .narrow,
+                        numberFormatStyle: .number.precision(.fractionLength(0))
                     )
-                    .foregroundStyle(.secondary)
-                }
+                )
                 Slider(value: $measurementValue, in: range)
             }
         }

--- a/Shared/Samples/Style symbols from mobile style file/StyleSymbolsFromMobileStyleFileView.SymbolOptionsListView.swift
+++ b/Shared/Samples/Style symbols from mobile style file/StyleSymbolsFromMobileStyleFileView.SymbolOptionsListView.swift
@@ -49,12 +49,11 @@ extension StyleSymbolsFromMobileStyleFileView {
                     Section {
                         ColorPicker("Color", selection: $model.symbolOptionSelections.color)
                         VStack {
-                            HStack {
-                                Text("Size")
-                                Spacer()
-                                Text(model.symbolOptionSelections.size.formatted(.number.rounded()))
-                                    .foregroundStyle(.secondary)
-                            }
+                            LabeledContent(
+                                "Size",
+                                value: model.symbolOptionSelections.size,
+                                format: .number.rounded()
+                            )
                             Slider(value: $model.symbolOptionSelections.size, in: 20...60, step: 1)
                         }
                     }

--- a/Shared/Supporting Files/Views/AboutView.swift
+++ b/Shared/Supporting Files/Views/AboutView.swift
@@ -21,6 +21,10 @@ struct AboutView: View {
         Text("Copyright © 2022 - 2024 Esri. All Rights Reserved.")
     }
     
+    let arcGISVersion = Bundle.arcGIS.version.isEmpty
+    ? Bundle.arcGIS.shortVersion
+    : "\(Bundle.arcGIS.shortVersion) (\(Bundle.arcGIS.version))"
+    
     var body: some View {
         NavigationStack {
             List {
@@ -37,8 +41,8 @@ struct AboutView: View {
                     .frame(maxWidth: .infinity)
                 }
                 Section {
-                    VersionRow(title: "Version", version: Bundle.main.shortVersion)
-                    VersionRow(title: "SDK Version", version: Bundle.arcGIS.shortVersion, build: Bundle.arcGIS.version)
+                    LabeledContent("Version", value: Bundle.main.shortVersion)
+                    LabeledContent("SDK Version", value: arcGISVersion)
                 }
                 Section(header: Text("Powered By")) {
                     Link("ArcGIS Maps SDK for Swift Toolkit", destination: .toolkit)
@@ -63,35 +67,6 @@ struct AboutView: View {
                     }
                 }
             }
-        }
-    }
-}
-
-private struct VersionRow: View {
-    let title: String
-    let version: String
-    let build: String
-    
-    init(title: String, version: String, build: String = "") {
-        self.title = title
-        self.version = version
-        self.build = build
-    }
-    
-    var versionText: Text {
-        if !build.isEmpty {
-            return Text("\(version) (\(build))")
-        } else {
-            return Text("\(version)")
-        }
-    }
-    
-    var body: some View {
-        HStack {
-            Text(title)
-            Spacer()
-            versionText
-                .foregroundStyle(.secondary)
         }
     }
 }


### PR DESCRIPTION
## Description

This PR updates the samples and sample viewer to use `LabeledContent` to display label/value pairs instead of using a `HStack` or `badge(_:)` modifier. The affected samples should be functionally equivalently with minimal UI changes. Generally, the value now has a `secondary` foreground style if it didn't already.

## Linked Issue(s)

- `swift/issues/5822`

## How To Test

- Ensure that the label/value pairs display as expected in the affected samples.

Replacing `FavoritesView.favoriteSamples` in `arcgis-maps-sdk-swift-samples/Shared/Supporting Files/Views/FavoritesView.swift` with the following code will load all of the affected samples in the "Favorites" category for easy testing.

<details><summary>Test Code</summary><p>

```swift
private var favoriteSamples: [Sample] {
    let sampleViews: [any View] = [
        AddDynamicEntityLayerView(),
        AddFeaturesWithContingentValuesView(),
        Animate3DGraphicView(),
        ChangeMapViewBackgroundView(),
        ConfigureClustersView(),
        CreateLoadReportView(),
        DensifyAndGeneralizeGeometryView(),
        GenerateOfflineMapWithCustomParametersView(),
        OrbitCameraAroundObjectView(),
        SetVisibilityOfSubtypeSublayerView(),
        ShowViewshedFromPointInSceneView(),
        StyleSymbolsFromMobileStyleFileView()
    ]
    
    return sampleViews.map { view in
        let sampleName = "\(type(of: view))"
            .dropLast(4)
        return SamplesApp.samples.first { $0.nameInUpperCamelCase == sampleName }!
    }
}
```

</p></details>  

