### PR TITLE
[Fix] Remove broken previews

### DIFF
--- a/Shared/Samples/Add ENC exchange set/AddENCExchangeSetView.swift
+++ b/Shared/Samples/Add ENC exchange set/AddENCExchangeSetView.swift
@@ -155,7 +155,3 @@ private extension URL {
         subdirectory: "hydrography/hydrography"
     )!
 }
-
-#Preview {
-    AddENCExchangeSetView()
-}

--- a/Shared/Samples/Add elevation source from raster/AddElevationSourceFromRasterView.swift
+++ b/Shared/Samples/Add elevation source from raster/AddElevationSourceFromRasterView.swift
@@ -55,7 +55,3 @@ private extension URL {
         Bundle.main.url(forResource: "MontereyElevation", withExtension: "dt2")!
     }
 }
-
-#Preview {
-    AddElevationSourceFromRasterView()
-}

--- a/Shared/Samples/Add elevation source from tile package/AddElevationSourceFromTilePackageView.swift
+++ b/Shared/Samples/Add elevation source from tile package/AddElevationSourceFromTilePackageView.swift
@@ -55,7 +55,3 @@ private extension URL {
         Bundle.main.url(forResource: "MontereyElevation", withExtension: "tpkx")!
     }
 }
-
-#Preview {
-    AddElevationSourceFromTilePackageView()
-}

--- a/Shared/Samples/Generate offline map with local basemap/GenerateOfflineMapWithLocalBasemapView.swift
+++ b/Shared/Samples/Generate offline map with local basemap/GenerateOfflineMapWithLocalBasemapView.swift
@@ -293,9 +293,3 @@ private extension PortalItem.ID {
     /// The portal item ID of the Naperville water network web map to be displayed on the map.
     static var napervilleWaterNetwork: Self { Self("acc027394bc84c2fb04d1ed317aac674")! }
 }
-
-#Preview {
-    NavigationStack {
-        GenerateOfflineMapWithLocalBasemapView()
-    }
-}


### PR DESCRIPTION
## Description

Currently, samples with on-demand resources do not support previews. This PR removes some previews that were add by mistake.

## Linked Issue(s)

- `swift/issues/6248`