### PR TITLE
[Fix] `Search for web map` navigation bugs

### DIFF
--- a/Shared/Samples/Augment reality to show hidden infrastructure/AugmentRealityToShowHiddenInfrastructureView.swift
+++ b/Shared/Samples/Augment reality to show hidden infrastructure/AugmentRealityToShowHiddenInfrastructureView.swift
@@ -104,14 +104,12 @@ struct AugmentRealityToShowHiddenInfrastructureView: View {
         .disabled(!geometryEditorCanUndo && !canDelete)
         Spacer()
         
-        NavigationStack {
-            NavigationLink {
-                ARPipesSceneView(model: model.sceneModel)
-            } label: {
-                Image(systemName: "camera")
-            }
-            .disabled(geometryEditorCanUndo || !canDelete)
+        NavigationLink {
+            ARPipesSceneView(model: model.sceneModel)
+        } label: {
+            Image(systemName: "camera")
         }
+        .disabled(geometryEditorCanUndo || !canDelete)
         Spacer()
         
         Button("Done", systemImage: "checkmark") {

--- a/Shared/Supporting Files/Views/ContentView.swift
+++ b/Shared/Supporting Files/Views/ContentView.swift
@@ -38,7 +38,9 @@ struct ContentView: View {
         } content: {
             Text("No Category Selected")
         } detail: {
-            Text("No Sample Selected")
+            NavigationStack {
+                Text("No Sample Selected")
+            }
         }
     }
 }


### PR DESCRIPTION
## Description

This PR fixes a regression where opening the `Search for web map` sample would just show "No Sample Selected" on iPhone (iOS 17). This was caused by the navigation stack added in  #477. Those changes were reverted, and the stack was moved to the `NavigationSplitView` detail. This solution should work for samples that use a navigation link in the future.

## Linked Issue(s)

- `swift/issues/5798`

## How To Test

Test the `Search for web map` and `Augment reality to show hidden infrastructure` samples:

- On iPhone, ensure the samples launch as expected.
- On iPad, ensure the samples have a navigation back button after clicking the navigation link in landscape mode.

## Screenshots

|Before|After|
|:-:|:-:|
|    ![Simulator Screenshot - 1 - iPhone 15 Pro - 2024-07-30 at 11 48 56](https://github.com/user-attachments/assets/81c4fe50-fcc8-49cf-ad6e-2236b2baed4f)    |    ![Simulator Screenshot - 1 - iPhone 15 Pro - 2024-07-30 at 12 08 49](https://github.com/user-attachments/assets/a3529735-348e-4e4e-b09e-f32ad9330ea0)    |



