### PR TITLE
[Update] Fix linter warnings for string <-> data conversion

### DIFF
--- a/Scripts/DowloadPortalItemData.swift
+++ b/Scripts/DowloadPortalItemData.swift
@@ -87,7 +87,7 @@ func name(ofFileInArchiveAt url: URL) throws -> String {
     process.waitUntilExit()
     
     let filenameData = outputPipe.fileHandleForReading.readDataToEndOfFile()
-    return String(data: filenameData, encoding: .utf8)!.trimmingCharacters(in: .whitespacesAndNewlines)
+    return String(decoding: filenameData, as: UTF8.self).trimmingCharacters(in: .whitespacesAndNewlines)
 }
 
 /// Counts files in a ZIP archive.
@@ -108,7 +108,7 @@ func count(ofFilesInArchiveAt url: URL) throws -> Int {
     // To extract the count, cut the string at the first whitespace.
     let totalsInfo = outputPipe.fileHandleForReading.readDataToEndOfFile()
     // `UInt8(32)` is space in ASCII.
-    let totalsCount = String(data: totalsInfo.prefix(while: { $0 != 32 }), encoding: .utf8)!
+    let totalsCount = String(decoding: totalsInfo.prefix(while: { $0 != 32 }), as: UTF8.self)
     return Int(totalsCount)!
 }
 

--- a/Shared/Samples/Navigate route with rerouting/NavigateRouteWithReroutingView.Model.swift
+++ b/Shared/Samples/Navigate route with rerouting/NavigateRouteWithReroutingView.Model.swift
@@ -122,7 +122,7 @@ extension NavigateRouteWithReroutingView {
             
             // Set up the data source's locations using a local JSON file.
             let jsonData = try Data(contentsOf: .sanDiegoTourPath)
-            guard let jsonString = String(data: jsonData, encoding: .utf8) else { return }
+            let jsonString = String(decoding: jsonData, as: UTF8.self)
             let routePolyline = try Polyline.fromJSON(jsonString)
             simulatedDataSource.setSimulatedLocations(with: routePolyline)
             

--- a/Shared/Supporting Files/Extensions/Array+RawRepresentable.swift
+++ b/Shared/Supporting Files/Extensions/Array+RawRepresentable.swift
@@ -29,9 +29,7 @@ extension Array: RawRepresentable where Element == String {
     
     /// The raw value of the array.
     public var rawValue: String {
-        guard let data = try? JSONEncoder().encode(self),
-              let result = String(data: data, encoding: .utf8)
-        else { return "[]" }
-        return result
+        guard let data = try? JSONEncoder().encode(self) else { return "[]" }
+        return String(decoding: data, as: UTF8.self)
     }
 }


### PR DESCRIPTION
## Description

This PR addresses the remaining linter warnings. 

I hoped that the change in https://github.com/realm/SwiftLint/pull/5601 get into SwiftLint 0.56.1, but it didn't and I don't want to wait for it. In our case, this change shouldn't cause a problem, as the data being converted to string are all known to be valid. Since this linter warning is addressed in the SDK, let's do it for the samples.

See https://github.com/realm/SwiftLint/issues/5263

## Linked Issue(s)

- `swift/pull/5695`

## How To Test

Build with latest SwiftLint and no more linter warnings.
