### PR TITLE
[Update] Replace deprecated item "OpenStreetMap Tourist Attractions for North America" for Display overview map

### DIFF
--- a/Shared/Samples/Display overview map/DisplayOverviewMapView.swift
+++ b/Shared/Samples/Display overview map/DisplayOverviewMapView.swift
@@ -33,7 +33,7 @@ struct DisplayOverviewMapView: View {
     /// The current viewpoint of the map view.
     @State private var viewpoint = Viewpoint(
         center: Point(x: -123.12052, y: 49.28299, spatialReference: .wgs84),
-        scale: 1e5
+        scale: 5e4
     )
     
     /// The visible area marked with a red rectangle on the overview map.
@@ -55,7 +55,7 @@ struct DisplayOverviewMapView: View {
 }
 
 private extension PortalItem.ID {
-    static var northAmericaTouristAttractions: Self { Self("97ceed5cfc984b4399e23888f6252856")! }
+    static var northAmericaTouristAttractions: Self { Self("addaa517dde346d1898c614fa91fd032")! }
 }
 
 #Preview {

--- a/Shared/Samples/Display overview map/README.md
+++ b/Shared/Samples/Display overview map/README.md
@@ -27,7 +27,7 @@ Pan or zoom across the map view to browse through the tourist attractions featur
 
 ## About the data
 
-The data used in this sample is the [OpenStreetMap Tourist Attractions for North America](https://www.arcgis.com/home/item.html?id=97ceed5cfc984b4399e23888f6252856) feature layer, which is scale-dependent and displays at scales larger than 1:160,000.
+The data used in this sample is the [OpenStreetMap Tourist Attractions for North America](https://www.arcgis.com/home/item.html?id=addaa517dde346d1898c614fa91fd032) feature layer, which is scale-dependent and displays at scales larger than 1:160,000.
 
 ## Additional information
 


### PR DESCRIPTION
## Description

This PR updates an item link.

Old: https://www.arcgis.com/home/item.html?id=97ceed5cfc984b4399e23888f6252856
New: https://www.arcgis.com/home/item.html?id=addaa517dde346d1898c614fa91fd032

## Linked Issue(s)

- `common-samples/pull/4001`

## How To Test

See the updated item still loads.

## To Discuss

- I didn't update the screenshot as it looks similar, despite the scale has changed.
- Although the [new item](https://www.arcgis.com/home/item.html?id=addaa517dde346d1898c614fa91fd032) states it renders at 1:160,000, in code I cannot get it render at 1e5 scale so I has to change to closer 5e4.
