### PR TITLE
[Update] Fix "Prefer Type Checking" linter warning

### DIFF
--- a/Shared/Samples/Analyze network with subnetwork trace/AnalyzeNetworkWithSubnetworkTraceView.swift
+++ b/Shared/Samples/Analyze network with subnetwork trace/AnalyzeNetworkWithSubnetworkTraceView.swift
@@ -165,7 +165,7 @@ struct AnalyzeNetworkWithSubnetworkTraceView: View {
                     }
                 }
             }
-            if selectedAttribute?.domain as? CodedValueDomain != nil {
+            if selectedAttribute?.domain is CodedValueDomain {
                 NavigationLink {
                     valuesView
                 } label: {


### PR DESCRIPTION
## Description

prefer_type_checking rule: https://realm.github.io/SwiftLint/prefer_type_checking.html

introduced in SwiftLint 0.55.0