### PR TITLE
[Fix] Remove unused imports

### DIFF
--- a/Shared/Samples/Add features with contingent values/AddFeaturesWithContingentValuesView.Model.swift
+++ b/Shared/Samples/Add features with contingent values/AddFeaturesWithContingentValuesView.Model.swift
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 import ArcGIS
-import SwiftUI
+import Combine
+import Foundation
 
 extension AddFeaturesWithContingentValuesView {
     /// The view model for the sample.

--- a/Shared/Samples/Animate 3D graphic/Animate3DGraphicView.Model.swift
+++ b/Shared/Samples/Animate 3D graphic/Animate3DGraphicView.Model.swift
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 import ArcGIS
-import SwiftUI
+import Combine
+import QuartzCore
 
 extension Animate3DGraphicView {
     /// The view model for the sample.

--- a/Shared/Samples/Augment reality to navigate route/AugmentRealityToNavigateRouteView.ARSceneView.swift
+++ b/Shared/Samples/Augment reality to navigate route/AugmentRealityToNavigateRouteView.ARSceneView.swift
@@ -14,7 +14,7 @@
 
 import ArcGIS
 import ArcGISToolkit
-import AVFoundation
+import AVFAudio
 import SwiftUI
 
 extension AugmentRealityToNavigateRouteView {

--- a/Shared/Samples/Augment reality to navigate route/AugmentRealityToNavigateRouteView.swift
+++ b/Shared/Samples/Augment reality to navigate route/AugmentRealityToNavigateRouteView.swift
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import ArcGIS
-import ArcGISToolkit
 import CoreLocation
 import SwiftUI
 

--- a/Shared/Samples/Create load report/CreateLoadReportView.swift
+++ b/Shared/Samples/Create load report/CreateLoadReportView.swift
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import ArcGIS
 import SwiftUI
 
 struct CreateLoadReportView: View {

--- a/Shared/Samples/Densify and generalize geometry/DensifyAndGeneralizeGeometryView.SettingsView.swift
+++ b/Shared/Samples/Densify and generalize geometry/DensifyAndGeneralizeGeometryView.SettingsView.swift
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import ArcGIS
 import SwiftUI
 
 extension DensifyAndGeneralizeGeometryView {

--- a/Shared/Samples/Edit feature attachments/EditFeatureAttachmentsView.Model.swift
+++ b/Shared/Samples/Edit feature attachments/EditFeatureAttachmentsView.Model.swift
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 import ArcGIS
-import SwiftUI
+import Combine
+import Foundation
 
 extension EditFeatureAttachmentsView {
     @MainActor

--- a/Shared/Samples/Find route around barriers/FindRouteAroundBarriersView.Model.swift
+++ b/Shared/Samples/Find route around barriers/FindRouteAroundBarriersView.Model.swift
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 import ArcGIS
-import SwiftUI
+import Combine
+import UIKit
 
 extension FindRouteAroundBarriersView {
     /// The view model for the sample.

--- a/Shared/Samples/Find route in mobile map package/FindRouteInMobileMapPackageView.Models.swift
+++ b/Shared/Samples/Find route in mobile map package/FindRouteInMobileMapPackageView.Models.swift
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 import ArcGIS
-import SwiftUI
+import Combine
+import UIKit
 
 extension FindRouteInMobileMapPackageView {
     /// The view model for the `FindRouteInMobileMapPackageView`.

--- a/Shared/Samples/Find route in transport network/FindRouteInTransportNetworkView.Model.swift
+++ b/Shared/Samples/Find route in transport network/FindRouteInTransportNetworkView.Model.swift
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 import ArcGIS
-import SwiftUI
+import Combine
+import UIKit
 
 extension FindRouteInTransportNetworkView {
     /// The view model for the sample.

--- a/Shared/Samples/Find route in transport network/FindRouteInTransportNetworkView.Model.swift
+++ b/Shared/Samples/Find route in transport network/FindRouteInTransportNetworkView.Model.swift
@@ -29,7 +29,7 @@ extension FindRouteInTransportNetworkView {
             let tiledLayer = ArcGISTiledLayer(tileCache: tileCache)
             let tiledBasemap = Basemap(baseLayer: tiledLayer)
             
-            // Create a map with the basemap and center it on San Deigo.
+            // Create a map with the basemap and center it on San Diego.
             let map = Map(basemap: tiledBasemap)
             map.initialViewpoint = Viewpoint(
                 center: Point(x: -13_042_250, y: 3_857_970, spatialReference: .webMercator),

--- a/Shared/Samples/Generate offline map with custom parameters/GenerateOfflineMapWithCustomParametersView.CustomParameters.swift
+++ b/Shared/Samples/Generate offline map with custom parameters/GenerateOfflineMapWithCustomParametersView.CustomParameters.swift
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import ArcGIS
 import SwiftUI
 
 extension GenerateOfflineMapWithCustomParametersView {

--- a/Shared/Samples/Geocode offline/GeocodeOfflineView.Model.swift
+++ b/Shared/Samples/Geocode offline/GeocodeOfflineView.Model.swift
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 import ArcGIS
-import SwiftUI
+import Combine
+import UIKit
 
 extension GeocodeOfflineView {
     /// The view model for the sample.

--- a/Shared/Samples/List spatial reference transformations/ListSpatialReferenceTransformationsView.Model.swift
+++ b/Shared/Samples/List spatial reference transformations/ListSpatialReferenceTransformationsView.Model.swift
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 import ArcGIS
-import SwiftUI
+import Combine
+import Foundation
 
 extension ListSpatialReferenceTransformationsView {
     /// The view model for the sample.

--- a/Shared/Samples/Navigate route with rerouting/NavigateRouteWithReroutingView.Model.swift
+++ b/Shared/Samples/Navigate route with rerouting/NavigateRouteWithReroutingView.Model.swift
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import ArcGIS
-import AVFoundation
+import AVFAudio
 import Combine
 
 extension NavigateRouteWithReroutingView {

--- a/Shared/Samples/Navigate route/NavigateRouteView.swift
+++ b/Shared/Samples/Navigate route/NavigateRouteView.swift
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import ArcGIS
-import AVFoundation
+import AVFAudio
 import SwiftUI
 
 struct NavigateRouteView: View {

--- a/Shared/Samples/Orbit camera around object/OrbitCameraAroundObjectView.Model.swift
+++ b/Shared/Samples/Orbit camera around object/OrbitCameraAroundObjectView.Model.swift
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 import ArcGIS
-import SwiftUI
+import Combine
+import Foundation
 
 extension OrbitCameraAroundObjectView {
     /// The view model for the sample.

--- a/Shared/Samples/Search for web map/SearchForWebMapView.Model.swift
+++ b/Shared/Samples/Search for web map/SearchForWebMapView.Model.swift
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 import ArcGIS
-import SwiftUI
+import Combine
+import Foundation
 
 extension SearchForWebMapView {
     /// The view model for the sample.

--- a/Shared/Samples/Search for web map/SearchForWebMapView.Views.swift
+++ b/Shared/Samples/Search for web map/SearchForWebMapView.Views.swift
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import ArcGIS
-import ArcGISToolkit
 import SwiftUI
 
 extension SearchForWebMapView {

--- a/Shared/Samples/Set visibility of subtype sublayer/SetVisibilityOfSubtypeSublayerView.Views.swift
+++ b/Shared/Samples/Set visibility of subtype sublayer/SetVisibilityOfSubtypeSublayerView.Views.swift
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import ArcGIS
 import SwiftUI
 
 extension SetVisibilityOfSubtypeSublayerView {

--- a/Shared/Samples/Show device location with NMEA data sources/ShowDeviceLocationWithNMEADataSourcesView.swift
+++ b/Shared/Samples/Show device location with NMEA data sources/ShowDeviceLocationWithNMEADataSourcesView.swift
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import ArcGIS
-import ExternalAccessory
 import SwiftUI
 
 struct ShowDeviceLocationWithNMEADataSourcesView: View {

--- a/Shared/Samples/Style symbols from mobile style file/StyleSymbolsFromMobileStyleFileView.SymbolOptionsListView.swift
+++ b/Shared/Samples/Style symbols from mobile style file/StyleSymbolsFromMobileStyleFileView.SymbolOptionsListView.swift
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import ArcGIS
 import SwiftUI
 
 extension StyleSymbolsFromMobileStyleFileView {

--- a/Shared/Samples/Validate utility network topology/ValidateUtilityNetworkTopologyView.Model.swift
+++ b/Shared/Samples/Validate utility network topology/ValidateUtilityNetworkTopologyView.Model.swift
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 import ArcGIS
-import SwiftUI
+import Combine
+import UIKit
 
 extension ValidateUtilityNetworkTopologyView {
     /// The view model for the sample.

--- a/Shared/Supporting Files/Extensions/String.swift
+++ b/Shared/Supporting Files/Extensions/String.swift
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import Foundation
-
 extension String {
     /// The key to read and write the names of the favorite samples to the user defaults.
     static var favoriteSampleNames: String { "favoriteSampleNames" }


### PR DESCRIPTION
## Description

This PR removes unnecessary imports that were discovered by running the swift lint `unused_import` analyzer rule.

## Linked Issue(s)

Similar to #257

## How To Test

- Ensure the project builds.
