### PR TITLE
[Fix] 18.0 sheet sizes

### DIFF
--- a/Samples.xcodeproj/project.pbxproj
+++ b/Samples.xcodeproj/project.pbxproj
@@ -252,6 +252,7 @@
 		D713C6D72CB990600073AA72 /* AddKMLLayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D713C6D12CB990600073AA72 /* AddKMLLayerView.swift */; };
 		D713C6D82CB990800073AA72 /* AddKMLLayerView.swift in Copy Source Code Files */ = {isa = PBXBuildFile; fileRef = D713C6D12CB990600073AA72 /* AddKMLLayerView.swift */; };
 		D713C6F72CB9B9A60073AA72 /* US_State_Capitals.kml in Resources */ = {isa = PBXBuildFile; fileRef = D713C6F52CB9B9A60073AA72 /* US_State_Capitals.kml */; settings = {ASSET_TAGS = (AddKmlLayer, ); }; };
+		D7142BC42DB71082004F87B7 /* View+PagePresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7142BC32DB71082004F87B7 /* View+PagePresentation.swift */; };
 		D71563E92D5AC2B600D2E948 /* CreateKMLMultiTrackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D71563E32D5AC2B600D2E948 /* CreateKMLMultiTrackView.swift */; };
 		D71563EA2D5AC2D500D2E948 /* CreateKMLMultiTrackView.swift in Copy Source Code Files */ = {isa = PBXBuildFile; fileRef = D71563E32D5AC2B600D2E948 /* CreateKMLMultiTrackView.swift */; };
 		D718A1E72B570F7500447087 /* OrbitCameraAroundObjectView.Model.swift in Sources */ = {isa = PBXBuildFile; fileRef = D718A1E62B570F7500447087 /* OrbitCameraAroundObjectView.Model.swift */; };
@@ -969,6 +970,7 @@
 		D71371752BD88ECC00EB2F86 /* MonitorChangesToLayerViewStateView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MonitorChangesToLayerViewStateView.swift; sourceTree = "<group>"; };
 		D713C6D12CB990600073AA72 /* AddKMLLayerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddKMLLayerView.swift; sourceTree = "<group>"; };
 		D713C6F52CB9B9A60073AA72 /* US_State_Capitals.kml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = US_State_Capitals.kml; sourceTree = "<group>"; };
+		D7142BC32DB71082004F87B7 /* View+PagePresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+PagePresentation.swift"; sourceTree = "<group>"; };
 		D71563E32D5AC2B600D2E948 /* CreateKMLMultiTrackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateKMLMultiTrackView.swift; sourceTree = "<group>"; };
 		D718A1E62B570F7500447087 /* OrbitCameraAroundObjectView.Model.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OrbitCameraAroundObjectView.Model.swift; sourceTree = "<group>"; };
 		D718A1EA2B575FD900447087 /* ManageBookmarksView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ManageBookmarksView.swift; sourceTree = "<group>"; };
@@ -1196,6 +1198,7 @@
 				D7A670D42DADB9630060E327 /* Bundle.swift */,
 				D7A670D62DADBC770060E327 /* EnvironmentValues+RequestReviewModel.swift */,
 				00181B452846AD7100654571 /* View+ErrorAlert.swift */,
+				D7142BC32DB71082004F87B7 /* View+PagePresentation.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -3561,6 +3564,7 @@
 				E0D04FF228A5390000747989 /* DownloadPreplannedMapAreaView.Model.swift in Sources */,
 				D764B7DF2BE2F89D002E2F92 /* EditGeodatabaseWithTransactionsView.swift in Sources */,
 				00CCB8A5285BAF8700BBAB70 /* OnDemandResource.swift in Sources */,
+				D7142BC42DB71082004F87B7 /* View+PagePresentation.swift in Sources */,
 				D7635FFE2B9277DC0044AB97 /* ConfigureClustersView.swift in Sources */,
 				1C19B4F32A578E46001D2506 /* CreateLoadReportView.swift in Sources */,
 				D71563E92D5AC2B600D2E948 /* CreateKMLMultiTrackView.swift in Sources */,

--- a/Shared/Samples/Download vector tiles to local cache/DownloadVectorTilesToLocalCacheView.swift
+++ b/Shared/Samples/Download vector tiles to local cache/DownloadVectorTilesToLocalCacheView.swift
@@ -146,6 +146,7 @@ struct DownloadVectorTilesToLocalCacheView: View {
                                         }
                                 }
                                 .highPriorityGesture(DragGesture())
+                                .pagePresentation()
                             }
                         }
                     }

--- a/Shared/Supporting Files/Extensions/View+PagePresentation.swift
+++ b/Shared/Supporting Files/Extensions/View+PagePresentation.swift
@@ -1,0 +1,27 @@
+// Copyright 2025 Esri
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import SwiftUI
+
+extension View {
+    /// Sets the sizing of the containing presentation to `PresentationSizing.page`.
+    @ViewBuilder
+    func pagePresentation() -> some View {
+        if #available(iOS 18.0, macCatalyst 18.0, *) {
+            presentationSizing(.page)
+        } else {
+            self
+        }
+    }
+}

--- a/Shared/Supporting Files/Views/ContentView.swift
+++ b/Shared/Supporting Files/Views/ContentView.swift
@@ -39,6 +39,7 @@ struct ContentView: View {
                         }
                         .sheet(isPresented: $isAboutViewPresented) {
                             AboutView()
+                                .pagePresentation()
                         }
                     }
                 }

--- a/Shared/Supporting Files/Views/FavoritesView.swift
+++ b/Shared/Supporting Files/Views/FavoritesView.swift
@@ -54,6 +54,7 @@ struct FavoritesView: View {
                 }
                 .sheet(isPresented: $addFavoriteSheetIsShowing) {
                     AddFavoriteView()
+                        .pagePresentation()
                 }
             }
         }

--- a/Shared/Supporting Files/Views/SampleDetailView.swift
+++ b/Shared/Supporting Files/Views/SampleDetailView.swift
@@ -109,6 +109,7 @@ struct SampleDetailView: View {
                     NavigationStack {
                         SampleInfoView(sample: sample)
                     }
+                    .pagePresentation()
                 }
             }
         }


### PR DESCRIPTION
## Description

This PR fixes an issue where sheets would display smaller than expected on iPadOS and Mac Catalyst 18.0+. The only sample that I thought needed this fix was `Download vector tiles to local cache`, since the rest of sheets have content small enough to fit in `PresentationSizing.form`, which appears to be the new default.

## How To Test

- Ensure the affected sheets work as expected.
  - About View: Tap on the info button in the categories toolbar.
  - Add favorite view: Enter the Favorites category and tap the plus button.
  - Sample info view: Enter a sample, tap the ellipsis button, and tap "View Info".
  - `Download vector tiles to local cache` sample: Tap "Download Vector Tiles" button in the sample.

## Screenshots

|Before|After|
|:-:|:-:|
|    ![Screenshot 2025-04-21 at 4 39 21 PM](https://github.com/user-attachments/assets/9816533e-582f-4870-8f7e-bc9efb4b9076)    |    ![Screenshot 2025-04-21 at 4 56 49 PM](https://github.com/user-attachments/assets/45a61ea8-4ad2-46b9-be7d-3534f4b3fc55)    |
|     ![Simulator Screenshot - iPad (10th generation) - 2025-04-21 at 17 41 43](https://github.com/user-attachments/assets/1b455bd9-024b-4468-8490-1088e1491ddf)    |    ![Simulator Screenshot - iPad (10th generation) - 2025-04-21 at 16 58 00](https://github.com/user-attachments/assets/691ffa04-8b1c-4519-b7c9-a998e1b3100a)    |
