### PR TITLE
[Update] Replace runtime org URL prefix

### DIFF
--- a/Shared/Samples/Add KML layer with network links/README.md
+++ b/Shared/Samples/Add KML layer with network links/README.md
@@ -26,7 +26,7 @@ The sample will load the KML file automatically. The data shown should refresh a
 
 ## Offline data
 
-This sample uses the "radar.kmz" file, which can be found on [ArcGIS Online](https://arcgisruntime.maps.arcgis.com/home/item.html?id=600748d4464442288f6db8a4ba27dc95).
+This sample uses the "radar.kmz" file, which can be found on [ArcGIS Online](https://www.arcgis.com/home/item.html?id=600748d4464442288f6db8a4ba27dc95).
 
 ## About the data
 

--- a/Shared/Samples/Add WFS layer/README.md
+++ b/Shared/Samples/Add WFS layer/README.md
@@ -28,7 +28,7 @@ Pan and zoom to see features within the current map extent.
 
 ## About the data
 
-This service shows building footprints for downtown Seattle. For additional information, see the underlying service on [ArcGIS Online](https://arcgisruntime.maps.arcgis.com/home/item.html?id=1b81d35c5b0942678140efc29bc25391).
+This service shows building footprints for downtown Seattle. For additional information, see the underlying service on [ArcGIS Online](https://www.arcgis.com/home/item.html?id=1b81d35c5b0942678140efc29bc25391).
 
 ## Tags
 

--- a/Shared/Samples/Add elevation source from raster/README.md
+++ b/Shared/Samples/Add elevation source from raster/README.md
@@ -25,7 +25,7 @@ When opened, the sample displays a scene with a terrain surface applied. Pan and
 
 ## Offline data
 
-This sample uses the [MontereyElevation](https://www.arcgis.com/home/item.html?id=98092369c4ae4d549bbbd45dba993ebc) raster. It is downloaded from ArcGIS Online automatically.
+This sample uses the [Monterey Elevation](https://www.arcgis.com/home/item.html?id=98092369c4ae4d549bbbd45dba993ebc) raster. It is downloaded from ArcGIS Online automatically.
 
 ## Additional information
 

--- a/Shared/Samples/Add elevation source from raster/README.md
+++ b/Shared/Samples/Add elevation source from raster/README.md
@@ -25,7 +25,7 @@ When opened, the sample displays a scene with a terrain surface applied. Pan and
 
 ## Offline data
 
-This sample uses the [MontereyElevation](https://arcgisruntime.maps.arcgis.com/home/item.html?id=98092369c4ae4d549bbbd45dba993ebc) raster. It is downloaded from ArcGIS Online automatically.
+This sample uses the [MontereyElevation](https://www.arcgis.com/home/item.html?id=98092369c4ae4d549bbbd45dba993ebc) raster. It is downloaded from ArcGIS Online automatically.
 
 ## Additional information
 

--- a/Shared/Samples/Add elevation source from tile package/README.md
+++ b/Shared/Samples/Add elevation source from tile package/README.md
@@ -25,7 +25,7 @@ When loaded, the sample will show a scene with a terrain surface applied. Pan an
 
 ## Offline data
 
-This sample uses the [Monterey Elevation](https://arcgisruntime.maps.arcgis.com/home/item.html?id=52ca74b4ba8042b78b3c653696f34a9c) tile package, using CompactV2 storage format (.tpkx). It is downloaded from ArcGIS Online automatically.
+This sample uses the [Monterey Elevation](https://www.arcgis.com/home/item.html?id=52ca74b4ba8042b78b3c653696f34a9c) tile package, using CompactV2 storage format (.tpkx). It is downloaded from ArcGIS Online automatically.
 
 ## Additional information
 


### PR DESCRIPTION
## Description

This PR clean up some URLs that contain the "arcgisruntime" org prefix.

## Linked Issue(s)

- https://github.com/Esri/arcgis-maps-sdk-swift-samples/pull/607#discussion_r2085181465

## How To Test

Open each updated URL and don't see 404. Use `grep -nrF 'runtime' .` to see if there are more "runtime" occurrence in the folder.
