### PR TITLE
[Update] Add details to README for Create planar and geodetic buffers

### DIFF
--- a/Shared/Samples/Create planar and geodetic buffers/README.md
+++ b/Shared/Samples/Create planar and geodetic buffers/README.md
@@ -12,7 +12,7 @@ Creating buffers is a core concept in GIS proximity analysis that allows you to 
 
 1. Tap on the map.
 2. A planar and a geodetic buffer will be created at the tap location using the distance (miles) specified in the options menu.
-3. Continue tapping to create additional buffers. Notice that buffers closer to the equator appear similar in size. As you move north or south from the equator, however, the geodetic polygons become much larger. Geodetic polygons are in fact a better representation of the true shape and size of the buffer.
+3. Continue tapping to create additional buffers. Notice that buffers closer to the equator appear similar in size. As you move north or south from the equator, however, the geodetic polygons become much larger. Geodetic polygons are in fact a better representation of the true shape and size of the buffer. Geodetic buffers will not be generated for points placed beyond +/-90 degrees latitude.
 4. Tap *Clear All* to remove all buffers and start again.
 
 ## How it works
@@ -35,6 +35,8 @@ Creating buffers is a core concept in GIS proximity analysis that allows you to 
 The polygon results (and tap location) are displayed in the map view with different symbols in order to highlight the difference between the buffer techniques due to the spatial reference used in the planar calculation.
 
 Buffers can be generated as either *planar* (flat - coordinate space of the map's spatial reference) or *geodetic* (technique that considers the curved shape of the Earth's surface, which is generally a more accurate representation). In general, distortion in the map increases as you move away from the standard parallels of the spatial reference's projection. This map is in Web Mercator, so areas near the equator are the most accurate. As you move the buffer location north or south from that line, you'll see a greater difference in the polygon size and shape. Planar operations are generally faster, but performance improvement may only be noticeable for large operations (buffering a great number or complex geometry).
+
+Geodetic buffers in the far northern and southern regions of the map will extend beyond the map's limits. The visible extent of the basemap in this sample is limited to between approximately +/-85 degrees latitude while geodetic buffers are calculated to extend all the way to the poles (+/-90 degrees). Also, since map view wraparound is active, geodetic buffers that cross the international date line (180 degrees longitude) will be [normalized](https://developers.arcgis.com/swift/api-reference/documentation/arcgis/geometryengine/normalizecentralmeridian(of:)), resulting in a multipart geometry. This results in a vertical line in the buffer graphic at the dateline.
 
 For more information about using buffer analysis, see the topic [How Buffer (Analysis) works](https://pro.arcgis.com/en/pro-app/tool-reference/analysis/how-buffer-analysis-works.htm) in the *ArcGIS Pro* documentation.  
 


### PR DESCRIPTION
## Description

This PR updates the README for  `Create planar and geodetic buffers`.

## Linked Issue(s)

- `swift/issues/6401`

## How To Test

Look for typos in README.

## To Discuss

Because the API is called `GeometryEngine.geodeticBuffer`, I opt for using the word "geodetic" throughout the README.