### PR TITLE
[Fix] WorldElevation3D URL typos

### DIFF
--- a/Shared/Samples/Add point cloud layer from file/AddPointCloudLayerFromFileView.swift
+++ b/Shared/Samples/Add point cloud layer from file/AddPointCloudLayerFromFileView.swift
@@ -60,6 +60,6 @@ private extension URL {
     
     /// A URL to the Terrain3D image server on ArcGIS REST.
     static var worldElevationService: URL {
-        URL(string: "https://elevation3d.arcgis.com/arcagis/rest/services/WorldElevation3D/Terrain3D/ImageServer")!
+        URL(string: "https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer")!
     }
 }

--- a/Shared/Samples/Add point scene layer/AddPointSceneLayerView.swift
+++ b/Shared/Samples/Add point scene layer/AddPointSceneLayerView.swift
@@ -45,7 +45,7 @@ private extension URL {
     
     /// A web URL to the Terrain3D image server on ArcGIS REST.
     static var worldElevationService: URL {
-        URL(string: "https://elevation3d.arcgis.com/arcagis/rest/services/WorldElevation3D/Terrain3D/ImageServer")!
+        URL(string: "https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer")!
     }
 }
 


### PR DESCRIPTION
## Description

This PR fixes a typo with the WorldElevation3D URLs in  `Add point cloud layer from file` & `Add point scene layer`.

## How To Test

Ensure the samples now have elevation.

**Note:** Swift daily is currently required to build. 
