### PR TITLE
[Update] Add toggles to `Snap geometry edits`

### DIFF
--- a/Shared/Samples/Snap geometry edits/README.md
+++ b/Shared/Samples/Snap geometry edits/README.md
@@ -12,7 +12,7 @@ A field worker can create new features by editing and snapping the vertices of a
 
 To create a geometry, press the create button to choose the geometry type you want to create (i.e. points, multipoints, polyline, or polygon) and interactively tap and drag on the map view to create the geometry.
 
-Snap settings can be configured by enabling and disabling snapping, feature snapping, geometry guides, and snap sources.
+Snap settings can be configured by enabling or disabling snapping, feature snapping, geometry guides, and snap sources.
 
 To interactively snap a vertex to a feature or graphic, ensure that snapping is enabled for the relevant snap source and move the mouse pointer or drag a vertex close to an existing feature or graphic. When the pointer is close to that existing geoelement, the edit position will be adjusted to coincide with (or snap to), edges and vertices of its geometry. Release the touch pointer to place the vertex at the snapped location.
 

--- a/Shared/Samples/Snap geometry edits/README.md
+++ b/Shared/Samples/Snap geometry edits/README.md
@@ -12,7 +12,7 @@ A field worker can create new features by editing and snapping the vertices of a
 
 To create a geometry, press the create button to choose the geometry type you want to create (i.e. points, multipoints, polyline, or polygon) and interactively tap and drag on the map view to create the geometry.
 
-To configure snapping, press the snap settings button to enable or disable snapping and choose which snap sources to snap to.
+Snap settings can be configured by enabling and disabling snapping, feature snapping, geometry guides, and snap sources.
 
 To interactively snap a vertex to a feature or graphic, ensure that snapping is enabled for the relevant snap source and move the mouse pointer or drag a vertex close to an existing feature or graphic. When the pointer is close to that existing geoelement, the edit position will be adjusted to coincide with (or snap to), edges and vertices of its geometry. Release the touch pointer to place the vertex at the snapped location.
 
@@ -25,7 +25,8 @@ To more clearly see how the vertex is snapped, long press to invoke the magnifie
 3. Create a `GeometryEditor` and connect it to the map view.
 4. Call `syncSourceSettings()` after the map's operational layers are loaded and the geometry editor is connected to the map view.
 5. Set `SnapSettings.isEnabled` and each `SnapSourceSettings.isEnabled` to `true` for the `SnapSource` of interest.
-6. Start the geometry editor with a `GeometryType`.
+6. Toggle geometry guides using `SnapSettings.isGeometryGuidesEnabled` and feature snapping using `SnapSettings.isFeatureSnappingEnabled`.
+7. Start the geometry editor with a `GeometryType`.
 
 ## Relevant API
 
@@ -51,6 +52,8 @@ Snapping is used to maintain data integrity between different sources of data wh
 To snap to polygon and polyline layers, the recommended approach is to set the `FeatureLayer`'s feature tiling mode to `FeatureTilingMode.enabledWithFullResolutionWhenSupported` and use the default `ServiceFeatureTable` feature request mode `FeatureRequestMode.onInteractionCache`. Local data sources, such as geodatabases, always provide full resolution geometries. Point and multipoint feature layers are also always full resolution.
 
 Snapping can be used during interactive edits that move existing vertices using the `VertexTool` or `ReticleVertexTool`. When adding new vertices, snapping also works with a hover event (such as a mouse move without a mouse button press). Using the `ReticleVertexTool` to add and move vertices allows users of touch screen devices to clearly see the visual cues for snapping.
+
+Geometry guides are enabled by default when snapping is enabled. These allow for snapping to a point coinciding with, parallel to, perpendicular to, or extending an existing geometry.
 
 ## Tags
 

--- a/Shared/Samples/Snap geometry edits/SnapGeometryEditsView.GeometryEditorModel.swift
+++ b/Shared/Samples/Snap geometry edits/SnapGeometryEditsView.GeometryEditorModel.swift
@@ -20,7 +20,12 @@ extension SnapGeometryEditsView {
     @MainActor
     class GeometryEditorModel: ObservableObject {
         /// The geometry editor.
-        let geometryEditor = GeometryEditor()
+        let geometryEditor: GeometryEditor = {
+            let geometryEditor = GeometryEditor()
+            geometryEditor.snapSettings.isEnabled = true
+            geometryEditor.snapSettings.isGeometryGuidesEnabled = true
+            return geometryEditor
+        }()
         
         /// The graphics overlay used to save geometries to.
         let geometryOverlay: GraphicsOverlay = {

--- a/Shared/Samples/Snap geometry edits/SnapGeometryEditsView.SnapSettingsView.swift
+++ b/Shared/Samples/Snap geometry edits/SnapGeometryEditsView.SnapSettingsView.swift
@@ -27,6 +27,12 @@ extension SnapGeometryEditsView {
         /// for the geometry editor.
         @State private var snappingEnabled = false
         
+        /// A Boolean value indicating whether snapping to geometry guides is enabled.
+        @State private var geometryGuidesEnabled = false
+        
+        /// A Boolean value indicating whether snapping to features and graphics is enabled.
+        @State private var featureSnappingEnabled = false
+        
         /// An array of snap source names and their source settings.
         @State private var snapSources: [(name: String, sourceSettings: SnapSourceSettings)] = []
         
@@ -40,6 +46,18 @@ extension SnapGeometryEditsView {
                         .onChange(of: snappingEnabled) { newValue in
                             model.geometryEditor.snapSettings.isEnabled = newValue
                         }
+                    
+                    Toggle("Geometry Guides", isOn: $geometryGuidesEnabled)
+                        .onChange(of: geometryGuidesEnabled) { newValue in
+                            model.geometryEditor.snapSettings.isGeometryGuidesEnabled = newValue
+                        }
+                        .disabled(!snappingEnabled)
+                    
+                    Toggle("Feature Snapping", isOn: $featureSnappingEnabled)
+                        .onChange(of: featureSnappingEnabled) { newValue in
+                            model.geometryEditor.snapSettings.isFeatureSnappingEnabled = newValue
+                        }
+                        .disabled(!snappingEnabled)
                 }
                 
                 Section("Individual Source Snapping") {
@@ -50,6 +68,7 @@ extension SnapGeometryEditsView {
                             }
                     }
                 }
+                .disabled(!snappingEnabled || !featureSnappingEnabled)
             }
             .navigationTitle("Snap Settings")
             .navigationBarTitleDisplayMode(.inline)
@@ -61,9 +80,9 @@ extension SnapGeometryEditsView {
                 }
             }
             .onAppear {
-                // Enables snapping in the current geometry editor.
-                model.geometryEditor.snapSettings.isEnabled = true
                 snappingEnabled = model.geometryEditor.snapSettings.isEnabled
+                geometryGuidesEnabled = model.geometryEditor.snapSettings.isGeometryGuidesEnabled
+                featureSnappingEnabled = model.geometryEditor.snapSettings.isFeatureSnappingEnabled
                 
                 // Creates an array from snap source layers or graphics overlays
                 // with their name and source settings.


### PR DESCRIPTION
## Description

This PR adds "Geometry Guides" and "Feature Snapping" toggles to `Snap geometry edits` corresponding to the updated design.

## Linked Issue(s)

- `swift/issues/6031`

## How To Test

- Ensure the new toggles work as expected. (See the video in the design for an example if needed).

## Screenshots

|Before|After|
|:-:|:-:|
|    ![Simulator Screenshot - iPhone 16 Pro - 2024-10-09 at 11 57 21](https://github.com/user-attachments/assets/4be77082-0a5c-4422-b02c-da6e896cf85b)    |    ![Simulator Screenshot - iPhone 16 Pro - 2024-10-09 at 11 53 09](https://github.com/user-attachments/assets/a02289ea-6d8f-427c-9ab1-08187d991ced)    |

