### PR TITLE
[Setup] Add App Store review requests

### DIFF
--- a/Samples.xcodeproj/project.pbxproj
+++ b/Samples.xcodeproj/project.pbxproj
@@ -431,6 +431,8 @@
 		D79482D72C35D8A3006521CD /* CreateDynamicBasemapGalleryView.swift in Copy Source Code Files */ = {isa = PBXBuildFile; fileRef = D79482D02C35D872006521CD /* CreateDynamicBasemapGalleryView.swift */; };
 		D79EE76E2A4CEA5D005A52AE /* SetUpLocationDrivenGeotriggersView.Model.swift in Sources */ = {isa = PBXBuildFile; fileRef = D79EE76D2A4CEA5D005A52AE /* SetUpLocationDrivenGeotriggersView.Model.swift */; };
 		D79EE76F2A4CEA7F005A52AE /* SetUpLocationDrivenGeotriggersView.Model.swift in Copy Source Code Files */ = {isa = PBXBuildFile; fileRef = D79EE76D2A4CEA5D005A52AE /* SetUpLocationDrivenGeotriggersView.Model.swift */; };
+		D7A670D52DADB9630060E327 /* Bundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7A670D42DADB9630060E327 /* Bundle.swift */; };
+		D7A670D72DADBC770060E327 /* EnvironmentValues+RequestReviewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7A670D62DADBC770060E327 /* EnvironmentValues+RequestReviewModel.swift */; };
 		D7A737E02BABB9FE00B7C7FC /* AugmentRealityToShowHiddenInfrastructureView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7A737DC2BABB9FE00B7C7FC /* AugmentRealityToShowHiddenInfrastructureView.swift */; };
 		D7A737E32BABBA2200B7C7FC /* AugmentRealityToShowHiddenInfrastructureView.swift in Copy Source Code Files */ = {isa = PBXBuildFile; fileRef = D7A737DC2BABB9FE00B7C7FC /* AugmentRealityToShowHiddenInfrastructureView.swift */; };
 		D7A85A082CD5ABF5009DC68A /* QueryWithCQLFiltersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7A85A022CD5ABF5009DC68A /* QueryWithCQLFiltersView.swift */; };
@@ -1066,6 +1068,8 @@
 		D78FA4932C3C88880079313E /* CreateDynamicBasemapGalleryView.Views.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateDynamicBasemapGalleryView.Views.swift; sourceTree = "<group>"; };
 		D79482D02C35D872006521CD /* CreateDynamicBasemapGalleryView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CreateDynamicBasemapGalleryView.swift; sourceTree = "<group>"; };
 		D79EE76D2A4CEA5D005A52AE /* SetUpLocationDrivenGeotriggersView.Model.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SetUpLocationDrivenGeotriggersView.Model.swift; sourceTree = "<group>"; };
+		D7A670D42DADB9630060E327 /* Bundle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bundle.swift; sourceTree = "<group>"; };
+		D7A670D62DADBC770060E327 /* EnvironmentValues+RequestReviewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EnvironmentValues+RequestReviewModel.swift"; sourceTree = "<group>"; };
 		D7A737DC2BABB9FE00B7C7FC /* AugmentRealityToShowHiddenInfrastructureView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AugmentRealityToShowHiddenInfrastructureView.swift; sourceTree = "<group>"; };
 		D7A85A022CD5ABF5009DC68A /* QueryWithCQLFiltersView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryWithCQLFiltersView.swift; sourceTree = "<group>"; };
 		D7ABA2F82A32579C0021822B /* MeasureDistanceInSceneView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MeasureDistanceInSceneView.swift; sourceTree = "<group>"; };
@@ -1189,6 +1193,8 @@
 		00181B442846AD3900654571 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				D7A670D42DADB9630060E327 /* Bundle.swift */,
+				D7A670D62DADBC770060E327 /* EnvironmentValues+RequestReviewModel.swift */,
 				00181B452846AD7100654571 /* View+ErrorAlert.swift */,
 			);
 			path = Extensions;
@@ -3634,6 +3640,7 @@
 				79302F852A1ED4E30002336A /* CreateAndSaveKMLView.Model.swift in Sources */,
 				D7C3AB4A2B683291008909B9 /* SetFeatureRequestModeView.swift in Sources */,
 				95D2EE0F2C334D1600683D53 /* ShowServiceAreaView.swift in Sources */,
+				D7A670D72DADBC770060E327 /* EnvironmentValues+RequestReviewModel.swift in Sources */,
 				D7058FB12ACB423C00A40F14 /* Animate3DGraphicView.Model.swift in Sources */,
 				D7BEBAC52CBDC0F800F882E7 /* AddElevationSourceFromTilePackageView.swift in Sources */,
 				D77D9C002BB2438200B38A6C /* AugmentRealityToShowHiddenInfrastructureView.ARSceneView.swift in Sources */,
@@ -3684,6 +3691,7 @@
 				D7E440D72A1ECE7D005D74DE /* CreateBuffersAroundPointsView.swift in Sources */,
 				00D4EF802863842100B9CC30 /* AddFeatureLayersView.swift in Sources */,
 				4D126D7E29CA43D200CFB7A7 /* ShowDeviceLocationWithNMEADataSourcesView.Model.swift in Sources */,
+				D7A670D52DADB9630060E327 /* Bundle.swift in Sources */,
 				4D126D6D29CA1B6000CFB7A7 /* ShowDeviceLocationWithNMEADataSourcesView.swift in Sources */,
 				D710996D2A27D9210065A1C1 /* DensifyAndGeneralizeGeometryView.swift in Sources */,
 				88F93CC129C3D59D0006B28E /* CreateAndEditGeometriesView.swift in Sources */,

--- a/Shared/Supporting Files/Extensions/Bundle.swift
+++ b/Shared/Supporting Files/Extensions/Bundle.swift
@@ -1,0 +1,22 @@
+// Copyright 2025 Esri
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import SwiftUI
+
+extension Bundle {
+    /// The short version string of the bundle.
+    var shortVersion: String {
+        object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? ""
+    }
+}

--- a/Shared/Supporting Files/Extensions/EnvironmentValues+RequestReviewModel.swift
+++ b/Shared/Supporting Files/Extensions/EnvironmentValues+RequestReviewModel.swift
@@ -28,14 +28,21 @@ final class RequestReviewModel {
     @AppStorage("lastRequestedReviewVersion") var lastRequestedReviewVersion: String?
     
     /// A Boolean value indicating whether an App Store review can be requested.
+    ///
+    /// This is `true` if all the following conditions are met:
+    /// - The project was not compiled using the `Debug` Build Configuration.
+    /// - A sample is not currently showing.
+    /// - A sample has been opened since the app has been launched.
+    /// - There have been at least four total sample launches.
+    /// - A review has not yet been requested for the current bundle version.
     var canRequestReview: Bool {
 #if DEBUG
         false
 #else
         !sampleIsShowing &&
         sampleOpenedSinceLaunch &&
-        lastRequestedReviewVersion != Bundle.main.shortVersion &&
-        sampleOpenCount > 3
+        sampleOpenCount > 3 &&
+        lastRequestedReviewVersion != Bundle.main.shortVersion
 #endif
     }
     

--- a/Shared/Supporting Files/Extensions/EnvironmentValues+RequestReviewModel.swift
+++ b/Shared/Supporting Files/Extensions/EnvironmentValues+RequestReviewModel.swift
@@ -29,7 +29,7 @@ final class RequestReviewModel {
     
     /// A Boolean value indicating whether an App Store review can be requested.
     var canRequestReview: Bool {
-#if DEBUG && !targetEnvironment(simulator)
+#if DEBUG
         false
 #else
         !sampleIsShowing &&

--- a/Shared/Supporting Files/Extensions/EnvironmentValues+RequestReviewModel.swift
+++ b/Shared/Supporting Files/Extensions/EnvironmentValues+RequestReviewModel.swift
@@ -1,0 +1,55 @@
+// Copyright 2025 Esri
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import SwiftUI
+
+extension EnvironmentValues {
+    /// The view model for requesting App Store reviews.
+    @Entry var requestReviewModel = RequestReviewModel()
+}
+
+/// A view model for requesting App Store reviews.
+final class RequestReviewModel {
+    /// The number of times a sample has been opened by the user.
+    @AppStorage("sampleOpenCount") private var sampleOpenCount = 0
+    
+    /// The last version that an App Store review was requested.
+    @AppStorage("lastRequestedReviewVersion") var lastRequestedReviewVersion: String?
+    
+    /// A Boolean value indicating whether an App Store review can be requested.
+    var canRequestReview: Bool {
+#if DEBUG && !targetEnvironment(simulator)
+        false
+#else
+        !sampleIsShowing &&
+        sampleOpenedSinceLaunch &&
+        lastRequestedReviewVersion != Bundle.main.shortVersion &&
+        sampleOpenCount > 3
+#endif
+    }
+    
+    /// A Boolean value indicating whether a sample is displayed.
+    var sampleIsShowing = false {
+        didSet {
+            if sampleIsShowing {
+                sampleOpenedSinceLaunch = true
+                sampleOpenCount += 1
+            }
+        }
+    }
+    
+    /// A Boolean value indicating whether a sample has been opened since the
+    /// app has been launched.
+    private var sampleOpenedSinceLaunch = false
+}

--- a/Shared/Supporting Files/Views/AboutView.swift
+++ b/Shared/Supporting Files/Views/AboutView.swift
@@ -43,6 +43,9 @@ struct AboutView: View {
                 Section {
                     LabeledContent("Version", value: Bundle.main.shortVersion)
                     LabeledContent("SDK Version", value: arcGISVersion)
+#if !targetEnvironment(simulator)
+                    Link("Write Review", destination: .writeReview)
+#endif
                 }
                 Section("Powered By") {
                     Link("ArcGIS Maps SDK for Swift Toolkit", destination: .toolkit)
@@ -84,7 +87,6 @@ private extension Bundle {
     static let arcGIS = Bundle(identifier: "com.esri.ArcGIS") ?? Bundle(identifier: "ArcGIS")!
     
     var name: String { object(forInfoDictionaryKey: "CFBundleName") as? String ?? "" }
-    var shortVersion: String { object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "" }
     var version: String { object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "" }
 }
 
@@ -94,4 +96,5 @@ private extension URL {
     static let githubRepository = URL(string: "https://github.com/Esri/arcgis-maps-sdk-swift-samples")!
     static let toolkit = URL(string: "https://github.com/Esri/arcgis-maps-sdk-swift-toolkit")!
     static let apiReference = URL(string: "https://developers.arcgis.com/swift/api-reference/documentation/arcgis/")!
+    static let writeReview = URL(string: "https://apps.apple.com/app/id1630449018?action=write-review")!
 }

--- a/Shared/Supporting Files/Views/AboutView.swift
+++ b/Shared/Supporting Files/Views/AboutView.swift
@@ -43,9 +43,7 @@ struct AboutView: View {
                 Section {
                     LabeledContent("Version", value: Bundle.main.shortVersion)
                     LabeledContent("SDK Version", value: arcGISVersion)
-#if !targetEnvironment(simulator)
                     Link("Write Review", destination: .writeReview)
-#endif
                 }
                 Section("Powered By") {
                     Link("ArcGIS Maps SDK for Swift Toolkit", destination: .toolkit)

--- a/Shared/Supporting Files/Views/ContentView.swift
+++ b/Shared/Supporting Files/Views/ContentView.swift
@@ -20,7 +20,7 @@ struct ContentView: View {
     @Environment(\.requestReview) private var requestReview
     
     /// The view model for requesting App Store reviews.
-    @State private var requestReviewModel = RequestReviewModel()
+    @Environment(\.requestReviewModel) private var requestReviewModel
     
     /// The visibility of the leading columns in the navigation split view.
     @State private var columnVisibility: NavigationSplitViewVisibility = .all

--- a/Shared/Supporting Files/Views/ContentView.swift
+++ b/Shared/Supporting Files/Views/ContentView.swift
@@ -12,9 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import StoreKit
 import SwiftUI
 
 struct ContentView: View {
+    /// The action to request an App Store review.
+    @Environment(\.requestReview) private var requestReview
+    
+    /// The view model for requesting App Store reviews.
+    @State private var requestReviewModel = RequestReviewModel()
+    
     /// The visibility of the leading columns in the navigation split view.
     @State private var columnVisibility: NavigationSplitViewVisibility = .all
     
@@ -35,6 +42,19 @@ struct ContentView: View {
                         }
                     }
                 }
+                .task {
+                    // Requests an App Store review.
+                    guard requestReviewModel.canRequestReview else {
+                        return
+                    }
+                    
+                    try? await Task.sleep(for: .seconds(2))
+                    
+                    if !requestReviewModel.sampleIsShowing, !Task.isCancelled {
+                        requestReview()
+                        requestReviewModel.lastRequestedReviewVersion = Bundle.main.shortVersion
+                    }
+                }
         } content: {
             Text("No Category Selected")
         } detail: {
@@ -42,5 +62,6 @@ struct ContentView: View {
                 Text("No Sample Selected")
             }
         }
+        .environment(\.requestReviewModel, requestReviewModel)
     }
 }

--- a/Shared/Supporting Files/Views/SampleDetailView.swift
+++ b/Shared/Supporting Files/Views/SampleDetailView.swift
@@ -18,6 +18,9 @@ struct SampleDetailView: View {
     /// The sample to display in the view.
     private let sample: Sample
     
+    /// The view model for requesting App Store reviews.
+    @Environment(\.requestReviewModel) private var requestReviewModel
+    
     /// A Boolean value that indicates whether to present the sample's information view.
     @State private var isSampleInfoViewPresented = false
     
@@ -33,6 +36,17 @@ struct SampleDetailView: View {
 #else
         return sample.hasDependencies
 #endif
+    }
+    
+    /// The sample's view body.
+    private var sampleBody: some View {
+        sample.makeBody()
+            .onAppear {
+                requestReviewModel.sampleIsShowing = true
+            }
+            .onDisappear {
+                requestReviewModel.sampleIsShowing = false
+            }
     }
     
     init(sample: Sample) {
@@ -69,7 +83,7 @@ struct SampleDetailView: View {
                         }
                         .padding()
                     case .downloaded:
-                        sample.makeBody()
+                        sampleBody
                     }
                 }
                 .task {
@@ -78,7 +92,7 @@ struct SampleDetailView: View {
                 }
             } else {
                 // 'onDemandResource' is not created in this branch.
-                sample.makeBody()
+                sampleBody
             }
         }
         .navigationTitle(sample.name)


### PR DESCRIPTION
## Description

This PR adds App Store review requests to the Samples app. The review request will appear after the user opens 4 samples and then pauses on the "Categories" page for a couple of seconds. The request will also only appear once per version. The alert will not show if the app is built for release or ran on simulator, to prevent interfering with development. This workflow is heavily derived from Apple's [Requesting App Store reviews](https://developer.apple.com/documentation/storekit/requesting-app-store-reviews) sample code.

## Linked Issue(s)

- `swift/issues/6333`

## How To Test

- Comment out [this check](https://github.com/Esri/arcgis-maps-sdk-swift-samples/blob/Caleb/New-AppStoreReviews/Shared/Supporting%20Files/Extensions/EnvironmentValues%2BRequestReviewModel.swift#L32-L34) to test with a debug build and on simulator.
- Open 4 samples.
- Navigation back to the "Categories" page (close and reopen it if it is already showing on iPad or Mac Catalyst).
- Wait for a couple of seconds for the alert to appear.
- To reset, you can remove the [AppStorage property wrappers](https://github.com/Esri/arcgis-maps-sdk-swift-samples/blob/Caleb/New-AppStoreReviews/Shared/Supporting%20Files/Extensions/EnvironmentValues%2BRequestReviewModel.swift#L24-L28).

Example:

https://github.com/user-attachments/assets/fa842b8d-ac74-40c9-b686-1aafacca4669

## Screenshots

![Simulator Screenshot - 1 - iPhone 16 Pro - 2025-04-14 at 15 45 30](https://github.com/user-attachments/assets/ab62d90d-bafd-4f02-9c51-be8f0e517a5b)


