### PR TITLE
[Update] Remove runtime references

### DIFF
--- a/Shared/Samples/Augment reality to collect data/README.md
+++ b/Shared/Samples/Augment reality to collect data/README.md
@@ -33,7 +33,7 @@ When you tap, an orange diamond will appear at the tapped location. You can move
 
 ## About the data
 
-The sample uses a publicly-editable sample tree survey feature service hosted on ArcGIS Online called [AR Tree Survey](https://arcgisruntime.maps.arcgis.com/home/item.html?id=8feb9ea6a27f48b58b3faf04e0e303ed). You can use AR to quickly record the location and health of a tree.
+The sample uses a publicly-editable sample tree survey feature service hosted on ArcGIS Online called [AR Tree Survey](https://www.arcgis.com/home/item.html?id=8feb9ea6a27f48b58b3faf04e0e303ed). You can use AR to quickly record the location and health of a tree.
 
 ## Additional information
 

--- a/Shared/Samples/Create symbol styles from web styles/README.md
+++ b/Shared/Samples/Create symbol styles from web styles/README.md
@@ -6,7 +6,7 @@ Create symbol styles from a style file hosted on a portal.
 
 ## Use case
 
-Style files hosted on an ArcGIS Online or Enterprise portal are known as web styles. They can be used to style symbols on a feature layer or graphic overlay. Since styles are published from ArcGIS Pro, you can author and design your own beautiful multilayer vector symbols. These vector symbols look good at any resolution and scale well. Runtime users can now access these styles from their native application, and make use of the vector symbols within them to enhance features and graphics in the map.
+Style files hosted on an ArcGIS Online or Enterprise portal are known as web styles. They can be used to style symbols on a feature layer or graphic overlay. Since styles are published from ArcGIS Pro, you can author and design your own beautiful multilayer vector symbols. These vector symbols look good at any resolution and scale well. ArcGIS Maps SDK users can now access these styles from their native application, and make use of the vector symbols within them to enhance features and graphics in the map.
 
 ## How to use the sample
 

--- a/Shared/Samples/Find route in transport network/README.md
+++ b/Shared/Samples/Find route in transport network/README.md
@@ -31,7 +31,7 @@ Tap near a road to start adding a stop to the route. Tap again to place it on th
 
 ## Offline data
 
-The data used by this sample is available on [ArcGIS Online](https://arcgisruntime.maps.arcgis.com/home/item.html?id=df193653ed39449195af0c9725701dca).
+The data used by this sample is available on [ArcGIS Online](https://www.arcgis.com/home/item.html?id=df193653ed39449195af0c9725701dca).
 
 ## About the data
 

--- a/Shared/Samples/Play KML tour/README.md
+++ b/Shared/Samples/Play KML tour/README.md
@@ -33,11 +33,11 @@ The sample will load the KMZ file from ArcGIS Online. When a tour is found, the 
 
 Data will be downloaded by the sample viewer automatically.
 
-* [Esri_tour.kmz](https://arcgisruntime.maps.arcgis.com/home/item.html?id=f10b1d37fdd645c9bc9b189fb546307c)
+* [Esri_tour.kmz](https://www.arcgis.com/home/item.html?id=f10b1d37fdd645c9bc9b189fb546307c)
 
 ## About the data
 
-This sample uses a custom tour created by a member of the ArcGIS Runtime API samples team. When you play the tour, you'll see a narrated journey through some of Esri's offices.
+This sample uses a custom tour created by a member of the ArcGIS Map SDK samples team. When you play the tour, you'll see a narrated journey through some of Esri's offices.
 
 ## Additional information
 

--- a/Shared/Samples/Show mobile map package expiration date/README.md
+++ b/Shared/Samples/Show mobile map package expiration date/README.md
@@ -29,7 +29,7 @@ Load the app. The author of the MMPK used in this sample chose to set the MMPK's
 
 ## Offline data
 
-This sample uses the [LothianRiversAnno - Expired](https://arcgisruntime.maps.arcgis.com/home/item.html?id=174150279af74a2ba6f8b87a567f480b) mobile map package. It is downloaded from ArcGIS Online automatically.
+This sample uses the [LothianRiversAnno - Expired](https://www.arcgis.com/home/item.html?id=174150279af74a2ba6f8b87a567f480b) mobile map package. It is downloaded from ArcGIS Online automatically.
 
 ## Tags
 

--- a/Shared/Samples/Style symbols from mobile style file/README.md
+++ b/Shared/Samples/Style symbols from mobile style file/README.md
@@ -39,7 +39,7 @@ The mobile style file used in this sample was created using ArcGIS Pro, and is h
 
 ## Additional information
 
-While each of these symbols can be created from scratch, a more convenient workflow is to author them using ArcGIS Pro and store them in a mobile style file (.stylx). ArcGIS Runtime can read symbols from a mobile style, and you can modify and combine them as needed in your app.
+While each of these symbols can be created from scratch, a more convenient workflow is to author them using ArcGIS Pro and store them in a mobile style file (.stylx). ArcGIS Maps SDK can read symbols from a mobile style, and you can modify and combine them as needed in your app.
 
 ## Tags
 


### PR DESCRIPTION
## Description

This PR replaces "ArcGIS Runtime" with "ArcGIS Maps SDK" in the documentation. It also updates `arcgisruntime.maps.arcgis.com` links to `www.arcgis.com`.

## Linked Issue(s)

Closes #414

## How To Test

- Ensure the updated links work.
