### PR TITLE
[Fix] `Query feature count and extent` category

### DIFF
--- a/Shared/Samples/Query feature count and extent/README.metadata.json
+++ b/Shared/Samples/Query feature count and extent/README.metadata.json
@@ -1,5 +1,5 @@
 {
-    "category": "Analysis",
+    "category": "Search and Query",
     "description": "Zoom to features matching a query and count the features in the current visible extent.",
     "ignore": false,
     "images": [


### PR DESCRIPTION
## Description

This PR changes the `Query feature count and extent` category to the more fitting "Search and Query".

