### PR TITLE
[Update] Add sample action menu

### DIFF
--- a/Samples.xcodeproj/project.pbxproj
+++ b/Samples.xcodeproj/project.pbxproj
@@ -280,6 +280,7 @@
 		D72F272E2ADA1E4400F906DA /* AugmentRealityToShowTabletopSceneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D72F272B2ADA1E4400F906DA /* AugmentRealityToShowTabletopSceneView.swift */; };
 		D72F27302ADA1E9900F906DA /* AugmentRealityToShowTabletopSceneView.swift in Copy Source Code Files */ = {isa = PBXBuildFile; fileRef = D72F272B2ADA1E4400F906DA /* AugmentRealityToShowTabletopSceneView.swift */; };
 		D72FE7032CE6D05600BBC0FE /* AppFavorites.swift in Sources */ = {isa = PBXBuildFile; fileRef = D72FE7022CE6D05600BBC0FE /* AppFavorites.swift */; };
+		D72FE7082CE6DA1900BBC0FE /* SampleMenuButtons.swift in Sources */ = {isa = PBXBuildFile; fileRef = D72FE7072CE6DA1900BBC0FE /* SampleMenuButtons.swift */; };
 		D731F3C12AD0D2AC00A8431E /* IdentifyGraphicsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D731F3C02AD0D2AC00A8431E /* IdentifyGraphicsView.swift */; };
 		D731F3C22AD0D2BB00A8431E /* IdentifyGraphicsView.swift in Copy Source Code Files */ = {isa = PBXBuildFile; fileRef = D731F3C02AD0D2AC00A8431E /* IdentifyGraphicsView.swift */; };
 		D7337C5A2ABCFDB100A5D865 /* StyleSymbolsFromMobileStyleFileView.SymbolOptionsListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7337C592ABCFDB100A5D865 /* StyleSymbolsFromMobileStyleFileView.SymbolOptionsListView.swift */; };
@@ -967,6 +968,7 @@
 		D72C43F22AEB066D00B6157B /* GeocodeOfflineView.Model.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GeocodeOfflineView.Model.swift; sourceTree = "<group>"; };
 		D72F272B2ADA1E4400F906DA /* AugmentRealityToShowTabletopSceneView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AugmentRealityToShowTabletopSceneView.swift; sourceTree = "<group>"; };
 		D72FE7022CE6D05600BBC0FE /* AppFavorites.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppFavorites.swift; sourceTree = "<group>"; };
+		D72FE7072CE6DA1900BBC0FE /* SampleMenuButtons.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SampleMenuButtons.swift; sourceTree = "<group>"; };
 		D731F3C02AD0D2AC00A8431E /* IdentifyGraphicsView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IdentifyGraphicsView.swift; sourceTree = "<group>"; };
 		D7337C592ABCFDB100A5D865 /* StyleSymbolsFromMobileStyleFileView.SymbolOptionsListView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StyleSymbolsFromMobileStyleFileView.SymbolOptionsListView.swift; sourceTree = "<group>"; };
 		D7337C5F2ABD142D00A5D865 /* ShowMobileMapPackageExpirationDateView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ShowMobileMapPackageExpirationDateView.swift; sourceTree = "<group>"; };
@@ -1147,6 +1149,7 @@
 				000558092817C51E00224BC6 /* SampleDetailView.swift */,
 				E041ABD6287DB04D0056009B /* SampleInfoView.swift */,
 				00273CF52A82AB8700A7A77D /* SampleLink.swift */,
+				D72FE7072CE6DA1900BBC0FE /* SampleMenuButtons.swift */,
 				00273CF32A82AB5900A7A77D /* SamplesSearchView.swift */,
 				E041ABBF287CA9F00056009B /* WebView.swift */,
 			);
@@ -3439,6 +3442,7 @@
 				95F891292C46E9D60010EBED /* ShowDeviceLocationUsingIndoorPositioningView.swift in Sources */,
 				1C2538562BABACFD00337307 /* AugmentRealityToNavigateRouteView.swift in Sources */,
 				1C2538572BABACFD00337307 /* AugmentRealityToNavigateRouteView.ARSceneView.swift in Sources */,
+				D72FE7082CE6DA1900BBC0FE /* SampleMenuButtons.swift in Sources */,
 				D76929FA2B4F79540047205E /* OrbitCameraAroundObjectView.swift in Sources */,
 				D771D0C82CD55211004C13CB /* ApplyRasterRenderingRuleView.swift in Sources */,
 				79D84D132A81711A00F45262 /* AddCustomDynamicEntityDataSourceView.swift in Sources */,

--- a/Shared/Supporting Files/Models/Sample.swift
+++ b/Shared/Supporting Files/Models/Sample.swift
@@ -42,6 +42,13 @@ protocol Sample: Sendable {
 // MARK: Computed Variables
 
 extension Sample {
+    /// The web URL to the sample's Esri Developer page.
+    var esriDeveloperURL: URL {
+        let dashedName = name.replacingOccurrences(of: " ", with: "-").lowercased()
+        return URL(string: "https://developers.arcgis.com/swift/sample-code")!
+            .appendingPathComponent(dashedName)
+    }
+    
     /// The URL to a sample's sub-directory on GitHub main branch.
     var gitHubURL: URL {
         URL(string: "https://github.com/Esri/arcgis-maps-sdk-swift-samples/tree/main/Shared/Samples")!

--- a/Shared/Supporting Files/Views/SampleDetailView.swift
+++ b/Shared/Supporting Files/Views/SampleDetailView.swift
@@ -25,10 +25,10 @@ struct SampleDetailView: View {
     @StateObject private var onDemandResource: OnDemandResource
     
     /// A Boolean value indicating whether a sample should use on-demand resources.
-    var usesOnDemandResources: Bool {
+    private var usesOnDemandResources: Bool {
 #if targetEnvironment(macCatalyst)
         // Mac Catalyst isn't supported by `NSBundleResourceRequest`. Instead, Xcode
-        // put the offline data into the app bundle on Mac Catalyst.
+        // puts the offline data into the app bundle on Mac Catalyst.
         return false
 #else
         return sample.hasDependencies
@@ -84,14 +84,12 @@ struct SampleDetailView: View {
         .navigationTitle(sample.name)
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
-            ToolbarItemGroup(placement: .topBarTrailing) {
-#if targetEnvironment(macCatalyst)
-                Link("View on GitHub", destination: sample.gitHubURL)
-#endif
-                Button {
-                    isSampleInfoViewPresented = true
-                } label: {
-                    Image(systemName: "info.circle")
+            ToolbarItem(placement: .topBarTrailing) {
+                Menu("Sample Actions", systemImage: "ellipsis.circle") {
+                    Button("View Info", systemImage: "info.circle") {
+                        isSampleInfoViewPresented = true
+                    }
+                    SampleMenuButtons(sample: sample)
                 }
                 .sheet(isPresented: $isSampleInfoViewPresented) {
                     NavigationStack {

--- a/Shared/Supporting Files/Views/SampleLink.swift
+++ b/Shared/Supporting Files/Views/SampleLink.swift
@@ -38,18 +38,15 @@ struct SampleLink: View {
                 // of its map when a keyboard is presented in landscape mode.
                 .ignoresSafeArea(.keyboard, edges: .bottom)
         } label: {
-            SampleRow(
-                name: sample.name.boldingFirstOccurrence(of: textToBold),
-                description: sample.description.boldingFirstOccurrence(of: textToBold)
-            )
+            SampleRow(sample, textToBold: textToBold)
         }
     }
 }
 
 private extension SampleLink {
     struct SampleRow: View {
-        /// The name of the sample.
-        private let name: String
+        /// The sample for the row.
+        private let sample: Sample
         
         /// The name of the sample with attributes.
         private let attributedName: AttributedString
@@ -63,15 +60,10 @@ private extension SampleLink {
         /// The names of the favorite samples loaded from user defaults.
         @AppFavorites private var favoriteNames
         
-        /// A Boolean value indicating whether the sample is a favorite.
-        private var sampleIsFavorite: Bool {
-            favoriteNames.contains(name)
-        }
-        
-        init(name: AttributedString, description: AttributedString) {
-            self.name = String(name.characters)
-            self.attributedName = name
-            self.attributedDescription = description
+        init(_ sample: Sample, textToBold: String) {
+            self.sample = sample
+            self.attributedName = sample.name.boldingFirstOccurrence(of: textToBold)
+            self.attributedDescription = sample.description.boldingFirstOccurrence(of: textToBold)
         }
         
         var body: some View {
@@ -88,7 +80,7 @@ private extension SampleLink {
                 }
                 Spacer()
                 
-                if sampleIsFavorite {
+                if favoriteNames.contains(sample.name) {
                     Image(systemName: "star.fill")
                         .foregroundStyle(.yellow)
                 }
@@ -103,16 +95,7 @@ private extension SampleLink {
                 }
             }
             .contextMenu {
-                Button {
-                    if sampleIsFavorite {
-                        favoriteNames.removeAll { $0 == name }
-                    } else {
-                        favoriteNames.append(name)
-                    }
-                } label: {
-                    Label(sampleIsFavorite ? "Unfavorite" : "Favorite", systemImage: "star")
-                        .symbolVariant(sampleIsFavorite ? .slash : .none)
-                }
+                SampleMenuButtons(sample: sample)
             }
             .animation(.easeOut(duration: 0.2), value: isShowingDescription)
         }

--- a/Shared/Supporting Files/Views/SampleMenuButtons.swift
+++ b/Shared/Supporting Files/Views/SampleMenuButtons.swift
@@ -36,7 +36,7 @@ struct SampleMenuButtons: View {
         Divider()
         Button {
             if sampleIsFavorite {
-                favoriteNames.removeAll { $0 == sample.name }
+                favoriteNames.removeAll(where: { $0 == sample.name })
             } else {
                 favoriteNames.append(sample.name)
             }

--- a/Shared/Supporting Files/Views/SampleMenuButtons.swift
+++ b/Shared/Supporting Files/Views/SampleMenuButtons.swift
@@ -1,0 +1,48 @@
+// Copyright 2024 Esri
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import SwiftUI
+
+struct SampleMenuButtons: View {
+    /// The sample to show the menu buttons for.
+    let sample: Sample
+    
+    /// The names of the favorite samples loaded from user defaults.
+    @AppFavorites private var favoriteNames
+    
+    /// A Boolean value indicating whether the sample is a favorite.
+    private var sampleIsFavorite: Bool {
+        favoriteNames.contains(sample.name)
+    }
+    
+    var body: some View {
+        Link(destination: sample.esriDeveloperURL) {
+            Label("View on Esri Developer", systemImage: "link")
+        }
+        Link(destination: sample.gitHubURL) {
+            Label("View on GitHub", systemImage: "link")
+        }
+        Divider()
+        Button {
+            if sampleIsFavorite {
+                favoriteNames.removeAll { $0 == sample.name }
+            } else {
+                favoriteNames.append(sample.name)
+            }
+        } label: {
+            Label(sampleIsFavorite ? "Unfavorite" : "Favorite", systemImage: "star")
+                .symbolVariant(sampleIsFavorite ? .slash : .none)
+        }
+    }
+}


### PR DESCRIPTION
## Description

This PR updates the sample row context menu and adds a new sample toolbar menu with following actions: 
- `View Info` (This replaces the sample info button to save space. Also, this is only present in the toolbar menu since it was much simipler to do it that way.)
- `View on Esri Developer`
- `View on GitHub` (This replaces the Mac Catalyst toolbar button.) 
- `Favorite`/`Unfavorite`

## Linked Issue(s)

Closes #407

## How To Test

- Ensure all of the menu actions work in the context menu (long press on a sample row) and the sample toolbar menu (circle ellipse button).

## Screenshots

|Before|After|
|:-:|:-:|
|    ![Simulator Screenshot - 1 - iPhone 16 Pro - 2024-11-15 at 12 27 26](https://github.com/user-attachments/assets/77811b05-e615-421e-b6c8-70b8c71cf4c4)    |    ![Simulator Screenshot - 1 - iPhone 16 Pro - 2024-11-15 at 12 26 25](https://github.com/user-attachments/assets/c8f53dd0-d5b0-483b-9fae-39439dbbd139)    |
|    ![Simulator Screenshot - 1 - iPhone 16 Pro - 2024-11-15 at 12 23 56](https://github.com/user-attachments/assets/8ec589a8-03fd-490e-bcce-5b74e4c261e2)    |     ![Simulator Screenshot - 1 - iPhone 16 Pro - 2024-11-15 at 12 26 38](https://github.com/user-attachments/assets/b91678ed-085e-4c3d-b7cd-e39e4f74b935)    |




