### PR TITLE
[Fix] Create metadata script error

### DIFF
--- a/Scripts/create-metadata-from-README.py
+++ b/Scripts/create-metadata-from-README.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from common import *
+from CI.common import *
 import argparse
 
 


### PR DESCRIPTION
## Description

This PR fixes an error with the `create-metadata-from-README.py` script introduced in #501.

## How To Test

- Ensure the script runs without error. Example: `Scripts/create-metadata-from-README.py -c "Shared/Samples/Display map"`

