### PR TITLE
[Update] Remove `Show device location using indoor positioning` "table"  references

### DIFF
--- a/Shared/Samples/Show device location using indoor positioning/README.md
+++ b/Shared/Samples/Show device location using indoor positioning/README.md
@@ -25,8 +25,6 @@ When there are no IPS beacons nearby or other errors occur while initializing th
 
 ## Relevant API
 
-* ArcGISFeatureTable
-* FeatureTable
 * IndoorPositioningDefinition
 * IndoorsLocationDataSource
 * LocationDisplay

--- a/Shared/Samples/Show device location using indoor positioning/README.metadata.json
+++ b/Shared/Samples/Show device location using indoor positioning/README.metadata.json
@@ -21,8 +21,6 @@
         "navigation",
         "site",
         "transmitter",
-        "ArcGISFeatureTable",
-        "FeatureTable",
         "IndoorPositioningDefinition",
         "IndoorsLocationDataSource",
         "LocationDisplay",
@@ -32,8 +30,6 @@
     ],
     "redirect_from": [],
     "relevant_apis": [
-        "ArcGISFeatureTable",
-        "FeatureTable",
         "IndoorPositioningDefinition",
         "IndoorsLocationDataSource",
         "LocationDisplay",

--- a/Shared/Samples/Show device location using indoor positioning/ShowDeviceLocationUsingIndoorPositioningView.Model.swift
+++ b/Shared/Samples/Show device location using indoor positioning/ShowDeviceLocationUsingIndoorPositioningView.Model.swift
@@ -126,7 +126,7 @@ private extension ShowDeviceLocationUsingIndoorPositioningView.Model {
         var errorDescription: String? {
             .init(
                 localized: "Cannot initialize indoors location data source.",
-                comment: "No indoor positioning definition or positioning table is found."
+                comment: "No indoor positioning definition is found."
             )
         }
     }


### PR DESCRIPTION
## Description

This PR removes "table" references from `Show device location using indoor positioning` since the sample no longer uses the `IndoorsLocationDataSource`  table-based initializer (as of #565). See related [comment](https://github.com/Esri/arcgis-maps-sdk-swift-samples/pull/565#discussion_r2033594943).

URL to README: [Show device location using indoor positioning](https://github.com/Esri/arcgis-maps-sdk-swift-samples/tree/Caleb/Update-RemoveTableReferences/Shared/Samples/Show%20device%20location%20using%20indoor%20positioning)

## Linked Issue(s)

- `common-samples/pull/3975`
