### PR TITLE
[Setup] Add swift lint analyzer rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,5 +37,5 @@ Package.resolved
 # If the style check scripts are run locally, ignore the script build artifact.
 Scripts/CI/__pycache__/
 
-## Swift Lint Analyzer Log
+## SwiftLint Analyzer Log
 .xcodebuild.log

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ Package.resolved
 ## Python build artifact
 # If the style check scripts are run locally, ignore the script build artifact.
 Scripts/CI/__pycache__/
+
+## Swift Lint Analyzer Log
+.xcodebuild.log

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -73,6 +73,11 @@ opt_in_rules:
   - vertical_whitespace_closing_braces
   - vertical_whitespace_opening_braces
   - yoda_condition
+  
+analyzer_rules:
+  - typesafe_array_init
+  - unused_declaration
+  - unused_import
 
 attributes:
   attributes_with_arguments_always_on_line_above: false

--- a/Scripts/CI/run_swift_lint_analyzer.sh
+++ b/Scripts/CI/run_swift_lint_analyzer.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Copyright 2024 Esri
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# set -xv # uncomment for debugging
+
+# Variables ::
+build_destination="generic/platform=iOS Simulator"
+log_name=.xcodebuild.log
+
+# Delete derived data. Otherwise, swift lint won't find any files to analyze.
+rm -rf ~/Library/Developer/Xcode/DerivedData
+
+# Go to project root directory.
+cd "$(dirname "$0")/../.."
+
+echo "Building '$log_name'"
+xcodebuild -project Samples.xcodeproj -scheme Samples -destination "$build_destination" > $log_name
+
+swiftlint analyze --compiler-log-path $log_name
+
+rm $log_name

--- a/Scripts/CI/run_swift_lint_analyzer.sh
+++ b/Scripts/CI/run_swift_lint_analyzer.sh
@@ -19,7 +19,7 @@
 build_destination="generic/platform=iOS Simulator"
 log_name=.xcodebuild.log
 
-# Delete derived data. Otherwise, swift lint won't find any files to analyze.
+# Delete derived data. Otherwise, SwiftLint won't find any files to analyze.
 rm -rf ~/Library/Developer/Xcode/DerivedData
 
 # Go to project root directory.

--- a/Scripts/run_swift_lint_analyzer.sh
+++ b/Scripts/run_swift_lint_analyzer.sh
@@ -23,7 +23,7 @@ log_name=.xcodebuild.log
 rm -rf ~/Library/Developer/Xcode/DerivedData
 
 # Go to project root directory.
-cd "$(dirname "$0")/../.."
+cd "$(dirname "$0")/.."
 
 echo "Building '$log_name'"
 xcodebuild -project Samples.xcodeproj -scheme Samples -destination "$build_destination" > $log_name


### PR DESCRIPTION
## Description

This PR adds to swift lint analyzer rules with a bash script to run them. These will be run as part of release verification.

The relevant errors/warning for the these rules were fixed here:
- `typesafe_array_init` : No errors
- `unused_declaration`: #490
- `unused_import`: #489 

## Linked Issue(s)

- `swift/issues/5873`

## How To Test

Run `run_swift_lint_analyzer.sh`  in `Scripts/CI` (may take a while).
- **Note:** The many top level sample views produce unused declaration warnings due to the current project structure. This is expected.

