### PR TITLE
[Update] Remove MainActor annotation from views

### DIFF
--- a/Shared/Samples/Animate 3D graphic/Animate3DGraphicView.SettingsView.swift
+++ b/Shared/Samples/Animate 3D graphic/Animate3DGraphicView.SettingsView.swift
@@ -38,7 +38,7 @@ extension Animate3DGraphicView {
         }
         
         /// The view content of the settings sheet.
-        @MainActor private var settingsContent: some View {
+        private var settingsContent: some View {
             NavigationStack {
                 content
                     .navigationTitle("\(label) Settings")

--- a/Shared/Samples/Augment reality to navigate route/AugmentRealityToNavigateRouteView.swift
+++ b/Shared/Samples/Augment reality to navigate route/AugmentRealityToNavigateRouteView.swift
@@ -16,7 +16,6 @@ import ArcGIS
 import CoreLocation
 import SwiftUI
 
-@MainActor
 struct AugmentRealityToNavigateRouteView: View {
     /// The view model for the map view in the sample.
     @StateObject private var model = MapModel()

--- a/Shared/Samples/Create symbol styles from web styles/CreateSymbolStylesFromWebStylesView.swift
+++ b/Shared/Samples/Create symbol styles from web styles/CreateSymbolStylesFromWebStylesView.swift
@@ -15,7 +15,6 @@
 import ArcGIS
 import SwiftUI
 
-@MainActor
 struct CreateSymbolStylesFromWebStylesView: View {
     /// The display scale of the environment.
     @Environment(\.displayScale) private var displayScale

--- a/Shared/Samples/Display dimensions/DisplayDimensionsView.swift
+++ b/Shared/Samples/Display dimensions/DisplayDimensionsView.swift
@@ -15,7 +15,6 @@
 import ArcGIS
 import SwiftUI
 
-@MainActor
 struct DisplayDimensionsView: View {
     /// A map with no specified style.
     @State private var map = Map()

--- a/Shared/Samples/Display map from mobile map package/DisplayMapFromMobileMapPackageView.swift
+++ b/Shared/Samples/Display map from mobile map package/DisplayMapFromMobileMapPackageView.swift
@@ -15,7 +15,6 @@
 import ArcGIS
 import SwiftUI
 
-@MainActor
 struct DisplayMapFromMobileMapPackageView: View {
     /// A map with no specified style.
     @State private var map = Map()

--- a/Shared/Samples/Find route around barriers/FindRouteAroundBarriersView.Views.swift
+++ b/Shared/Samples/Find route around barriers/FindRouteAroundBarriersView.Views.swift
@@ -88,7 +88,7 @@ extension FindRouteAroundBarriersView {
         }
         
         /// The content to display in the sheet with a title and done button.
-        @MainActor private var sheetContent: some View {
+        private var sheetContent: some View {
             NavigationStack {
                 content()
                     .navigationTitle(title)

--- a/Shared/Samples/Group layers together/GroupLayersTogetherView.swift
+++ b/Shared/Samples/Group layers together/GroupLayersTogetherView.swift
@@ -67,7 +67,7 @@ struct GroupLayersTogetherView: View {
     }
     
     /// The list of group layers and their child layers that are currently added to the map.
-    @MainActor private var layersList: some View {
+    private var layersList: some View {
         NavigationStack {
             List {
                 ForEach(scene.operationalLayers as! [GroupLayer], id: \.name) { groupLayer in

--- a/Shared/Samples/Identify KML features/IdentifyKMLFeaturesView.swift
+++ b/Shared/Samples/Identify KML features/IdentifyKMLFeaturesView.swift
@@ -15,7 +15,6 @@
 import ArcGIS
 import SwiftUI
 
-@MainActor
 struct IdentifyKMLFeaturesView: View {
     /// A map with a dark gray base basemap centered on the USA.
     @State private var map: Map = {


### PR DESCRIPTION
## Description

This PR closes #455, #456, #457 . Since Xcode 16 is supported, views are always on main actor.

## Linked Issue(s)

- `swift/pulls/6067`

## How To Test

Build and run without concurrency warnings.

Please note: this branch targets #508 so it will be merged after it.

