### PR TITLE
[Update] Sample type and member access levels

### DIFF
--- a/Shared/Samples/Add custom dynamic entity data source/AddCustomDynamicEntityDataSourceView.swift
+++ b/Shared/Samples/Add custom dynamic entity data source/AddCustomDynamicEntityDataSourceView.swift
@@ -65,7 +65,7 @@ struct AddCustomDynamicEntityDataSourceView: View {
     }
     
     /// Makes a map with a dynamic entity layer.
-    static func makeMap() -> Map {
+    private static func makeMap() -> Map {
         let map = Map(basemapStyle: .arcGISOceans)
         map.initialViewpoint = Viewpoint(
             latitude: 47.984,

--- a/Shared/Samples/Add dynamic entity layer/AddDynamicEntityLayerView.Model.swift
+++ b/Shared/Samples/Add dynamic entity layer/AddDynamicEntityLayerView.Model.swift
@@ -88,9 +88,9 @@ private extension URL {
     )!
 }
 
-extension ConnectionStatus: CustomStringConvertible {
+extension ConnectionStatus {
     /// A user-friendly string for `ConnectionStatus`.
-    public var description: String {
+    var description: String {
         switch self {
         case .connecting:
             return "Connecting"

--- a/Shared/Samples/Add dynamic entity layer/AddDynamicEntityLayerView.swift
+++ b/Shared/Samples/Add dynamic entity layer/AddDynamicEntityLayerView.swift
@@ -32,7 +32,7 @@ struct AddDynamicEntityLayerView: View {
     @State private var placement: CalloutPlacement?
     
     /// A Boolean value indicating if the stream service is connected.
-    var isConnected: Bool {
+    private var isConnected: Bool {
         model.streamService.connectionStatus == .connected
     }
     

--- a/Shared/Samples/Analyze network with subnetwork trace/AnalyzeNetworkWithSubnetworkTraceView.Model.swift
+++ b/Shared/Samples/Analyze network with subnetwork trace/AnalyzeNetworkWithSubnetworkTraceView.Model.swift
@@ -371,7 +371,7 @@ private extension ArcGISCredential {
     }
 }
 
-extension AnalyzeNetworkWithSubnetworkTraceView.Model {
+private extension AnalyzeNetworkWithSubnetworkTraceView.Model {
     /// An error returned when data required to setup the sample cannot be found.
     struct SetupError: LocalizedError {
         var errorDescription: String? {

--- a/Shared/Samples/Analyze network with subnetwork trace/AnalyzeNetworkWithSubnetworkTraceView.swift
+++ b/Shared/Samples/Analyze network with subnetwork trace/AnalyzeNetworkWithSubnetworkTraceView.swift
@@ -97,7 +97,7 @@ struct AnalyzeNetworkWithSubnetworkTraceView: View {
         }
     }
     
-    @ViewBuilder var toolbarItems: some View {
+    @ViewBuilder private var toolbarItems: some View {
         Button("Reset") {
             model.reset()
         }
@@ -124,7 +124,7 @@ struct AnalyzeNetworkWithSubnetworkTraceView: View {
         .disabled(!model.traceEnabled)
     }
     
-    @ViewBuilder var loadingView: some View {
+    @ViewBuilder private var loadingView: some View {
         ZStack {
             if !model.statusText.isEmpty {
                 Color.clear.background(.ultraThinMaterial)
@@ -142,7 +142,7 @@ struct AnalyzeNetworkWithSubnetworkTraceView: View {
         .errorAlert(presentingError: $error)
     }
     
-    @ViewBuilder var conditionMenu: some View {
+    @ViewBuilder private var conditionMenu: some View {
         List {
             NavigationLink {
                 attributesView
@@ -239,7 +239,7 @@ struct AnalyzeNetworkWithSubnetworkTraceView: View {
         }
     }
     
-    @ViewBuilder var attributesView: some View {
+    @ViewBuilder private var attributesView: some View {
         List(model.possibleAttributes, id: \.name) { attribute in
             HStack {
                 Text(attribute.name)
@@ -257,7 +257,7 @@ struct AnalyzeNetworkWithSubnetworkTraceView: View {
         .navigationTitle("Attributes")
     }
     
-    @ViewBuilder var operatorsView: some View {
+    @ViewBuilder private var operatorsView: some View {
         Section {
             List(UtilityNetworkAttributeComparison.Operator.allCases, id: \.self) { comparison in
                 HStack {
@@ -277,7 +277,7 @@ struct AnalyzeNetworkWithSubnetworkTraceView: View {
         .navigationTitle("Operators")
     }
     
-    @ViewBuilder var valuesView: some View {
+    @ViewBuilder private var valuesView: some View {
         if let domain = selectedAttribute?.domain as? CodedValueDomain {
             Section {
                 List(domain.codedValues, id: \.name) { value in

--- a/Shared/Samples/Animate 3D graphic/Animate3DGraphicView.swift
+++ b/Shared/Samples/Animate 3D graphic/Animate3DGraphicView.swift
@@ -151,7 +151,7 @@ struct Animate3DGraphicView: View {
     }
 }
 
-extension Animate3DGraphicView {
+private extension Animate3DGraphicView {
     /// Creates a binding to a camera controller property based on a given property.
     /// - Parameter property: The property associated with a corresponding camera controller property.
     /// - Returns: A binding to a camera controller property on the model.

--- a/Shared/Samples/Authenticate with OAuth/AuthenticateWithOAuthView.swift
+++ b/Shared/Samples/Authenticate with OAuth/AuthenticateWithOAuthView.swift
@@ -66,7 +66,7 @@ struct AuthenticateWithOAuthView: View {
     }
     
     /// Signs out from the portal by revoking OAuth tokens and clearing credential stores.
-    func signOut() {
+    private func signOut() {
         Task {
             await ArcGISEnvironment.authenticationManager.revokeOAuthTokens()
             await ArcGISEnvironment.authenticationManager.clearCredentialStores()
@@ -74,7 +74,7 @@ struct AuthenticateWithOAuthView: View {
     }
     
     // Sets up new ArcGIS and Network credential stores that will be persisted in the keychain.
-    func setupPersistentCredentialStorage() {
+    private func setupPersistentCredentialStorage() {
         Task {
             try await ArcGISEnvironment.authenticationManager.setupPersistentCredentialStorage(
                 access: .whenUnlockedThisDeviceOnly,

--- a/Shared/Samples/Change camera controller/ChangeCameraControllerView.swift
+++ b/Shared/Samples/Change camera controller/ChangeCameraControllerView.swift
@@ -72,7 +72,7 @@ struct ChangeCameraControllerView: View {
     /// The camera controller kind of the scene view.
     @State private var cameraControllerKind: CameraControllerKind = .globe
     
-    enum CameraControllerKind: CaseIterable {
+    private enum CameraControllerKind: CaseIterable {
         case globe
         case plane
         case crater
@@ -113,7 +113,7 @@ struct ChangeCameraControllerView: View {
     /// Creates a camera controller with the given kind of camera controller.
     /// - Parameter kind: The camera controller kind.
     /// - Returns: A camera controller.
-    func makeCameraController(kind: CameraControllerKind) -> CameraController {
+    private func makeCameraController(kind: CameraControllerKind) -> CameraController {
         switch kind {
         case .crater:
             let targetLocation = Point(

--- a/Shared/Samples/Change viewpoint/ChangeViewpointView.swift
+++ b/Shared/Samples/Change viewpoint/ChangeViewpointView.swift
@@ -28,7 +28,7 @@ struct ChangeViewpointView: View {
     /// The current viewpoint type.
     @State private var viewpointType: ViewpointType = .centerAndScale
     
-    enum ViewpointType: CaseIterable {
+    private enum ViewpointType: CaseIterable {
         case geometry, centerAndScale, animate
         
         /// A human-readable label for the viewpoint type.
@@ -90,7 +90,7 @@ struct ChangeViewpointView: View {
     }
 }
 
-extension ChangeViewpointView {
+private extension ChangeViewpointView {
     /// The model used to store the geo model and other expensive objects
     /// used in this view.
     class Model: ObservableObject {

--- a/Shared/Samples/Create and save KML file/CreateAndSaveKMLView.Views.swift
+++ b/Shared/Samples/Create and save KML file/CreateAndSaveKMLView.Views.swift
@@ -76,7 +76,7 @@ extension CreateAndSaveKMLView {
     }
     
     /// The point style menu.
-    var pointStyleMenuContent: some View {
+    private var pointStyleMenuContent: some View {
         VStack {
             Button {
                 model.kmlStyle = KMLStyle(iconURL: URL(string: "http://resources.esri.com/help/900/arcgisexplorer/sdk/doc/bitmaps/148cca9a-87a8-42bd-9da4-5fe427b6fb7b127.png")!)
@@ -130,7 +130,7 @@ extension CreateAndSaveKMLView {
     }
     
     /// The polyline style menu.
-    var polylineStyleMenuContent: some View {
+    private var polylineStyleMenuContent: some View {
         VStack {
             Button {
                 model.kmlStyle = KMLStyle(lineColor: .red)
@@ -177,7 +177,7 @@ extension CreateAndSaveKMLView {
     }
     
     /// The polygon style menu.
-    var polygonStyleMenuContent: some View {
+    private var polygonStyleMenuContent: some View {
         VStack {
             Button {
                 model.kmlStyle = KMLStyle(fillColor: .red)

--- a/Shared/Samples/Create and save KML file/CreateAndSaveKMLView.swift
+++ b/Shared/Samples/Create and save KML file/CreateAndSaveKMLView.swift
@@ -68,54 +68,56 @@ struct CreateAndSaveKMLView: View {
     }
 }
 
-/// A KMZ file that can be used with the native file exporter.
-final class KMZFile: FileDocument {
-    /// The KML document that is used to create the KMZ file.
-    private let document: KMLDocument
-    
-    /// The temporary directory where the KMZ file will be stored.
-    private var temporaryDirectory: URL?
-    
-    /// The temporary URL to the KMZ file.
-    private var temporaryDocumentURL: URL?
-    
-    static var readableContentTypes: [UTType] { [.kmz] }
-    
-    /// Creates a KMZ file with a KML document.
-    /// - Parameter document: The KML document that is used when creating the KMZ file.
-    init(document: KMLDocument) {
-        self.document = document
-    }
-    
-    // This initializer loads data that has been saved previously.
-    init(configuration: ReadConfiguration) throws {
-        fatalError("Loading KML files is not supported by this sample")
-    }
-    
-    // This will be called when the system wants to write our data to disk
-    func fileWrapper(configuration: WriteConfiguration) throws -> FileWrapper {
-        guard let temporaryDocumentURL else { return FileWrapper() }
-        return try FileWrapper(url: temporaryDocumentURL)
-    }
-    
-    /// Deletes the temporarily stored KMZ file.
-    func deleteFile() {
-        guard let url = temporaryDirectory else { return }
-        try? FileManager.default.removeItem(at: url)
-    }
-    
-    /// Saves the KML document as a KMZ file to a temporary location.
-    @MainActor
-    func saveFile() async throws {
-        temporaryDirectory = FileManager.createTemporaryDirectory()
+extension CreateAndSaveKMLView {
+    /// A KMZ file that can be used with the native file exporter.
+    final class KMZFile: FileDocument {
+        /// The KML document that is used to create the KMZ file.
+        private let document: KMLDocument
         
-        if document.name.isEmpty {
-            document.name = "Untitled"
+        /// The temporary directory where the KMZ file will be stored.
+        private var temporaryDirectory: URL?
+        
+        /// The temporary URL to the KMZ file.
+        private var temporaryDocumentURL: URL?
+        
+        static var readableContentTypes: [UTType] { [.kmz] }
+        
+        /// Creates a KMZ file with a KML document.
+        /// - Parameter document: The KML document that is used when creating the KMZ file.
+        init(document: KMLDocument) {
+            self.document = document
         }
         
-        temporaryDocumentURL = temporaryDirectory?.appendingPathComponent("\(document.name).kmz")
+        // This initializer loads data that has been saved previously.
+        init(configuration: ReadConfiguration) throws {
+            fatalError("Loading KML files is not supported by this sample")
+        }
         
-        try await document.save(to: temporaryDocumentURL!)
+        // This will be called when the system wants to write our data to disk
+        func fileWrapper(configuration: WriteConfiguration) throws -> FileWrapper {
+            guard let temporaryDocumentURL else { return FileWrapper() }
+            return try FileWrapper(url: temporaryDocumentURL)
+        }
+        
+        /// Deletes the temporarily stored KMZ file.
+        func deleteFile() {
+            guard let url = temporaryDirectory else { return }
+            try? FileManager.default.removeItem(at: url)
+        }
+        
+        /// Saves the KML document as a KMZ file to a temporary location.
+        @MainActor
+        func saveFile() async throws {
+            temporaryDirectory = FileManager.createTemporaryDirectory()
+            
+            if document.name.isEmpty {
+                document.name = "Untitled"
+            }
+            
+            temporaryDocumentURL = temporaryDirectory?.appendingPathComponent("\(document.name).kmz")
+            
+            try await document.save(to: temporaryDocumentURL!)
+        }
     }
 }
 

--- a/Shared/Samples/Create load report/CreateLoadReportView.Model.swift
+++ b/Shared/Samples/Create load report/CreateLoadReportView.Model.swift
@@ -346,7 +346,7 @@ private extension CreateLoadReportView {
     }
 }
 
-extension CreateLoadReportView.Model {
+private extension CreateLoadReportView.Model {
     /// An error returned when data required to setup the sample cannot be found.
     struct SetupError: LocalizedError {
         var errorDescription: String? {

--- a/Shared/Samples/Download preplanned map area/DownloadPreplannedMapAreaView.MapPicker.swift
+++ b/Shared/Samples/Download preplanned map area/DownloadPreplannedMapAreaView.MapPicker.swift
@@ -113,7 +113,7 @@ extension DownloadPreplannedMapAreaView {
         }
         
         /// The color of the title for a given result.
-        func titleColor(for result: Result<MobileMapPackage, Error>?) -> Color {
+        private func titleColor(for result: Result<MobileMapPackage, Error>?) -> Color {
             switch model.result {
             case .success:
                 return .primary

--- a/Shared/Samples/Download preplanned map area/DownloadPreplannedMapAreaView.MapPicker.swift
+++ b/Shared/Samples/Download preplanned map area/DownloadPreplannedMapAreaView.MapPicker.swift
@@ -29,7 +29,7 @@ extension DownloadPreplannedMapAreaView {
                     Section {
                         Picker("Web Maps (Online)", selection: $model.selectedMap) {
                             Text("Web Map (Online)")
-                                .tag(Model.SelectedMap.onlineWebMap)
+                                .tag(SelectedMap.onlineWebMap)
                         }
                         .labelsHidden()
                         .pickerStyle(.inline)
@@ -109,7 +109,7 @@ extension DownloadPreplannedMapAreaView {
                     }
                 }
             }
-            .tag(Model.SelectedMap.offlineMap(model))
+            .tag(SelectedMap.offlineMap(model))
         }
         
         /// The color of the title for a given result.

--- a/Shared/Samples/Download preplanned map area/DownloadPreplannedMapAreaView.Model.swift
+++ b/Shared/Samples/Download preplanned map area/DownloadPreplannedMapAreaView.Model.swift
@@ -205,13 +205,16 @@ extension DownloadPreplannedMapAreaView {
     }
 }
 
-extension DownloadPreplannedMapAreaView.OfflineMapModel: Hashable {
-    typealias OfflineMapModel = DownloadPreplannedMapAreaView.OfflineMapModel
-    
-    static func == (lhs: OfflineMapModel, rhs: OfflineMapModel) -> Bool {
+extension DownloadPreplannedMapAreaView.OfflineMapModel: Equatable {
+    static func == (
+        lhs: DownloadPreplannedMapAreaView.OfflineMapModel,
+        rhs: DownloadPreplannedMapAreaView.OfflineMapModel
+    ) -> Bool {
         lhs === rhs
     }
-    
+}
+
+extension DownloadPreplannedMapAreaView.OfflineMapModel: Hashable {
     func hash(into hasher: inout Hasher) {
         hasher.combine(ObjectIdentifier(self))
     }

--- a/Shared/Samples/Download preplanned map area/DownloadPreplannedMapAreaView.Model.swift
+++ b/Shared/Samples/Download preplanned map area/DownloadPreplannedMapAreaView.Model.swift
@@ -155,7 +155,7 @@ extension DownloadPreplannedMapAreaView {
     }
 }
 
-extension DownloadPreplannedMapAreaView.Model {
+extension DownloadPreplannedMapAreaView {
     /// A type that specifies the currently selected map.
     enum SelectedMap: Hashable {
         /// The online version of the map.
@@ -165,45 +165,49 @@ extension DownloadPreplannedMapAreaView.Model {
     }
 }
 
-/// An object that encapsulates state about an offline map.
-class OfflineMapModel: ObservableObject, Identifiable {
-    /// The preplanned map area.
-    let preplannedMapArea: PreplannedMapArea
-    
-    /// The task to use to take the area offline.
-    let offlineMapTask: OfflineMapTask
-    
-    /// The directory where the mmpk will be stored.
-    let mmpkDirectory: URL
-    
-    /// The currently running download job.
-    @Published private(set) var job: DownloadPreplannedOfflineMapJob?
-    
-    /// The result of the download job.
-    @Published private(set) var result: Result<MobileMapPackage, Error>?
-    
-    init?(preplannedMapArea: PreplannedMapArea, offlineMapTask: OfflineMapTask, temporaryDirectory: URL) {
-        self.preplannedMapArea = preplannedMapArea
-        self.offlineMapTask = offlineMapTask
+extension DownloadPreplannedMapAreaView {
+    /// An object that encapsulates state about an offline map.
+    class OfflineMapModel: ObservableObject, Identifiable {
+        /// The preplanned map area.
+        let preplannedMapArea: PreplannedMapArea
         
-        if let itemID = preplannedMapArea.portalItem.id {
-            self.mmpkDirectory = temporaryDirectory
-                .appendingPathComponent(itemID.rawValue)
-                .appendingPathExtension("mmpk")
-        } else {
-            return nil
+        /// The task to use to take the area offline.
+        let offlineMapTask: OfflineMapTask
+        
+        /// The directory where the mmpk will be stored.
+        let mmpkDirectory: URL
+        
+        /// The currently running download job.
+        @Published private(set) var job: DownloadPreplannedOfflineMapJob?
+        
+        /// The result of the download job.
+        @Published private(set) var result: Result<MobileMapPackage, Error>?
+        
+        init?(preplannedMapArea: PreplannedMapArea, offlineMapTask: OfflineMapTask, temporaryDirectory: URL) {
+            self.preplannedMapArea = preplannedMapArea
+            self.offlineMapTask = offlineMapTask
+            
+            if let itemID = preplannedMapArea.portalItem.id {
+                self.mmpkDirectory = temporaryDirectory
+                    .appendingPathComponent(itemID.rawValue)
+                    .appendingPathExtension("mmpk")
+            } else {
+                return nil
+            }
         }
-    }
-    
-    deinit {
-        Task { [job] in
-            // Cancel any outstanding job.
-            await job?.cancel()
+        
+        deinit {
+            Task { [job] in
+                // Cancel any outstanding job.
+                await job?.cancel()
+            }
         }
     }
 }
 
-extension OfflineMapModel: Hashable {
+extension DownloadPreplannedMapAreaView.OfflineMapModel: Hashable {
+    typealias OfflineMapModel = DownloadPreplannedMapAreaView.OfflineMapModel
+    
     static func == (lhs: OfflineMapModel, rhs: OfflineMapModel) -> Bool {
         lhs === rhs
     }
@@ -213,7 +217,7 @@ extension OfflineMapModel: Hashable {
     }
 }
 
-extension OfflineMapModel {
+extension DownloadPreplannedMapAreaView.OfflineMapModel {
     /// A Boolean value indicating whether the map is being taken offline.
     var isDownloading: Bool {
         job != nil
@@ -221,7 +225,7 @@ extension OfflineMapModel {
 }
 
 @MainActor
-private extension OfflineMapModel {
+private extension DownloadPreplannedMapAreaView.OfflineMapModel {
     /// Downloads the given preplanned map area.
     /// - Parameter preplannedMapArea: The preplanned map area to be downloaded.
     /// - Precondition: `canDownload`

--- a/Shared/Samples/Download preplanned map area/DownloadPreplannedMapAreaView.swift
+++ b/Shared/Samples/Download preplanned map area/DownloadPreplannedMapAreaView.swift
@@ -66,7 +66,7 @@ struct DownloadPreplannedMapAreaView: View {
             }
     }
     
-    var mapNameOverlay: some View {
+    private var mapNameOverlay: some View {
         Text(model.currentMap.item?.title ?? "Unknown Map")
             .font(.footnote)
             .frame(maxWidth: .infinity)

--- a/Shared/Samples/Edit geodatabase with transactions/EditGeodatabaseWithTransactionsView.Model.swift
+++ b/Shared/Samples/Edit geodatabase with transactions/EditGeodatabaseWithTransactionsView.Model.swift
@@ -15,130 +15,132 @@
 import ArcGIS
 import Foundation
 
-/// The view model for the sample.
-@MainActor
-class Model: ObservableObject {
-    /// The current progress of the running job.
-    @Published private(set) var progress: Progress?
-    
-    /// A map with an oceans basemap.
-    let map: Map = {
-        let map = Map(basemapStyle: .arcGISOceans)
-        map.initialViewpoint = Viewpoint(center: .christmasBay.center, scale: 8e4)
-        return map
-    }()
-    
-    /// The local geodatabase to edit.
-    private(set) var geodatabase: Geodatabase!
-    
-    /// The task for generating and synchronizing the geodatabase with the feature service.
-    private let geodatabaseSyncTask = GeodatabaseSyncTask(url: .saveTheBaySync)
-    
-    /// The parameters for synchronizing the geodatabase and the feature service.
-    private var syncGeodatabaseParameters: SyncGeodatabaseParameters?
-    
-    /// A URL to a temporary directory where the geodatabase file is stored.
-    private let temporaryDirectoryURL = FileManager.createTemporaryDirectory()
-    
-    /// A Boolean value indicating whether a transaction is active on the geodatabase.
-    var hasLocalEdits: Bool {
-        geodatabase?.hasLocalEdits ?? false
-    }
-    
-    deinit {
-        // Removes the temporary directory and geodatabase file.
-        try? FileManager.default.removeItem(at: temporaryDirectoryURL)
-    }
-    
-    /// Sets up geodatabase and map.
-    func setUp() async throws {
-        geodatabase = try await makeGeodatabase()
+extension EditGeodatabaseWithTransactionsView {
+    /// The view model for the sample.
+    @MainActor
+    class Model: ObservableObject {
+        /// The current progress of the running job.
+        @Published private(set) var progress: Progress?
         
-        // Creates the default parameters for synchronizing the geodatabase.
-        syncGeodatabaseParameters = try await geodatabaseSyncTask.makeDefaultSyncGeodatabaseParameters(
-            geodatabase: geodatabase
-        )
+        /// A map with an oceans basemap.
+        let map: Map = {
+            let map = Map(basemapStyle: .arcGISOceans)
+            map.initialViewpoint = Viewpoint(center: .christmasBay.center, scale: 8e4)
+            return map
+        }()
         
-        // Adds the geodatabase's tables to the map as feature layers.
-        await geodatabase.featureTables.load()
+        /// The local geodatabase to edit.
+        private(set) var geodatabase: Geodatabase!
         
-        let featureLayers = geodatabase.featureTables
-            .map(FeatureLayer.init(featureTable:))
-        map.addOperationalLayers(featureLayers)
+        /// The task for generating and synchronizing the geodatabase with the feature service.
+        private let geodatabaseSyncTask = GeodatabaseSyncTask(url: .saveTheBaySync)
         
-        // Sets feature tables' display names.
-        let marineTable = geodatabase.featureTables.first {
-            $0.tableName == "Save_The_Bay_Marine_Sync"
+        /// The parameters for synchronizing the geodatabase and the feature service.
+        private var syncGeodatabaseParameters: SyncGeodatabaseParameters?
+        
+        /// A URL to a temporary directory where the geodatabase file is stored.
+        private let temporaryDirectoryURL = FileManager.createTemporaryDirectory()
+        
+        /// A Boolean value indicating whether a transaction is active on the geodatabase.
+        var hasLocalEdits: Bool {
+            geodatabase?.hasLocalEdits ?? false
         }
-        marineTable?.displayName = "Marine"
         
-        let birdTable = geodatabase.featureTables.first {
-            $0.tableName == "Save_The_Bay_Birds_Sync"
+        deinit {
+            // Removes the temporary directory and geodatabase file.
+            try? FileManager.default.removeItem(at: temporaryDirectoryURL)
         }
-        birdTable?.displayName = "Bird"
-    }
-    
-    /// Creates and adds a feature to a table in the geodatabase.
-    /// - Parameters:
-    ///   - tableName: The name of the table in the geodatabase.
-    ///   - featureTypeName: The name of the type of feature to create.
-    ///   - point: The point on the map to add the feature at.
-    func addFeature(tableName: String, featureTypeName: String, point: Point) async throws {
-        guard let featureTable = geodatabase.featureTables.first(
-            where: { $0.tableName == tableName }
-        ), let featureType = featureTable.featureTypes.first(
-            where: { $0.name == featureTypeName }
-        ) else { return }
         
-        let feature = featureTable.makeFeature(type: featureType, geometry: point)
-        try await featureTable.add(feature)
-    }
-    
-    /// Synchronizes the geodatabase and feature service.
-    func syncGeodatabase() async throws {
-        guard let syncGeodatabaseParameters else { return }
+        /// Sets up geodatabase and map.
+        func setUp() async throws {
+            geodatabase = try await makeGeodatabase()
+            
+            // Creates the default parameters for synchronizing the geodatabase.
+            syncGeodatabaseParameters = try await geodatabaseSyncTask.makeDefaultSyncGeodatabaseParameters(
+                geodatabase: geodatabase
+            )
+            
+            // Adds the geodatabase's tables to the map as feature layers.
+            await geodatabase.featureTables.load()
+            
+            let featureLayers = geodatabase.featureTables
+                .map(FeatureLayer.init(featureTable:))
+            map.addOperationalLayers(featureLayers)
+            
+            // Sets feature tables' display names.
+            let marineTable = geodatabase.featureTables.first {
+                $0.tableName == "Save_The_Bay_Marine_Sync"
+            }
+            marineTable?.displayName = "Marine"
+            
+            let birdTable = geodatabase.featureTables.first {
+                $0.tableName == "Save_The_Bay_Birds_Sync"
+            }
+            birdTable?.displayName = "Bird"
+        }
         
-        // Creates the sync job using the parameters.
-        let syncGeodatabaseJob = geodatabaseSyncTask.makeSyncGeodatabaseJob(
-            parameters: syncGeodatabaseParameters,
-            geodatabase: geodatabase
-        )
-        progress = syncGeodatabaseJob.progress
-        defer { progress = nil }
+        /// Creates and adds a feature to a table in the geodatabase.
+        /// - Parameters:
+        ///   - tableName: The name of the table in the geodatabase.
+        ///   - featureTypeName: The name of the type of feature to create.
+        ///   - point: The point on the map to add the feature at.
+        func addFeature(tableName: String, featureTypeName: String, point: Point) async throws {
+            guard let featureTable = geodatabase.featureTables.first(
+                where: { $0.tableName == tableName }
+            ), let featureType = featureTable.featureTypes.first(
+                where: { $0.name == featureTypeName }
+            ) else { return }
+            
+            let feature = featureTable.makeFeature(type: featureType, geometry: point)
+            try await featureTable.add(feature)
+        }
         
-        // Synchronizes the geodatabase with the feature service.
-        syncGeodatabaseJob.start()
-        _ = try await syncGeodatabaseJob.output
-    }
-    
-    /// Makes a geodatabase using the geodatabase sync task.
-    /// - Returns: A new `Geodatabase` object.
-    private func makeGeodatabase() async throws -> Geodatabase {
-        // Creates the parameters for generating the geodatabase from the sync task.
-        let parameters = try await geodatabaseSyncTask.makeDefaultGenerateGeodatabaseParameters(
-            extent: .christmasBay
-        )
-        parameters.outSpatialReference = map.spatialReference
+        /// Synchronizes the geodatabase and feature service.
+        func syncGeodatabase() async throws {
+            guard let syncGeodatabaseParameters else { return }
+            
+            // Creates the sync job using the parameters.
+            let syncGeodatabaseJob = geodatabaseSyncTask.makeSyncGeodatabaseJob(
+                parameters: syncGeodatabaseParameters,
+                geodatabase: geodatabase
+            )
+            progress = syncGeodatabaseJob.progress
+            defer { progress = nil }
+            
+            // Synchronizes the geodatabase with the feature service.
+            syncGeodatabaseJob.start()
+            _ = try await syncGeodatabaseJob.output
+        }
         
-        let areaLayerOption = parameters.layerOptions.first { $0.layerID == 2 }!
-        parameters.removeLayerOption(areaLayerOption)
-        
-        // Creates the job to generate the geodatabase.
-        let temporaryGeodatabaseURL = temporaryDirectoryURL
-            .appending(component: "SaveTheBay.geodatabase")
-        let generateGeodatabaseJob = geodatabaseSyncTask.makeGenerateGeodatabaseJob(
-            parameters: parameters,
-            downloadFileURL: temporaryGeodatabaseURL
-        )
-        progress = generateGeodatabaseJob.progress
-        defer { progress = nil }
-        
-        // Generates the geodatabase.
-        generateGeodatabaseJob.start()
-        let geodatabase = try await generateGeodatabaseJob.output
-        try await geodatabase.load()
-        
-        return geodatabase
+        /// Makes a geodatabase using the geodatabase sync task.
+        /// - Returns: A new `Geodatabase` object.
+        private func makeGeodatabase() async throws -> Geodatabase {
+            // Creates the parameters for generating the geodatabase from the sync task.
+            let parameters = try await geodatabaseSyncTask.makeDefaultGenerateGeodatabaseParameters(
+                extent: .christmasBay
+            )
+            parameters.outSpatialReference = map.spatialReference
+            
+            let areaLayerOption = parameters.layerOptions.first { $0.layerID == 2 }!
+            parameters.removeLayerOption(areaLayerOption)
+            
+            // Creates the job to generate the geodatabase.
+            let temporaryGeodatabaseURL = temporaryDirectoryURL
+                .appending(component: "SaveTheBay.geodatabase")
+            let generateGeodatabaseJob = geodatabaseSyncTask.makeGenerateGeodatabaseJob(
+                parameters: parameters,
+                downloadFileURL: temporaryGeodatabaseURL
+            )
+            progress = generateGeodatabaseJob.progress
+            defer { progress = nil }
+            
+            // Generates the geodatabase.
+            generateGeodatabaseJob.start()
+            let geodatabase = try await generateGeodatabaseJob.output
+            try await geodatabase.load()
+            
+            return geodatabase
+        }
     }
 }
 

--- a/Shared/Samples/Find nearest vertex/FindNearestVertexView.swift
+++ b/Shared/Samples/Find nearest vertex/FindNearestVertexView.swift
@@ -20,10 +20,10 @@ struct FindNearestVertexView: View {
     @StateObject private var model = Model()
     
     /// A location callout placement.
-    @State var calloutPlacement: CalloutPlacement?
+    @State private var calloutPlacement: CalloutPlacement?
     
     /// The tap location.
-    @State var tapLocation: Point!
+    @State private var tapLocation: Point!
     
     var body: some View {
         MapView(map: model.map, graphicsOverlays: [model.graphicsOverlay])

--- a/Shared/Samples/Identify layer features/IdentifyLayerFeaturesView.swift
+++ b/Shared/Samples/Identify layer features/IdentifyLayerFeaturesView.swift
@@ -17,7 +17,7 @@ import SwiftUI
 
 struct IdentifyLayerFeaturesView: View {
     /// A map with a topographic basemap centered on the United States.
-    @State var map: Map = {
+    @State private var map: Map = {
         let map = Map(basemapStyle: .arcGISTopographic)
         map.initialViewpoint = Viewpoint(
             center: Point(x: -10977012.785807, y: 4514257.550369, spatialReference: .webMercator),
@@ -27,10 +27,10 @@ struct IdentifyLayerFeaturesView: View {
     }()
     
     /// The tapped screen point.
-    @State var tapScreenPoint: CGPoint?
+    @State private var tapScreenPoint: CGPoint?
     
     /// The string text for the identify layer results overlay.
-    @State var overlayText = "Tap on the map to identify feature layers."
+    @State private var overlayText = "Tap on the map to identify feature layers."
     
     /// The error shown in the error alert.
     @State private var error: Error?

--- a/Shared/Samples/Run valve isolation trace/RunValveIsolationTraceView.swift
+++ b/Shared/Samples/Run valve isolation trace/RunValveIsolationTraceView.swift
@@ -111,7 +111,7 @@ struct RunValveIsolationTraceView: View {
     }
     
     /// Buttons for each the available terminals on the last added utility element.
-    @ViewBuilder var terminalPickerButtons: some View {
+    @ViewBuilder private var terminalPickerButtons: some View {
         if let lastAddedElement = model.lastAddedElement,
            let terminalConfiguration = lastAddedElement.assetType.terminalConfiguration {
             ForEach(terminalConfiguration.terminals) { terminal in
@@ -124,7 +124,7 @@ struct RunValveIsolationTraceView: View {
         }
     }
     
-    @ViewBuilder var configurationView: some View {
+    @ViewBuilder private var configurationView: some View {
         Form {
             Section {
                 List(model.filterBarrierCategories, id: \.name) { category in
@@ -173,7 +173,7 @@ struct RunValveIsolationTraceView: View {
     }
 }
 
-extension RunValveIsolationTraceView.Model.TracingActivity {
+private extension RunValveIsolationTraceView.Model.TracingActivity {
     /// A human-readable label for the tracing activity.
     var label: String {
         switch self {

--- a/Shared/Samples/Set visibility of subtype sublayer/SetVisibilityOfSubtypeSublayerView.Model.swift
+++ b/Shared/Samples/Set visibility of subtype sublayer/SetVisibilityOfSubtypeSublayerView.Model.swift
@@ -108,7 +108,7 @@ extension SetVisibilityOfSubtypeSublayerView {
     }
 }
 
-extension SetVisibilityOfSubtypeSublayerView.Model {
+private extension SetVisibilityOfSubtypeSublayerView.Model {
     enum SetupError: LocalizedError {
         case cannotFindSublayer
         

--- a/Shared/Samples/Set visibility of subtype sublayer/SetVisibilityOfSubtypeSublayerView.swift
+++ b/Shared/Samples/Set visibility of subtype sublayer/SetVisibilityOfSubtypeSublayerView.swift
@@ -17,7 +17,7 @@ import SwiftUI
 
 struct SetVisibilityOfSubtypeSublayerView: View {
     /// The view model for the sample.
-    @StateObject var model = Model()
+    @StateObject private var model = Model()
     
     /// A Boolean value indicating whether the settings should be presented.
     @State private var isShowingSettings = false

--- a/Shared/Samples/Show coordinates in multiple formats/ShowCoordinatesInMultipleFormatsView.swift
+++ b/Shared/Samples/Show coordinates in multiple formats/ShowCoordinatesInMultipleFormatsView.swift
@@ -93,7 +93,7 @@ struct ShowCoordinatesInMultipleFormatsView: View {
     }
 }
 
-struct CoordinateTextField: View {
+private struct CoordinateTextField: View {
     /// The title of the text field.
     var title: String
     

--- a/Shared/Samples/Show device location with NMEA data sources/FileNMEASentenceReader.swift
+++ b/Shared/Samples/Show device location with NMEA data sources/FileNMEASentenceReader.swift
@@ -14,91 +14,93 @@
 
 import Foundation
 
-/// A data source simulating a hardware that emits NMEA data.
-class FileNMEASentenceReader {
-    /// The playback time interval.
-    private let interval: TimeInterval
-    
-    /// An iterator to hold and loop through the mock NMEA data.
-    private var nmeaDataIterator: CircularIterator<Data>
-    
-    /// A timer to periodically provide NMEA data updates.
-    private var timer: Timer?
-    
-    /// An asynchronous stream of NMEA data.
-    private(set) var messages: AsyncStream<Data>!
-    
-    /// A Boolean value specifying if the reader is started.
-    private(set) var isStarted = false
-    
-    /// Loads locations from NMEA sentences.
-    /// Reads mock NMEA sentences line by line and group them by the timestamp.
-    /// - Parameters:
-    ///   - nmeaSourceFile: The URL of the NMEA source file.
-    ///   - speed: The playback time interval in second.
-    init(url: URL, interval: TimeInterval = 1.0) {
-        // An empty container for NMEA data.
-        var dataBySeconds = [Data]()
+extension ShowDeviceLocationWithNMEADataSourcesView {
+    /// A data source simulating a hardware that emits NMEA data.
+    class FileNMEASentenceReader {
+        /// The playback time interval.
+        private let interval: TimeInterval
         
-        if let nmeaStrings = try? String(contentsOf: url, encoding: .utf8).components(separatedBy: .newlines).filter({ !$0.isEmpty }) {
-            // A temporary container for the NMEA sentences at current timestamp.
-            var currentTimestamp = [String]()
-            for nmeaLine in nmeaStrings {
-                currentTimestamp.append(nmeaLine)
-                // In the mock data file, the sentences in each second end with
-                // an RMC message. Join all the messages in this second to a
-                // single data object.
-                let sentenceIdentifier = nmeaLine.prefix(6)
-                if sentenceIdentifier == "$GPRMC",
-                   !currentTimestamp.isEmpty {
-                    dataBySeconds.append(Data(currentTimestamp.joined(separator: "\n").utf8))
-                    currentTimestamp.removeAll()
+        /// An iterator to hold and loop through the mock NMEA data.
+        private var nmeaDataIterator: CircularIterator<Data>
+        
+        /// A timer to periodically provide NMEA data updates.
+        private var timer: Timer?
+        
+        /// An asynchronous stream of NMEA data.
+        private(set) var messages: AsyncStream<Data>!
+        
+        /// A Boolean value specifying if the reader is started.
+        private(set) var isStarted = false
+        
+        /// Loads locations from NMEA sentences.
+        /// Reads mock NMEA sentences line by line and group them by the timestamp.
+        /// - Parameters:
+        ///   - nmeaSourceFile: The URL of the NMEA source file.
+        ///   - speed: The playback time interval in second.
+        init(url: URL, interval: TimeInterval = 1.0) {
+            // An empty container for NMEA data.
+            var dataBySeconds = [Data]()
+            
+            if let nmeaStrings = try? String(contentsOf: url, encoding: .utf8).components(separatedBy: .newlines).filter({ !$0.isEmpty }) {
+                // A temporary container for the NMEA sentences at current timestamp.
+                var currentTimestamp = [String]()
+                for nmeaLine in nmeaStrings {
+                    currentTimestamp.append(nmeaLine)
+                    // In the mock data file, the sentences in each second end with
+                    // an RMC message. Join all the messages in this second to a
+                    // single data object.
+                    let sentenceIdentifier = nmeaLine.prefix(6)
+                    if sentenceIdentifier == "$GPRMC",
+                       !currentTimestamp.isEmpty {
+                        dataBySeconds.append(Data(currentTimestamp.joined(separator: "\n").utf8))
+                        currentTimestamp.removeAll()
+                    }
+                }
+            }
+            
+            if dataBySeconds.isEmpty {
+                fatalError("Fail to create mock NMEA data from local file.")
+            } else {
+                // Create an iterator for the mock data generation.
+                nmeaDataIterator = CircularIterator(elements: dataBySeconds)
+                self.interval = interval
+            }
+        }
+        
+        /// Starts the mock NMEA data feed.
+        func start() {
+            // Invalidate timer to stop previous mock data generation.
+            timer?.invalidate()
+            isStarted = true
+            
+            messages = AsyncStream { continuation in
+                // Create a new timer.
+                timer = Timer.scheduledTimer(
+                    withTimeInterval: interval,
+                    repeats: true
+                ) { [weak self] _ in
+                    guard let self = self else { return }
+                    let data = self.nmeaDataIterator.next()!
+                    continuation.yield(data)
                 }
             }
         }
         
-        if dataBySeconds.isEmpty {
-            fatalError("Fail to create mock NMEA data from local file.")
-        } else {
-            // Create an iterator for the mock data generation.
-            nmeaDataIterator = CircularIterator(elements: dataBySeconds)
-            self.interval = interval
+        /// Stops the mock NMEA data feed.
+        func stop() {
+            timer?.invalidate()
+            isStarted = false
+            timer = nil
+            messages = nil
         }
-    }
-    
-    /// Starts the mock NMEA data feed.
-    func start() {
-        // Invalidate timer to stop previous mock data generation.
-        timer?.invalidate()
-        isStarted = true
         
-        messages = AsyncStream { continuation in
-            // Create a new timer.
-            timer = Timer.scheduledTimer(
-                withTimeInterval: interval,
-                repeats: true
-            ) { [weak self] _ in
-                guard let self = self else { return }
-                let data = self.nmeaDataIterator.next()!
-                continuation.yield(data)
-            }
+        deinit {
+            stop()
         }
-    }
-    
-    /// Stops the mock NMEA data feed.
-    func stop() {
-        timer?.invalidate()
-        isStarted = false
-        timer = nil
-        messages = nil
-    }
-    
-    deinit {
-        stop()
     }
     
     /// A generic circular iterator.
-    struct CircularIterator<Element>: IteratorProtocol {
+    private struct CircularIterator<Element>: IteratorProtocol {
         let elements: [Element]
         private var elementIterator: Array<Element>.Iterator
         

--- a/Shared/Samples/Show device location with NMEA data sources/ShowDeviceLocationWithNMEADataSourcesView.swift
+++ b/Shared/Samples/Show device location with NMEA data sources/ShowDeviceLocationWithNMEADataSourcesView.swift
@@ -166,7 +166,7 @@ struct ShowDeviceLocationWithNMEADataSourcesView: View {
             }
     }
     
-    func reset() {
+    private func reset() {
         // Reset the status text.
         accuracyStatus = "Accuracy info will be shown here."
         satelliteStatus = "Satellites info will be shown here."
@@ -179,7 +179,7 @@ struct ShowDeviceLocationWithNMEADataSourcesView: View {
         }
     }
     
-    func selectDevice() throws {
+    private func selectDevice() throws {
         if let (accessory, protocolString) = model.firstSupportedAccessoryWithProtocol() {
             // Use the supported accessory directly if it's already connected.
             model.accessoryDidConnect(connectedAccessory: accessory, protocolString: protocolString)

--- a/Shared/Samples/Show realistic light and shadows/ShowRealisticLightAndShadowsView.swift
+++ b/Shared/Samples/Show realistic light and shadows/ShowRealisticLightAndShadowsView.swift
@@ -68,7 +68,7 @@ struct ShowRealisticLightAndShadowsView: View {
     }
     
     /// An overlay showing the date time adjusted by the slider.
-    var dateTimeOverlay: some View {
+    private var dateTimeOverlay: some View {
         Text(dateTimeText)
             .frame(maxWidth: .infinity)
             .padding(.vertical, 6)
@@ -85,7 +85,7 @@ struct ShowRealisticLightAndShadowsView: View {
     }
 }
 
-extension ShowRealisticLightAndShadowsView {
+private extension ShowRealisticLightAndShadowsView {
     /// The model used to store the geo model and other expensive objects
     /// used in this view.
     class Model: ObservableObject {

--- a/Shared/Samples/Trace utility network/TraceUtilityNetworkView.Views.swift
+++ b/Shared/Samples/Trace utility network/TraceUtilityNetworkView.Views.swift
@@ -63,7 +63,7 @@ extension TraceUtilityNetworkView {
     }
     
     /// Buttons for each the available terminals on the last added utility element.
-    @ViewBuilder var terminalPickerButtons: some View {
+    @ViewBuilder private var terminalPickerButtons: some View {
         ForEach(model.lastAddedElement?.assetType.terminalConfiguration?.terminals ?? []) { terminal in
             Button(terminal.name) {
                 model.lastAddedElement?.terminal = terminal
@@ -101,7 +101,7 @@ extension TraceUtilityNetworkView {
     ///
     /// When a trace type is selected, the pending trace is initialized as a new instance of trace
     /// parameters. The trace configuration can also be set. The user should set trace points next.
-    @ViewBuilder var traceTypePickerButtons: some View {
+    @ViewBuilder private var traceTypePickerButtons: some View {
         ForEach(supportedTraceTypes, id: \.self) { type in
             Button(type.displayName) {
                 model.setTraceParameters(ofType: type)


### PR DESCRIPTION
## Description

This PR updates the access levels of types and members used by samples to make them more encapsulated. This was done to: 
- Prevent types and members being reused in other samples. (Samples should be stand alone to allow users to copy and paste them, see related [comment](https://github.com/Esri/arcgis-maps-sdk-swift-samples/pull/372#discussion_r1567718805).)
- Prevent existing declarations interfering with new ones. (E.g., the internal `Model` used by `Edit geodatabase with transactions` was preventing any new samples from implementing their own file-private `Model`.)

Overview of changes (corresponding to a commit):
- Make types file-private or nested (or both).
- Make extensions private were possible.
- Make sample view members (properties, methods, & nested types) private were possible.

## Linked Issue(s)

Closes #375.

## How To Test

There are no functionality changes in this PR so ensuring the project builds should be sufficient.
