### PR TITLE
[Fix] `Manage features` certification issues

### DIFF
--- a/Shared/Samples/Manage features/ManageFeaturesView.swift
+++ b/Shared/Samples/Manage features/ManageFeaturesView.swift
@@ -157,6 +157,7 @@ struct ManageFeaturesView: View {
                     .contentShape(.rect)
                     .labelStyle(.iconOnly)
             }
+            .fixedSize()
             .confirmationDialog("Update Attribute", isPresented: $isShowingUpdateAttributeDialog) {
                 ForEach(DamageKind.allCases, id: \.self) { damageKind in
                     Button(damageKind.rawValue) {

--- a/Shared/Samples/Manage features/ManageFeaturesView.swift
+++ b/Shared/Samples/Manage features/ManageFeaturesView.swift
@@ -156,12 +156,13 @@ struct ManageFeaturesView: View {
                     Text("Delete Feature")
                 }
             } label: {
-                Image(systemName: "ellipsis")
-                    .padding(.leading)
+                Label("Edit Feature", systemImage: "ellipsis")
+                    .padding()
+                    .contentShape(.rect)
+                    .labelStyle(.iconOnly)
             }
-            .fixedSize()
         }
-        .padding()
+        .padding([.leading, .vertical])
     }
     
     /// Overlay with instructions for the user.

--- a/Shared/Samples/Manage features/ManageFeaturesView.swift
+++ b/Shared/Samples/Manage features/ManageFeaturesView.swift
@@ -62,10 +62,12 @@ struct ManageFeaturesView: View {
         MapViewReader { mapView in
             MapView(map: data.map)
                 .onSingleTapGesture { tapLocation, tapMapPoint in
-                    // Store state and clear selection on tap.
-                    self.tapLocation = tapLocation
-                    self.tapMapPoint = tapMapPoint
-                    clearSelection()
+                    if calloutPlacement == nil {
+                        self.tapLocation = tapLocation
+                        self.tapMapPoint = tapMapPoint
+                    } else {
+                        clearSelection()
+                    }
                 }
                 .callout(placement: $calloutPlacement) { placement in
                     if let feature = placement.geoElement as? Feature {


### PR DESCRIPTION
## Description

This PR updates `Manage features` with some suggestions that Sarat gave during `200.8.0` certification:
- Enlarges the edit feature menu's hit box since it was hard to press.
- Hides the callout when it is showing and the map is tapped rather than immediately performing another identify.
- Allows the user to select a damage kind attribute value instead of incrementing it.

## Linked Issue(s)

- `swift/issues/7113`

## Screenshots

Other than the added confirmation dialog, there are no UI changes.

<img width="276" height="600" alt="Simulator Screenshot - 1 - iPhone 16 Pro - 2025-07-22 at 17 53 01" src="https://github.com/user-attachments/assets/d1940f8b-7960-4659-ba96-967710d2e9dd" />




