### PR TITLE
[Update] Replace deprecated UtilityNetwork initializers

### DIFF
--- a/Shared/Samples/Analyze network with subnetwork trace/AnalyzeNetworkWithSubnetworkTraceView.Model.swift
+++ b/Shared/Samples/Analyze network with subnetwork trace/AnalyzeNetworkWithSubnetworkTraceView.Model.swift
@@ -20,8 +20,8 @@ extension AnalyzeNetworkWithSubnetworkTraceView {
     /// The view model for this sample.
     @MainActor
     class Model: ObservableObject {
-        /// A feature service for an electric utility network in Naperville, Illinois.
-        private let utilityNetwork = UtilityNetwork(url: .featureServiceURL)
+        /// An electric utility network in Naperville, Illinois.
+        private let utilityNetwork = UtilityNetwork(serviceGeodatabase: .napervilleGeodatabase)
         
         /// An array of condition expressions.
         private var traceConditionalExpressions: [UtilityTraceConditionalExpression] = []
@@ -397,6 +397,13 @@ private extension URL {
     /// The URL to the feature service for running the isolation trace.
     static var featureServiceURL: URL {
         URL(string: "https://sampleserver7.arcgisonline.com/server/rest/services/UtilityNetwork/NapervilleElectric/FeatureServer")!
+    }
+}
+
+private extension ServiceGeodatabase {
+    /// The Naperville, Illinois electric utility network service geodatabase.
+    static var napervilleGeodatabase: ServiceGeodatabase {
+        .init(url: .featureServiceURL)
     }
 }
 

--- a/Shared/Samples/Create load report/CreateLoadReportView.Model.swift
+++ b/Shared/Samples/Create load report/CreateLoadReportView.Model.swift
@@ -22,8 +22,8 @@ extension CreateLoadReportView {
     @MainActor
     class Model: ObservableObject {
         // MARK: Properties
-        /// The utility network for this sample.
-        private let utilityNetwork = UtilityNetwork(url: .utilityNetwork)
+        /// An electric utility network in Naperville, Illinois.
+        private let utilityNetwork = UtilityNetwork(serviceGeodatabase: .napervilleGeodatabase)
         
         /// The initial conditional expression.
         private var initialExpression: UtilityTraceConditionalExpression?
@@ -364,5 +364,12 @@ private extension URL {
     /// The utility network for this sample.
     static var utilityNetwork: URL {
         URL(string: "https://sampleserver7.arcgisonline.com/server/rest/services/UtilityNetwork/NapervilleElectric/FeatureServer")!
+    }
+}
+
+private extension ServiceGeodatabase {
+    /// The Naperville, Illinois electric utility network service geodatabase.
+    static var napervilleGeodatabase: ServiceGeodatabase {
+        .init(url: .utilityNetwork)
     }
 }

--- a/Shared/Samples/Display content of utility network container/DisplayContentOfUtilityNetworkContainerView.Model.swift
+++ b/Shared/Samples/Display content of utility network container/DisplayContentOfUtilityNetworkContainerView.Model.swift
@@ -70,7 +70,7 @@ extension DisplayContentOfUtilityNetworkContainerView {
             ArcGISEnvironment.authenticationManager.arcGISAuthenticationChallengeHandler = ChallengeHandler()
             
             // Creates the utility network.
-            network = UtilityNetwork(url: .featureService, map: map)
+            network = UtilityNetwork(serviceGeodatabase: .napervilleGeodatabase)
         }
         
         deinit {
@@ -252,6 +252,13 @@ private extension URL {
     /// The portal containing the data for this sample.
     static var samplePortal: URL {
         sampleServer7.appendingPathComponent("portal")
+    }
+}
+
+private extension ServiceGeodatabase {
+    /// The Naperville, Illinois electric utility network service geodatabase.
+    static var napervilleGeodatabase: ServiceGeodatabase {
+        .init(url: .featureService)
     }
 }
 

--- a/Shared/Samples/Run valve isolation trace/RunValveIsolationTraceView.Model.swift
+++ b/Shared/Samples/Run valve isolation trace/RunValveIsolationTraceView.Model.swift
@@ -24,7 +24,7 @@ extension RunValveIsolationTraceView {
         let map = Map(basemapStyle: .arcGISStreetsNight)
         
         /// The utility network for this sample.
-        private let utilityNetwork = UtilityNetwork(url: .featureServiceURL)
+        private let utilityNetwork: UtilityNetwork
         
         /// The service geodatabase used to create the feature layer.
         private let serviceGeodatabase = ServiceGeodatabase(url: .featureServiceURL)
@@ -94,6 +94,7 @@ extension RunValveIsolationTraceView {
         }()
         
         init() {
+            utilityNetwork = UtilityNetwork(serviceGeodatabase: serviceGeodatabase)
             map.addUtilityNetwork(utilityNetwork)
         }
         

--- a/Shared/Samples/Show utility associations/ShowUtilityAssociationsView.swift
+++ b/Shared/Samples/Show utility associations/ShowUtilityAssociationsView.swift
@@ -108,7 +108,7 @@ private extension ShowUtilityAssociationsView {
         let map = Map(basemapStyle: .arcGISTopographic)
         
         /// The utility network for this sample.
-        private let network = UtilityNetwork(url: .utilityNetwork)
+        private let network = UtilityNetwork(serviceGeodatabase: .napervilleGeodatabase)
         
         /// A container for associations results.
         let associationsOverlay = makeAssociationsOverlay()
@@ -258,6 +258,13 @@ private extension URL {
     /// The utility network for this sample.
     static var utilityNetwork: URL {
         URL(string: "https://sampleserver7.arcgisonline.com/server/rest/services/UtilityNetwork/NapervilleElectric/FeatureServer")!
+    }
+}
+
+private extension ServiceGeodatabase {
+    /// The Naperville, Illinois electric utility network service geodatabase.
+    static var napervilleGeodatabase: ServiceGeodatabase {
+        .init(url: .utilityNetwork)
     }
 }
 


### PR DESCRIPTION
## Description

This PR replaces deprecated UtilityNetwork initializers. 

## Linked Issue(s)

- `swift/issues/6976`

## How To Test

Go through each changed sample and verify that the utility network still loads. Read the READMEs and see if the phrasing change make sense.