### PR TITLE
[Fix] Search bugs

### DIFF
--- a/Shared/Samples/Geocode offline/GeocodeOfflineView.swift
+++ b/Shared/Samples/Geocode offline/GeocodeOfflineView.swift
@@ -46,6 +46,7 @@ struct GeocodeOfflineView: View {
     var body: some View {
         GeocodeMapView(model: model, viewpoint: $viewpoint)
             .searchable(text: $searchText, prompt: "Type in an address")
+            .autocorrectionDisabled()
             .onSubmit(of: .search) {
                 submittedSearchText = searchText
             }

--- a/Shared/Samples/Query feature table/QueryFeatureTableView.swift
+++ b/Shared/Samples/Query feature table/QueryFeatureTableView.swift
@@ -29,7 +29,8 @@ struct QueryFeatureTableView: View {
             MapView(map: model.map)
                 .errorAlert(presentingError: $error)
                 // Makes the search bar.
-                .searchable(text: $searchBarText, prompt: Text("Search state names"))
+                .searchable(text: $searchBarText, prompt: "Search state names")
+                .autocorrectionDisabled()
                 .onSubmit(of: .search) {
                     model.currentQuery = searchBarText
                 }

--- a/Shared/Samples/Search for web map/SearchForWebMapView.swift
+++ b/Shared/Samples/Search for web map/SearchForWebMapView.swift
@@ -74,6 +74,7 @@ struct SearchForWebMapView: View {
             placement: .navigationBarDrawer(displayMode: .always),
             prompt: "Web Maps"
         )
+        .autocorrectionDisabled()
         .task(id: query) {
             // Load new results when the query changes.
             resultsAreLoading = true

--- a/Shared/Supporting Files/Views/CategoriesView.swift
+++ b/Shared/Supporting Files/Views/CategoriesView.swift
@@ -140,6 +140,7 @@ private extension CategoriesView {
                 }
             }
             .searchable(text: $query, placement: .navigationBarDrawer(displayMode: .always))
+            .autocorrectionDisabled()
             .scrollDismissesKeyboard(.immediately)
         }
     }

--- a/Shared/Supporting Files/Views/FavoritesView.swift
+++ b/Shared/Supporting Files/Views/FavoritesView.swift
@@ -132,6 +132,7 @@ private extension FavoritesView {
                 }
             }
             .searchable(text: $query, placement: .navigationBarDrawer(displayMode: .always))
+            .autocorrectionDisabled()
         }
     }
 }

--- a/Shared/Supporting Files/Views/SampleLink.swift
+++ b/Shared/Supporting Files/Views/SampleLink.swift
@@ -131,11 +131,18 @@ private extension String {
     /// - Parameter substring: The substring to bold.
     /// - Returns: The attributed string with the bolded substring.
     func boldingFirstOccurrence(of substring: String) -> AttributedString {
-        if let range = localizedStandardRange(of: substring.trimmingCharacters(in: .whitespacesAndNewlines)),
-           let boldedString = try? AttributedString(markdown: replacingCharacters(in: range, with: "**\(self[range])**")) {
-            return boldedString
-        } else {
-            return AttributedString(self)
+        var attributedString = AttributedString(self)
+        
+        let trimmedSubstring = substring.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let range = localizedStandardRange(of: trimmedSubstring) {
+            let substring = self[range]
+            
+            if let boldedSubstring = try? AttributedString(markdown: "**\(substring)**"),
+               let attributedRange = attributedString.range(of: substring) {
+                attributedString.replaceSubrange(attributedRange, with: boldedSubstring)
+            }
         }
+        
+        return attributedString
     }
 }

--- a/Shared/Supporting Files/Views/SampleLink.swift
+++ b/Shared/Supporting Files/Views/SampleLink.swift
@@ -134,13 +134,10 @@ private extension String {
         var attributedString = AttributedString(self)
         
         let trimmedSubstring = substring.trimmingCharacters(in: .whitespacesAndNewlines)
-        if let range = localizedStandardRange(of: trimmedSubstring) {
-            let substring = self[range]
-            
-            if let boldedSubstring = try? AttributedString(markdown: "**\(substring)**"),
-               let attributedRange = attributedString.range(of: substring) {
-                attributedString.replaceSubrange(attributedRange, with: boldedSubstring)
-            }
+        if let range = localizedStandardRange(of: trimmedSubstring),
+           let boldedSubstring = try? AttributedString(markdown: "**\(self[range])**"),
+           let attributedRange = attributedString.range(of: self[range]) {
+            attributedString.replaceSubrange(attributedRange, with: boldedSubstring)
         }
         
         return attributedString


### PR DESCRIPTION
## Description

This PR fixes some issues related to searching in the samples:

- A bug where some text wouldn't be bolded correctly due to a markdown issue (see screenshots).
- A bug where autocorrect would change the search results would change when un-focusing a search bar. Disabled autocorrect appears to be the default behavior for `.searchable` in iOS 18+, so this fix is for iOS 16 & 17.

## How To Test

- Verify the search bars perform as expected.

## Screenshots

|Before|After|
|:-:|:-:|
|    ![Simulator Screenshot - 1 - iPhone 16 Pro - 2024-11-13 at 16 38 47](https://github.com/user-attachments/assets/da18b9a1-d277-4989-8dc3-4c837ff71b64)    |    ![Simulator Screenshot - 1 - iPhone 16 Pro - 2024-11-13 at 16 38 10](https://github.com/user-attachments/assets/7cd9c0b3-2cf4-4daf-8604-c948f0baa1ea)    |