### PR TITLE
[Fix] `Configure clusters` settings state

### DIFF
--- a/Shared/Samples/Configure clusters/ConfigureClustersView.swift
+++ b/Shared/Samples/Configure clusters/ConfigureClustersView.swift
@@ -61,7 +61,7 @@ struct ConfigureClustersView: View {
                         Button("Clustering Settings") {
                             showsSettings = true
                         }
-                        .popover(isPresented: $showsSettings) {
+                        .popover(isPresented: $showsSettings) { [mapViewScale] in
                             SettingsView(model: model, mapViewScale: mapViewScale)
                                 .presentationDetents([.fraction(0.5)])
                                 .frame(idealWidth: 320, idealHeight: 340)


### PR DESCRIPTION
## Description

This PR fixes a bug with the `Configure clusters` settings where the "Current Map Scale" wouldn't show the correct value until the map scale was changed.

## How To Test

Open "Clustering Settings" without interacting with the map first and verify that the "Current Map Scale" shows the correct default value.

## Screenshots

|Before|After|
|:-:|:-:|
|    ![Simulator Screenshot - 1 - iPhone 16 Pro - 2024-10-31 at 11 52 42](https://github.com/user-attachments/assets/4e10479f-bfb5-4515-a188-51d85a473b52)    |     ![Simulator Screenshot - 1 - iPhone 16 Pro - 2024-10-31 at 11 53 09](https://github.com/user-attachments/assets/6e618128-00f0-4e63-98cf-02e21f5b52d9)    |

