### PR TITLE
[Setup] Adapt scripts to add has_teardown

### DIFF
--- a/Scripts/CI/common.py
+++ b/Scripts/CI/common.py
@@ -374,7 +374,7 @@ class Metadata:
         data["snippets"] = self.snippets
         data["title"] = self.title
         if self.has_teardown:
-            # Only write offline_data when it is not empty.
+            # Only write has_teardown when it is not empty.
             data["has_teardown"] = self.has_teardown
         if self.offline_data:
             # Only write offline_data when it is not empty.

--- a/Scripts/CI/common.py
+++ b/Scripts/CI/common.py
@@ -275,6 +275,7 @@ class Metadata:
 
         # A list of ArcGIS Portal Item IDs.
         self.offline_data = []      # Default to empty list.
+        self.has_teardown = False   # Only applies to samples that require async tear down (e.g., authentication).
 
         self.folder_path = folder_path
         self.folder_name = get_folder_name_from_path(folder_path)
@@ -372,6 +373,9 @@ class Metadata:
         data["relevant_apis"] = self.relevant_apis
         data["snippets"] = self.snippets
         data["title"] = self.title
+        if self.has_teardown:
+            # Only write offline_data when it is not empty.
+            data["has_teardown"] = self.has_teardown
         if self.offline_data:
             # Only write offline_data when it is not empty.
             data["offline_data"] = self.offline_data

--- a/Scripts/CI/common.py
+++ b/Scripts/CI/common.py
@@ -374,7 +374,7 @@ class Metadata:
         data["snippets"] = self.snippets
         data["title"] = self.title
         if self.has_teardown:
-            # Only write has_teardown when it is not empty.
+            # Only write has_teardown when it is True.
             data["has_teardown"] = self.has_teardown
         if self.offline_data:
             # Only write offline_data when it is not empty.

--- a/Scripts/CI/metadata_checker.py
+++ b/Scripts/CI/metadata_checker.py
@@ -52,13 +52,13 @@ def run_check(path: str) -> None:
     # The special rule not to compare the redirect_from.
     checker.redirect_from = json_data['redirect_from']
 
-    # The special rule not to compare offline_data.
-    if 'offline_data' in json_data:
-        checker.offline_data = json_data['offline_data']
-
     # The special rule not to compare has_teardown.
     if 'has_teardown' in json_data:
         checker.has_teardown = json_data['has_teardown']
+
+    # The special rule not to compare offline_data.
+    if 'offline_data' in json_data:
+        checker.offline_data = json_data['offline_data']
 
     # The special rule to be lenient on shortened description.
     # If the original json has a shortened/special char purged description,

--- a/Scripts/CI/metadata_checker.py
+++ b/Scripts/CI/metadata_checker.py
@@ -56,6 +56,10 @@ def run_check(path: str) -> None:
     if 'offline_data' in json_data:
         checker.offline_data = json_data['offline_data']
 
+    # The special rule not to compare has_teardown.
+    if 'has_teardown' in json_data:
+        checker.has_teardown = json_data['has_teardown']
+
     # The special rule to be lenient on shortened description.
     # If the original json has a shortened/special char purged description,
     # then no need to raise an error.

--- a/Scripts/create-metadata-from-README.py
+++ b/Scripts/create-metadata-from-README.py
@@ -50,7 +50,7 @@ class MetadataCreator(Metadata):
         data["snippets"] = self.snippets
         data["title"] = self.title
         if self.has_teardown:
-            # Only write offline_data when it is not empty.
+            # Only write has_teardown when it is not empty.
             data["has_teardown"] = self.has_teardown
         if self.offline_data:
             # Only write offline_data when it is not empty.

--- a/Scripts/create-metadata-from-README.py
+++ b/Scripts/create-metadata-from-README.py
@@ -50,7 +50,7 @@ class MetadataCreator(Metadata):
         data["snippets"] = self.snippets
         data["title"] = self.title
         if self.has_teardown:
-            # Only write has_teardown when it is not empty.
+            # Only write has_teardown when it is True.
             data["has_teardown"] = self.has_teardown
         if self.offline_data:
             # Only write offline_data when it is not empty.

--- a/Scripts/create-metadata-from-README.py
+++ b/Scripts/create-metadata-from-README.py
@@ -49,6 +49,9 @@ class MetadataCreator(Metadata):
         data["relevant_apis"] = self.relevant_apis
         data["snippets"] = self.snippets
         data["title"] = self.title
+        if self.has_teardown:
+            # Only write offline_data when it is not empty.
+            data["has_teardown"] = self.has_teardown
         if self.offline_data:
             # Only write offline_data when it is not empty.
             data["offline_data"] = self.offline_data

--- a/Shared/Samples/Display map/README.metadata.json
+++ b/Shared/Samples/Display map/README.metadata.json
@@ -1,6 +1,7 @@
 {
     "category": "Maps",
     "description": "Display a map with an imagery basemap.",
+    "has_teardown": true,
     "ignore": false,
     "images": [
         "display-map.png"

--- a/Shared/Samples/Display map/README.metadata.json
+++ b/Shared/Samples/Display map/README.metadata.json
@@ -1,6 +1,7 @@
 {
     "category": "Maps",
     "description": "Display a map with an imagery basemap.",
+    "has_teardown": false,
     "ignore": false,
     "images": [
         "display-map.png"

--- a/Shared/Samples/Display map/README.metadata.json
+++ b/Shared/Samples/Display map/README.metadata.json
@@ -1,7 +1,6 @@
 {
     "category": "Maps",
     "description": "Display a map with an imagery basemap.",
-    "has_teardown": false,
     "ignore": false,
     "images": [
         "display-map.png"

--- a/Shared/Samples/Display map/README.metadata.json
+++ b/Shared/Samples/Display map/README.metadata.json
@@ -1,7 +1,6 @@
 {
     "category": "Maps",
     "description": "Display a map with an imagery basemap.",
-    "has_teardown": true,
     "ignore": false,
     "images": [
         "display-map.png"


### PR DESCRIPTION
## Description

This PR updates the CI checker scripts to add the "has_teardown" metadata field, for the reasons listed in #667 .

## How To Test

See that I tweaked a metadata file below to pass then reverted.

35853b8: [check 1](https://github.com/Esri/arcgis-maps-sdk-swift-samples/actions/runs/16458283449/job/46520280546): check fails if `"has_teardown" : false` was specified (when a sample doesn't need teardown, it shouldn't specify this field)

414105d: [check 2](https://github.com/Esri/arcgis-maps-sdk-swift-samples/actions/runs/16458439854/job/46520760400): check succeeds if `"has_teardown" : true`, which is used to check those that require teardown

47919fd: when there is no this field, the check succeeds