### PR TITLE
[Fix] Remove unused declarations

### DIFF
--- a/Shared/Samples/Analyze network with subnetwork trace/AnalyzeNetworkWithSubnetworkTraceView.swift
+++ b/Shared/Samples/Analyze network with subnetwork trace/AnalyzeNetworkWithSubnetworkTraceView.swift
@@ -31,9 +31,6 @@ struct AnalyzeNetworkWithSubnetworkTraceView: View {
     /// A Boolean value indicating if the add condition menu is presented.
     @State private var isConditionMenuPresented = false
     
-    /// A Boolean value indicating whether the input box is showing.
-    @State private var inputBoxIsPresented = false
-    
     /// The value input by the user.
     @State private var inputValue: Double?
     

--- a/Shared/Samples/Augment reality to collect data/AugmentRealityToCollectDataView.swift
+++ b/Shared/Samples/Augment reality to collect data/AugmentRealityToCollectDataView.swift
@@ -137,8 +137,6 @@ private extension AugmentRealityToCollectDataView {
             graphicsOverlay.sceneProperties.surfacePlacement = .absolute
             return graphicsOverlay
         }()
-        /// The selected tree health for the new feature.
-        @State private var treeHealth: TreeHealth?
         
         init() {
             let featureLayer = FeatureLayer(featureTable: featureTable)

--- a/Shared/Samples/Change camera controller/ChangeCameraControllerView.swift
+++ b/Shared/Samples/Change camera controller/ChangeCameraControllerView.swift
@@ -66,9 +66,6 @@ struct ChangeCameraControllerView: View {
         return graphicsOverlay
     }()
     
-    /// A Boolean value indicating whether the settings view should be presented.
-    @State private var isShowingSettings = false
-    
     /// The camera controller kind of the scene view.
     @State private var cameraControllerKind: CameraControllerKind = .globe
     

--- a/Shared/Samples/Create dynamic basemap gallery/CreateDynamicBasemapGalleryView.Views.swift
+++ b/Shared/Samples/Create dynamic basemap gallery/CreateDynamicBasemapGalleryView.Views.swift
@@ -69,20 +69,6 @@ extension CreateDynamicBasemapGalleryView {
     }
 }
 
-private extension BasemapStyleLanguage {
-    /// A human-readable label for the basemap style language.
-    var label: String? {
-        switch self {
-        case .strategic(let strategy):
-            strategy.label
-        case .specific(let language):
-            language.label
-        @unknown default:
-            fatalError("Unknown basemap style language.")
-        }
-    }
-}
-
 private extension BasemapStyleLanguageStrategy {
     /// A human-readable label for the basemap style language strategy.
     var label: String {

--- a/Shared/Samples/Find route/FindRouteView.swift
+++ b/Shared/Samples/Find route/FindRouteView.swift
@@ -120,10 +120,6 @@ private extension FindRouteView {
         
         /// The graphic for the route.
         private var routeGraphic: Graphic { routeGraphicsOverlay.graphics.first! }
-        /// The graphic for the first stop.
-        private var stopOneGraphic: Graphic { stopGraphicsOverlay.graphics.first! }
-        /// The graphic for the second stop.
-        private var stopTwoGraphic: Graphic { stopGraphicsOverlay.graphics.last! }
         
         init() {
             // Initializes the map

--- a/Shared/Samples/Validate utility network topology/ValidateUtilityNetworkTopologyView.swift
+++ b/Shared/Samples/Validate utility network topology/ValidateUtilityNetworkTopologyView.swift
@@ -31,9 +31,6 @@ struct ValidateUtilityNetworkTopologyView: View {
     /// A Boolean value indicating whether the edit feature sheet is presented.
     @State private var editSheetIsPresented = false
     
-    /// A Boolean value indicating whether the details of the status message are presented.
-    @State private var statusDetailsArePresented = false
-    
     /// The error shown in the error alert.
     @State private var error: Error?
     

--- a/Shared/Supporting Files/Views/SamplesSearchView.swift
+++ b/Shared/Supporting Files/Views/SamplesSearchView.swift
@@ -88,11 +88,6 @@ private extension SamplesSearchView {
         let descriptionMatches: [Sample]
         /// The samples which one of the tags matches the search query.
         let tagMatches: [Sample]
-        
-        /// A Boolean value indicating whether all the matches are empty.
-        var isEmpty: Bool {
-            nameMatches.isEmpty && descriptionMatches.isEmpty && tagMatches.isEmpty
-        }
     }
     
     /// Searches through the list of samples to find ones that match the query.


### PR DESCRIPTION
## Description

This PR removes unused declarations that were discovered by running the swift lint `unused_declaration` analyzer rule.

## How To Test

- Ensure the project builds.
