### PR TITLE
[Update] Bump version numbers for 200.8.0 

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ This repository contains Swift sample code demonstrating the capabilities of the
 
 ## Requirements
 
-* [ArcGIS Maps SDK for Swift](https://developers.arcgis.com/swift/) 200.7 (or newer)
-* [ArcGIS Maps SDK for Swift Toolkit](https://github.com/Esri/arcgis-maps-sdk-swift-toolkit) 200.7 (or newer)
-* Xcode 16.0 (or newer)
+* [ArcGIS Maps SDK for Swift](https://developers.arcgis.com/swift/) 200.8 (or newer)
+* [ArcGIS Maps SDK for Swift Toolkit](https://github.com/Esri/arcgis-maps-sdk-swift-toolkit) 200.8 (or newer)
+* Xcode 16.4 (or newer)
 
 The *ArcGIS Maps SDK for Swift Samples app* has a *Target SDK* version of *17.0*, meaning that it can run on devices with *iOS 17.0* or newer.
 

--- a/Samples.xcodeproj/project.pbxproj
+++ b/Samples.xcodeproj/project.pbxproj
@@ -4832,7 +4832,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 200.7.0;
+				MARKETING_VERSION = 200.8.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.esri.arcgis-swift-sdk-samples";
 				PRODUCT_NAME = "ArcGIS Maps SDK Samples";
 				SDKROOT = iphoneos;
@@ -4862,7 +4862,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 200.7.0;
+				MARKETING_VERSION = 200.8.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.esri.arcgis-swift-sdk-samples";
 				PRODUCT_NAME = "ArcGIS Maps SDK Samples";
 				SDKROOT = iphoneos;
@@ -4905,7 +4905,7 @@
 			repositoryURL = "https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 200.7.0;
+				minimumVersion = 200.8.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */


### PR DESCRIPTION
## Description

This PR bumps the samples and toolkit version numbers to 200.8.0 in preparation for the upcoming release. It also increases the minimum requirement to Xcode 16.4.

Note that the project currently doesn't build since the 200.8 toolkit hasn't been released yet.

## Linked Issue(s)

- `swift/issues/7046`
