### PR TITLE
[Fix] `Browse OGC API feature service` alert bug

### DIFF
--- a/Shared/Samples/Browse OGC API feature service/BrowseOGCAPIFeatureServiceView.swift
+++ b/Shared/Samples/Browse OGC API feature service/BrowseOGCAPIFeatureServiceView.swift
@@ -19,8 +19,8 @@ struct BrowseOGCAPIFeatureServiceView: View {
     /// The error shown in the error alert.
     @State private var error: Error?
     
-    /// A Boolean value indicating whether the textfield alert should be presented.
-    @State private var textfieldAlertIsPresented = false
+    /// A Boolean value indicating whether the text field alert should be presented.
+    @State private var textFieldAlertIsPresented = false
     
     /// The data model for the sample.
     @StateObject private var model = Model()
@@ -37,7 +37,7 @@ struct BrowseOGCAPIFeatureServiceView: View {
                 .toolbar {
                     ToolbarItemGroup(placement: .bottomBar) {
                         Button("Open Service") {
-                            textfieldAlertIsPresented = true
+                            textFieldAlertIsPresented = true
                         }
                         
                         Spacer()
@@ -63,8 +63,9 @@ struct BrowseOGCAPIFeatureServiceView: View {
                         }
                     }
                 }
-                .alert("Load OGC API feature service", isPresented: $textfieldAlertIsPresented) {
-                    // Textfield has a default OGC API URL.
+                .alert("Load OGC API feature service", isPresented: $textFieldAlertIsPresented) {
+                    // Text
+                    field has a default OGC API URL.
                     TextField("URL", text: $userInput)
                         .keyboardType(.URL)
                         .textContentType(.URL)
@@ -86,14 +87,14 @@ struct BrowseOGCAPIFeatureServiceView: View {
                     }
                     .disabled(userInput.isEmpty)
                     Button("Cancel", role: .cancel) {
-                        // Reset the default value of the textfield.
+                        // Reset the default value of the text field.
                         userInput = URL.daraaService.absoluteString
                     }
                 } message: {
                     Text("Please provide a URL to an OGC API feature service.")
                 }
                 .onAppear {
-                    textfieldAlertIsPresented = true
+                    textFieldAlertIsPresented = true
                 }
                 .errorAlert(presentingError: $error)
         }

--- a/Shared/Samples/Browse OGC API feature service/BrowseOGCAPIFeatureServiceView.swift
+++ b/Shared/Samples/Browse OGC API feature service/BrowseOGCAPIFeatureServiceView.swift
@@ -20,7 +20,7 @@ struct BrowseOGCAPIFeatureServiceView: View {
     @State private var error: Error?
     
     /// A Boolean value indicating whether the textfield alert should be presented.
-    @State private var textfieldAlertIsPresented = true
+    @State private var textfieldAlertIsPresented = false
     
     /// The data model for the sample.
     @StateObject private var model = Model()
@@ -91,6 +91,9 @@ struct BrowseOGCAPIFeatureServiceView: View {
                     }
                 } message: {
                     Text("Please provide a URL to an OGC API feature service.")
+                }
+                .onAppear {
+                    textfieldAlertIsPresented = true
                 }
                 .errorAlert(presentingError: $error)
         }


### PR DESCRIPTION
## Description

This PR fixes a bug in `Browse OGC API feature service` where the alert wouldn't present when the sample was opened on iOS 18 (only iPhone), even when "Open Service" was pressed. I also changed the spelling of "textfield" to "text field" since it is [two words in SwiftUI](https://developer.apple.com/documentation/swiftui/textfield).

## How To Test

- Ensure the alert is presented when the sample is first opened on iOS 18.

