### PR TITLE
[Fix] `Edit with branch versioning` unneeded guard

### DIFF
--- a/Shared/Samples/Edit with branch versioning/EditWithBranchVersioningView.swift
+++ b/Shared/Samples/Edit with branch versioning/EditWithBranchVersioningView.swift
@@ -100,8 +100,6 @@ struct EditWithBranchVersioningView: View {
                         switch selectedAction {
                         case .setUp:
                             try await model.setUp()
-                            
-                            guard let versionName = model.existingVersionNames.first else { break }
                         case .makeVersion:
                             let version = try await model.createVersion(parameters: versionParameters!)
                             try await model.switchToVersion(named: version)


### PR DESCRIPTION
## Description

This PR removes unneeded guard in `Edit with branch versioning` that I missed when doing #479.

## Linked Issue(s)

- `swift/issues/5789`