### PR TITLE
[Update] Category for Show service area sample

### DIFF
--- a/Shared/Samples/Show service area/README.metadata.json
+++ b/Shared/Samples/Show service area/README.metadata.json
@@ -1,5 +1,5 @@
 {
-    "category": "Analysis",
+    "category": "Routing and Logistics",
     "description": "Find the service area within a network from a given point.",
     "ignore": false,
     "images": [


### PR DESCRIPTION
Change category for the sample.

## Description

This PR implements `Show service area` in `Routing and Logistics` category. According to the category design doc, Network analysis samples should be in this category, rather than Analysis.

## Linked Issue(s)

- https://github.com/Esri/arcgis-maps-sdk-swift-samples/pull/618#discussion_r2092110078
