### PR TITLE
[Update] Replace NOAA KML data in Add KML layer

### DIFF
--- a/Shared/Samples/Add KML layer/AddKMLLayerView.swift
+++ b/Shared/Samples/Add KML layer/AddKMLLayerView.swift
@@ -76,7 +76,7 @@ private extension AddKMLLayerView {
         
         /// A KML layer created from a web URL.
         let urlLayer: KMLLayer = {
-            let url = URL(string: "https://www.wpc.ncep.noaa.gov/kml/noaa_chart/WPC_Day1_SigWx.kml")!
+            let url = URL(string: "https://www.spc.noaa.gov/products/outlook/SPC_outlooks.kml")!
             let kmlDataset = KMLDataset(url: url)
             return KMLLayer(dataset: kmlDataset)
         }()

--- a/Shared/Samples/Add KML layer/README.md
+++ b/Shared/Samples/Add KML layer/README.md
@@ -32,7 +32,7 @@ This sample uses the [US State Capitals](https://www.arcgis.com/home/item.html?i
 
 This sample displays three different KML files:
 
-* From URL: This is a map of the significant weather outlook produced by NOAA/NWS. It uses KML network links to always show the latest data.
+* From URL: This is a map of the convective outlook produced by NOAA/NWS Storm Prediction Center. It uses KML network links to always show the latest data.
 * From local file: This is a map of U.S. state capitals. It doesn't define an icon, so the default pushpin is used for the points.
 * From portal item: This is a map of U.S. states.
 


### PR DESCRIPTION
## Description

This PR updates `Add KML layer` in `Layers` category. The current SigWx day 1 outlook data is no longer working, which might due to some faulty links in the KML network link. After discussion, we decided to replace it with a convective outlook data.

## Linked Issue(s)

- `common-samples/pull/4008`

## How To Test

Run the sample and see the kml show up on this branch, don't show up on v.next.

## Screenshots

<img width="1170" height="2532" alt="Simulator Screenshot - iPhone 16e - 2025-07-23 at 09 28 56" src="https://github.com/user-attachments/assets/cedf4f80-e4b5-4403-a70d-68c5456ddd9e" />
