### PR TITLE
[Update] Add `Style geometry types with symbols` redirect from link

### DIFF
--- a/Shared/Samples/Style geometry types with symbols/README.metadata.json
+++ b/Shared/Samples/Style geometry types with symbols/README.metadata.json
@@ -24,7 +24,9 @@
         "SimpleLineSymbol",
         "SimpleMarkerSymbol"
     ],
-    "redirect_from": [],
+    "redirect_from": [
+        "/swift/sample-code/style-point-with-picture-marker-symbols/"
+    ],
     "relevant_apis": [
         "Geometry",
         "Graphic",


### PR DESCRIPTION
## Description

This PR adds a `redirect_from` link to `Style geometry types with symbols` since it replaced `Style point with picture marker symbols` in #496.

## Linked Issue(s)

- `swift/issues/5786`

## How To Test

Append the `redirect_from` value to `https://developers.arcgis.com` to very the link is valid.

