### PR TITLE
[Update] Make `errorAlert` message more descriptive

### DIFF
--- a/Shared/Supporting Files/Extensions/View+ErrorAlert.swift
+++ b/Shared/Supporting Files/Extensions/View+ErrorAlert.swift
@@ -34,7 +34,7 @@ extension View {
                 error.wrappedValue = nil
             }
         } message: { error in
-            Text(error.localizedDescription)
+            Text(String(reflecting: error))
         }
     }
 }


### PR DESCRIPTION
## Description

This PR updates the `View.errorAlert(presentingError:)` message to better describe the errors it presents. Since most of the errors thrown contain their info in their type, it is better to show that rather than the `localizedDescription`.

## How To Test

I messed with the credentials in the [`Add feature layers`](https://github.com/Esri/arcgis-maps-sdk-swift-samples/blob/v.next/Shared/Samples/Add%20feature%20layers/AddFeatureLayersView.swift#L71) sample to throw some errors.

## Screenshots

|Before|After|
|:-:|:-:|
|    ![Simulator Screenshot - 1 - iPhone 16 Pro - 2024-12-12 at 18 20 58](https://github.com/user-attachments/assets/906925cc-7825-4646-833b-0bd50ac087e6)    |     ![Simulator Screenshot - 1 - iPhone 16 Pro - 2024-12-12 at 18 19 57](https://github.com/user-attachments/assets/9ba2ac56-1f60-467e-97e2-d39980e4e5ee)     |
