### PR TITLE
Use `formatted()` in fewer places

### DIFF
--- a/Shared/Samples/Add dynamic entity layer/AddDynamicEntityLayerView.SettingsView.swift
+++ b/Shared/Samples/Add dynamic entity layer/AddDynamicEntityLayerView.SettingsView.swift
@@ -38,7 +38,8 @@ extension AddDynamicEntityLayerView {
                         VStack {
                             LabeledContent(
                                 "Observations per track",
-                                value: model.maximumObservations.formatted()
+                                value: model.maximumObservations,
+                                format: .number
                             )
                             Slider(value: $model.maximumObservations, in: model.maxObservationRange, step: 1)
                         }

--- a/Shared/Samples/Add dynamic entity layer/AddDynamicEntityLayerView.VehicleCallout.swift
+++ b/Shared/Samples/Add dynamic entity layer/AddDynamicEntityLayerView.VehicleCallout.swift
@@ -64,7 +64,7 @@ extension AddDynamicEntityLayerView {
                 VStack(spacing: 6) {
                     Image(systemName: "arrow.up.circle")
                         .rotationEffect(.degrees(heading))
-                    Text(Measurement<UnitAngle>(value: heading, unit: .degrees).formatted())
+                    Text(Measurement<UnitAngle>(value: heading, unit: .degrees), format: .measurement(width: .abbreviated))
                         .font(.caption2)
                 }
             }

--- a/Shared/Samples/Change map view background/ChangeMapViewBackgroundView.SettingsView.swift
+++ b/Shared/Samples/Change map view background/ChangeMapViewBackgroundView.SettingsView.swift
@@ -28,11 +28,11 @@ extension ChangeMapViewBackgroundView {
                     ColorPicker("Color", selection: $model.color)
                     ColorPicker("Line Color", selection: $model.lineColor)
                     VStack {
-                        LabeledContent("Line Width", value: model.lineWidth.formatted())
+                        LabeledContent("Line Width", value: model.lineWidth, format: .number)
                         Slider(value: $model.lineWidth, in: model.lineWidthRange, step: 1)
                     }
                     VStack {
-                        LabeledContent("Grid Size", value: model.size.formatted())
+                        LabeledContent("Grid Size", value: model.size, format: .number)
                         Slider(value: $model.size, in: model.sizeRange, step: 1)
                     }
                 }

--- a/Shared/Samples/Create mobile geodatabase/CreateMobileGeodatabaseView.swift
+++ b/Shared/Samples/Create mobile geodatabase/CreateMobileGeodatabaseView.swift
@@ -111,7 +111,7 @@ struct CreateMobileGeodatabaseView: View {
                         HStack {
                             Text(String(feature.oid))
                                 .padding(.trailing, 8)
-                            Text(feature.timestamp.formatted(.collectionTimestamp))
+                            Text(feature.timestamp, format: .collectionTimestamp)
                         }
                     }
                 }

--- a/Shared/Samples/Show mobile map package expiration date/ShowMobileMapPackageExpirationDateView.swift
+++ b/Shared/Samples/Show mobile map package expiration date/ShowMobileMapPackageExpirationDateView.swift
@@ -44,7 +44,12 @@ struct ShowMobileMapPackageExpirationDateView: View {
             if let expiration = mapPackage.expiration, expiration.isExpired {
                 VStack {
                     Text(expiration.message)
-                    Text("Expiration date: \(expiration.date?.formatted() ?? "N/A")")
+                    let expirationDate = if let date = expiration.date {
+                        Text(date, format: .dateTime)
+                    } else {
+                        Text("N/A")
+                    }
+                    Text("Expiration date: \(expirationDate)")
                         .padding(.top)
                 }
                 .multilineTextAlignment(.center)


### PR DESCRIPTION
I noticed that some samples are using `formatted()` when they could instead pass the format style as a separate parameter, allowing SwiftUI to efficiently decide when to format the value. These changes replace uses of `formatted()` in views with the more appropriate SwiftUI formatting API.