### PR TITLE
[Update] Remove viewpoint jump workaround

### DIFF
--- a/Shared/Supporting Files/Views/SampleLink.swift
+++ b/Shared/Supporting Files/Views/SampleLink.swift
@@ -34,9 +34,6 @@ struct SampleLink: View {
         NavigationLink {
             SampleDetailView(sample: sample)
                 .id(sample.name)
-                // Workaround for bug that causes a map view to jump to the bottom
-                // of its map when a keyboard is presented in landscape mode.
-                .ignoresSafeArea(.keyboard, edges: .bottom)
         } label: {
             SampleRow(sample, textToBold: textToBold)
         }


### PR DESCRIPTION
## Description

This PR removes the viewpoint jump bug workaround since the issue has now been resolved in the SDK. Tested on iOS & iPadOS 16-18.

## Linked Issue(s)

- `swift/issues/1451`

## How To Test

- Replace `arcgis-maps-sdk-swift-toolkit` with `swift-toolkit-daily`.
- Open a keyboard in a sample, such as "Geocode offline".
- Rotate the device to landscape mode.
- Ensure the map view's viewpoint doesn't jump to the bottom of the map.
