### PR TITLE
[Update] Remove `try` keyword from for-await-in

### DIFF
--- a/Shared/Samples/Augment reality to navigate route/AugmentRealityToNavigateRouteView.ARSceneView.swift
+++ b/Shared/Samples/Augment reality to navigate route/AugmentRealityToNavigateRouteView.ARSceneView.swift
@@ -237,7 +237,7 @@ extension AugmentRealityToNavigateRouteView {
         /// Monitors the asynchronous stream of voice guidances.
         private func trackVoiceGuidance() async {
             guard let routeTracker else { return }
-            for try await voiceGuidance in routeTracker.voiceGuidances {
+            for await voiceGuidance in routeTracker.voiceGuidances {
                 speechSynthesizer.stopSpeaking(at: .word)
                 speechSynthesizer.speak(AVSpeechUtterance(string: voiceGuidance.text))
             }

--- a/Shared/Samples/Navigate route/NavigateRouteView.swift
+++ b/Shared/Samples/Navigate route/NavigateRouteView.swift
@@ -283,7 +283,7 @@ private extension NavigateRouteView {
         
         /// Monitors the asynchronous stream of voice guidances.
         private func trackVoiceGuidance() async {
-            for try await voiceGuidance in routeTracker.voiceGuidances {
+            for await voiceGuidance in routeTracker.voiceGuidances {
                 speechSynthesizer.stopSpeaking(at: .word)
                 speechSynthesizer.speak(AVSpeechUtterance(string: voiceGuidance.text))
             }


### PR DESCRIPTION
## Description

This PR removes superfluous `try` keyword from `for try await in` syntax. Found these while discussing `AsyncStream` with Mary.
