### PR TITLE
[Fix] `200.6.0` sample issues

### DIFF
--- a/Shared/Samples/Add vector tiled layer from custom style/AddVectorTiledLayerFromCustomStyleView.swift
+++ b/Shared/Samples/Add vector tiled layer from custom style/AddVectorTiledLayerFromCustomStyleView.swift
@@ -192,10 +192,3 @@ private extension FileManager {
         )
     }
 }
-
-private extension URL {
-    /// The URL to the local vector tile package file with Dodge City, KS data.
-    static var dodgeCityVectorTilePackage: URL {
-        Bundle.main.url(forResource: "dodge_city", withExtension: "vtpk")!
-    }
-}

--- a/Shared/Samples/Style geometry types with symbols/StyleGeometryTypesWithSymbolsView.Views.swift
+++ b/Shared/Samples/Style geometry types with symbols/StyleGeometryTypesWithSymbolsView.Views.swift
@@ -168,6 +168,11 @@ private struct EnumerationPicker<T: LabeledEnumeration>: View {
                 Text(style.label)
             }
         }
+#if targetEnvironment(macCatalyst)
+        // Workaround for bug where the picker selection doesn't update when the
+        // binding value changes on Mac Catalyst.
+        .id(selection)
+#endif
     }
 }
 


### PR DESCRIPTION
## Description

This PR fixes some issues discovered while verifying the samples completed for the `200.6.0` release:

- `Add vector tiled layer from custom style`: Removed an unused declaration.
- `Style geometry types with symbols`: Fixed a bug where the pickers wouldn't save state in between closing and opening the popover on Mac Catalyst.

Swift lint also recommended replacing `import SwiftUI` with `import SwiftUICore` in a few samples. It seems like this is an [Apple bug](https://forums.swift.org/t/swiftuicore-vs-swiftui/73722), so I left these as is for now.

## Linked Issue(s)

- `swift/issues/6285`

## How To Test

- `Add vector tiled layer from custom style`: Verify the project builds.
- `Style geometry types with symbols`: Verify the pickers show the correct values after the "Edit Style" settings are closed and reopened.
