### PR TITLE
[Setup] Add debug section to allow swapping API key

### DIFF
--- a/Shared/Supporting Files/Views/AboutView.swift
+++ b/Shared/Supporting Files/Views/AboutView.swift
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import ArcGIS
 import SwiftUI
 
 struct AboutView: View {
@@ -24,6 +25,8 @@ struct AboutView: View {
     private let arcGISVersion = Bundle.arcGIS.version.isEmpty
     ? Bundle.arcGIS.shortVersion
     : "\(Bundle.arcGIS.shortVersion) (\(Bundle.arcGIS.version))"
+    
+    @State private var apiKey = ""
     
     var body: some View {
         NavigationStack {
@@ -64,6 +67,9 @@ struct AboutView: View {
                 } footer: {
                     Text("View details about the API.")
                 }
+#if DEBUG
+                debugSection
+#endif
             }
             .navigationTitle("About")
             .navigationBarTitleDisplayMode(.inline)
@@ -96,4 +102,28 @@ private extension URL {
     static let toolkit = URL(string: "https://github.com/Esri/arcgis-maps-sdk-swift-toolkit")!
     static let apiReference = URL(string: "https://developers.arcgis.com/swift/api-reference/documentation/arcgis/")!
     static let writeReview = URL(string: "https://apps.apple.com/app/id1630449018?action=write-review")!
+}
+
+extension AboutView {
+    /// A section for debugging purposes.
+    var debugSection: some View {
+        Section {
+            TextField("Enter API Key Here", text: $apiKey, axis: .vertical)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+                .textEditorStyle(.plain)
+            Button("Submit") {
+                if let apiKey = APIKey(apiKey) {
+                    ArcGISEnvironment.apiKey = apiKey
+                } else {
+                    fatalError("Invalid API Key")
+                }
+            }
+            Button("Reset") {
+                ArcGISEnvironment.apiKey = .iOS
+            }
+        } footer: {
+            Text("The section above is for testing purposes only.")
+        }
+    }
 }

--- a/Shared/Supporting Files/Views/AboutView.swift
+++ b/Shared/Supporting Files/Views/AboutView.swift
@@ -26,6 +26,9 @@ struct AboutView: View {
     ? Bundle.arcGIS.shortVersion
     : "\(Bundle.arcGIS.shortVersion) (\(Bundle.arcGIS.version))"
     
+    /// A Boolean value indicating whether the API key alert is presented.
+    @State private var isAPIKeyAlertPresented = false
+    /// The API key entered in the alert.
     @State private var apiKey = ""
     
     var body: some View {
@@ -108,19 +111,22 @@ extension AboutView {
     /// A section for debugging purposes.
     var debugSection: some View {
         Section {
-            TextField("Enter API Key Here", text: $apiKey, axis: .vertical)
-                .textInputAutocapitalization(.never)
-                .autocorrectionDisabled()
-                .textEditorStyle(.plain)
-            Button("Submit") {
-                if let apiKey = APIKey(apiKey) {
-                    ArcGISEnvironment.apiKey = apiKey
-                } else {
-                    fatalError("Invalid API Key")
-                }
+            Button("Enter API Key") {
+                isAPIKeyAlertPresented = true
             }
-            Button("Reset") {
-                ArcGISEnvironment.apiKey = .iOS
+            .alert("Enter API Key", isPresented: $isAPIKeyAlertPresented) {
+                TextField("Enter API Key Here", text: $apiKey, axis: .vertical)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
+                    .textEditorStyle(.plain)
+                Button("Cancel", role: .cancel) {}
+                Button("Submit") {
+                    ArcGISEnvironment.apiKey = APIKey(apiKey)!
+                }
+                .disabled(apiKey.isEmpty)
+                Button("Reset") {
+                    ArcGISEnvironment.apiKey = .iOS
+                }
             }
         } footer: {
             Text("The section above is for testing purposes only.")


### PR DESCRIPTION
## Description

This PR adds a debug textfield to enter a different API key, in the case that a legacy key stops working but we still want to test an older daily build.

## Linked Issue(s)

- `swift/issues/7131`

## How To Test

- Put in an invalid key to see the app doesn't load basemap
- Put in a valid key to see the app works
- Use reset button to see the app works

## Screenshot

<img width="400" height="866" alt="Simulator Screenshot - iPhone 16e - 2025-07-24 at 15 12 07" src="https://github.com/user-attachments/assets/c335d595-8b0d-4a75-8ab5-03f9441eed8b" />
