### PR TITLE
[Fix] Some `200.8` sample certification issues

### DIFF
--- a/Samples.xcodeproj/project.pbxproj
+++ b/Samples.xcodeproj/project.pbxproj
@@ -577,6 +577,8 @@
 		D7AE861F2AC39E7F0049B626 /* DisplayAnnotationView.swift in Copy Source Code Files */ = {isa = PBXBuildFile; fileRef = D7AE861D2AC39DC50049B626 /* DisplayAnnotationView.swift */; };
 		D7AE86202AC3A1050049B626 /* AddCustomDynamicEntityDataSourceView.Vessel.swift in Copy Source Code Files */ = {isa = PBXBuildFile; fileRef = 7900C5F52A83FC3F002D430F /* AddCustomDynamicEntityDataSourceView.Vessel.swift */; };
 		D7AE86212AC3A10A0049B626 /* GroupLayersTogetherView.GroupLayerListView.swift in Copy Source Code Files */ = {isa = PBXBuildFile; fileRef = D75C35662AB50338003CD55F /* GroupLayersTogetherView.GroupLayerListView.swift */; };
+		D7AECFE72E31699400FD312A /* ControlAnnotationSublayerVisibilityView.Model.swift in Copy Source Code Files */ = {isa = PBXBuildFile; fileRef = 1C8438FA2DDCFCA9005CCBC7 /* ControlAnnotationSublayerVisibilityView.Model.swift */; };
+		D7AECFE82E31699A00FD312A /* GenerateGeodatabaseReplicaFromFeatureServiceView.Model.swift in Copy Source Code Files */ = {isa = PBXBuildFile; fileRef = 1C17E1CB2DE6456B00A012CB /* GenerateGeodatabaseReplicaFromFeatureServiceView.Model.swift */; };
 		D7B759B32B1FFBE300017FDD /* FavoritesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7B759B22B1FFBE300017FDD /* FavoritesView.swift */; };
 		D7BA38912BFBC476009954F5 /* EditFeaturesWithFeatureLinkedAnnotationView.Model.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7BA38902BFBC476009954F5 /* EditFeaturesWithFeatureLinkedAnnotationView.Model.swift */; };
 		D7BA38922BFBC4F0009954F5 /* EditFeaturesWithFeatureLinkedAnnotationView.Model.swift in Copy Source Code Files */ = {isa = PBXBuildFile; fileRef = D7BA38902BFBC476009954F5 /* EditFeaturesWithFeatureLinkedAnnotationView.Model.swift */; };
@@ -730,6 +732,8 @@
 			dstPath = "";
 			dstSubfolderSpec = 7;
 			files = (
+				D7AECFE82E31699A00FD312A /* GenerateGeodatabaseReplicaFromFeatureServiceView.Model.swift in Copy Source Code Files */,
+				D7AECFE72E31699400FD312A /* ControlAnnotationSublayerVisibilityView.Model.swift in Copy Source Code Files */,
 				9520B2B62E135AEE00B3BEF9 /* ShowLineOfSightBetweenGeoelementsView.swift in Copy Source Code Files */,
 				95FFEB442E06211B00543993 /* ShowGeodesicSectorAndEllipseView.swift in Copy Source Code Files */,
 				885F89BA2E0B5F8900C2E456 /* ManageFeaturesView.swift in Copy Source Code Files */,

--- a/Shared/Samples/Apply colormap renderer to raster/ApplyColormapRendererToRasterView.swift
+++ b/Shared/Samples/Apply colormap renderer to raster/ApplyColormapRendererToRasterView.swift
@@ -19,7 +19,7 @@ struct ApplyColormapRendererToRasterView: View {
     /// Creates the raster layer used by this sample.
     static func makeRasterLayer() -> RasterLayer {
         // Creates a raster and raster layer.
-        let raster = Raster(name: "ShastaBW", extension: "tif", bundle: nil)!
+        let raster = Raster(name: "ShastaBW/ShastaBW", extension: "tif", bundle: nil)!
         let rasterLayer = RasterLayer(raster: raster)
         
         // Creates a colormap renderer and assigns it to the raster layer.

--- a/Shared/Samples/Authenticate with PKI certificate/AuthenticateWithPKICertificateView.swift
+++ b/Shared/Samples/Authenticate with PKI certificate/AuthenticateWithPKICertificateView.swift
@@ -18,168 +18,169 @@ import SwiftUI
 
 struct AuthenticateWithPKICertificateView: View {
     /// The model that backs this view.
-     @StateObject private var model = Model()
+    @StateObject private var model = Model()
     
-     var body: some View {
-         Form {
-             switch model.portalContent {
-             case .success(let success):
-                 ForEach(success.results, id: \.id?.rawValue) { item in
-                     Button(item.title) {
-                         model.selectedItem = .init(portalItem: item)
-                     }
-                     .buttonStyle(.plain)
-                 }
-             case .failure:
-                 urlEntryView
-                 ContentUnavailableView(
-                     "Error",
-                     systemImage: "exclamationmark.triangle",
-                     description: Text("Error searching specified portal.")
-                 )
-             case nil:
-                 if model.isConnecting {
-                     ProgressView()
-                         .frame(maxWidth: .infinity)
-                 } else {
-                     urlEntryView
-                 }
-             }
-         }
-         .onTeardown {
-             // Reset the challenge handlers and clear credentials
-             // when the view disappears so that user is prompted to enter
-             // credentials every time the sample is run, and to clean
-             // the environment for other samples.
-             await model.teardownAuthenticator()
-         }
-         .sheet(item: $model.selectedItem) { selectedItem in
-             NavigationStack {
-                 MapView(map: Map(item: selectedItem.portalItem))
-                     .navigationTitle(selectedItem.portalItem.title)
-                     .navigationBarTitleDisplayMode(.inline)
-                     .toolbar {
-                         ToolbarItem(placement: .topBarTrailing) {
-                             Button("Done") {
-                                 model.selectedItem = nil
-                             }
-                         }
-                     }
-             }
-             .interactiveDismissDisabled()
-             .highPriorityGesture(DragGesture())
-             .pagePresentation()
-         }
-         .animation(.default, value: model.isConnecting)
-         .authenticator(model.authenticator)
-     }
+    var body: some View {
+        Form {
+            switch model.portalContent {
+            case .success(let success):
+                ForEach(success.results, id: \.id?.rawValue) { item in
+                    Button(item.title) {
+                        model.selectedItem = .init(portalItem: item)
+                    }
+                    .buttonStyle(.plain)
+                }
+            case .failure:
+                urlEntryView
+                ContentUnavailableView(
+                    "Error",
+                    systemImage: "exclamationmark.triangle",
+                    description: Text("Error searching specified portal.")
+                )
+            case nil:
+                if model.isConnecting {
+                    ProgressView()
+                        .frame(maxWidth: .infinity)
+                } else {
+                    urlEntryView
+                }
+            }
+        }
+        .onTeardown {
+            // Reset the challenge handlers and clear credentials
+            // when the view disappears so that user is prompted to enter
+            // credentials every time the sample is run, and to clean
+            // the environment for other samples.
+            await model.teardownAuthenticator()
+        }
+        .sheet(item: $model.selectedItem) { selectedItem in
+            NavigationStack {
+                MapView(map: Map(item: selectedItem.portalItem))
+                    .navigationTitle(selectedItem.portalItem.title)
+                    .navigationBarTitleDisplayMode(.inline)
+                    .toolbar {
+                        ToolbarItem(placement: .topBarTrailing) {
+                            Button("Done") {
+                                model.selectedItem = nil
+                            }
+                        }
+                    }
+            }
+            .interactiveDismissDisabled()
+            .highPriorityGesture(DragGesture())
+            .pagePresentation()
+        }
+        .animation(.default, value: model.isConnecting)
+        .authenticator(model.authenticator)
+    }
+    
+    @ViewBuilder private var urlEntryView: some View {
+        Section {
+            HStack {
+                TextField("PKI Secured Portal URL", text: $model.portalURLString)
+                    .onSubmit { Task { await model.connectToPortal() } }
+                    .autocapitalization(.none)
+                    .keyboardType(.URL)
+                Button("Connect") {
+                    Task { await model.connectToPortal() }
+                }
+                .disabled(model.portalURL == nil)
+            }
+        }
+    }
+}
 
-     @ViewBuilder private var urlEntryView: some View {
-         Section {
-             HStack {
-                 TextField("PKI Secured Portal URL", text: $model.portalURLString)
-                     .onSubmit { Task { await model.connectToPortal() } }
-                     .autocapitalization(.none)
-                     .keyboardType(.URL)
-                 Button("Connect") {
-                     Task { await model.connectToPortal() }
-                 }
-                 .disabled(model.portalURL == nil)
-             }
-         }
-     }
- }
+/// A value that represents an item selected by the user.
+private struct SelectedItem: Identifiable {
+    /// The portal item that was selected.
+    let portalItem: PortalItem
+    
+    var id: ObjectIdentifier {
+        ObjectIdentifier(portalItem)
+    }
+}
 
- /// A value that represents an item selected by the user.
- private struct SelectedItem: Identifiable {
-     /// The portal item that was selected.
-     let portalItem: PortalItem
-
-     var id: ObjectIdentifier {
-         ObjectIdentifier(portalItem)
-     }
- }
-
- extension AuthenticateWithPKICertificateView {
-     @MainActor
-     class Model: ObservableObject {
-         /// The authenticator to handle authentication challenges.
-         let authenticator = Authenticator()
-
-         /// The URL string entered by the user.
-         @Published var portalURLString = ""
-
-         /// The fetched portal content.
-         @Published var portalContent: Result<PortalQueryResultSet<PortalItem>, Error>?
-
-         /// A Boolean value indicating if a portal connection is in progress.
-         @Published var isConnecting = false
-
-         /// The selected item.
-         @Published fileprivate var selectedItem: SelectedItem?
-
-         /// The URL of the portal.
-         var portalURL: URL? { URL(string: portalURLString) }
-
-         init() {
-             setupAuthenticator()
-         }
-
-         /// Connects to the portal and finds a batch of webmaps.
-         func connectToPortal() async {
-             precondition(portalURL != nil)
-
-             isConnecting = true
-             defer { isConnecting = false }
-
-             do {
-                 let portal = Portal(url: portalURL!)
-                 try await portal.load()
-                 let results = try await portal.findItems(queryParameters: .items(ofKinds: [.webMap]))
-                 portalContent = .success(results)
-             } catch {
-                 portalContent = .failure(error)
-             }
-         }
-
-         /// Sets up the authenticator to handle challenges.
-         private func setupAuthenticator() {
-             // Setting the challenge handlers here when the model is created so user is prompted to enter
-             // credentials every time trying the sample. In real world applications, set challenge
-             // handlers at the start of the application.
-
-             // Sets authenticator as ArcGIS and Network challenge handlers to handle authentication
-             // challenges.
-             ArcGISEnvironment.authenticationManager.handleChallenges(using: authenticator)
-
-             // In your application you may want to uncomment this code to persist
-             // credentials in the keychain.
-             // setupPersistentCredentialStorage()
-         }
-
-         /// Stops the authenticator from handling the challenges and clears credentials.
-         nonisolated func teardownAuthenticator() async {
-             // Resets challenge handlers.
-             ArcGISEnvironment.authenticationManager.handleChallenges(using: nil)
-
-             // In your application, code may need to run at a different
-             // point in time based on the workflow desired. For example, it
-             // might make sense to remove credentials when the user taps
-             // a "sign out" button.
-             await ArcGISEnvironment.authenticationManager.revokeOAuthTokens()
-             await ArcGISEnvironment.authenticationManager.clearCredentialStores()
-         }
-
-         /// Sets up new ArcGIS and Network credential stores that will be persisted in the keychain.
-         private func setupPersistentCredentialStorage() {
-             Task {
-                 try await ArcGISEnvironment.authenticationManager.setupPersistentCredentialStorage(
-                     access: .whenUnlockedThisDeviceOnly,
-                     synchronizesWithiCloud: false
-                 )
-             }
-         }
-     }}
+extension AuthenticateWithPKICertificateView {
+    @MainActor
+    class Model: ObservableObject {
+        /// The authenticator to handle authentication challenges.
+        let authenticator = Authenticator()
+        
+        /// The URL string entered by the user.
+        @Published var portalURLString = ""
+        
+        /// The fetched portal content.
+        @Published var portalContent: Result<PortalQueryResultSet<PortalItem>, Error>?
+        
+        /// A Boolean value indicating if a portal connection is in progress.
+        @Published var isConnecting = false
+        
+        /// The selected item.
+        @Published fileprivate var selectedItem: SelectedItem?
+        
+        /// The URL of the portal.
+        var portalURL: URL? { URL(string: portalURLString) }
+        
+        init() {
+            setupAuthenticator()
+        }
+        
+        /// Connects to the portal and finds a batch of webmaps.
+        func connectToPortal() async {
+            precondition(portalURL != nil)
+            
+            isConnecting = true
+            defer { isConnecting = false }
+            
+            do {
+                let portal = Portal(url: portalURL!)
+                try await portal.load()
+                let results = try await portal.findItems(queryParameters: .items(ofKinds: [.webMap]))
+                portalContent = .success(results)
+            } catch {
+                portalContent = .failure(error)
+            }
+        }
+        
+        /// Sets up the authenticator to handle challenges.
+        private func setupAuthenticator() {
+            // Setting the challenge handlers here when the model is created so user is prompted to enter
+            // credentials every time trying the sample. In real world applications, set challenge
+            // handlers at the start of the application.
+            
+            // Sets authenticator as ArcGIS and Network challenge handlers to handle authentication
+            // challenges.
+            ArcGISEnvironment.authenticationManager.handleChallenges(using: authenticator)
+            
+            // In your application you may want to uncomment this code to persist
+            // credentials in the keychain.
+            // setupPersistentCredentialStorage()
+        }
+        
+        /// Stops the authenticator from handling the challenges and clears credentials.
+        nonisolated func teardownAuthenticator() async {
+            // Resets challenge handlers.
+            ArcGISEnvironment.authenticationManager.handleChallenges(using: nil)
+            
+            // In your application, code may need to run at a different
+            // point in time based on the workflow desired. For example, it
+            // might make sense to remove credentials when the user taps
+            // a "sign out" button.
+            await ArcGISEnvironment.authenticationManager.revokeOAuthTokens()
+            await ArcGISEnvironment.authenticationManager.clearCredentialStores()
+        }
+        
+        /// Sets up new ArcGIS and Network credential stores that will be persisted in the keychain.
+        private func setupPersistentCredentialStorage() {
+            Task {
+                try await ArcGISEnvironment.authenticationManager.setupPersistentCredentialStorage(
+                    access: .whenUnlockedThisDeviceOnly,
+                    synchronizesWithiCloud: false
+                )
+            }
+        }
+    }
+}
 
 #Preview {
     AuthenticateWithPKICertificateView()

--- a/Shared/Samples/Control annotation sublayer visibility/ControlAnnotationSublayerVisibilityView.Model.swift
+++ b/Shared/Samples/Control annotation sublayer visibility/ControlAnnotationSublayerVisibilityView.Model.swift
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import ArcGIS
-import SwiftUI
+import Foundation
 
 extension ControlAnnotationSublayerVisibilityView {
     /// The view model for this sample.

--- a/Shared/Samples/Generate geodatabase replica from feature service/GenerateGeodatabaseReplicaFromFeatureServiceView.Model.swift
+++ b/Shared/Samples/Generate geodatabase replica from feature service/GenerateGeodatabaseReplicaFromFeatureServiceView.Model.swift
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import ArcGIS
-import SwiftUI
+import Foundation
 
 extension GenerateGeodatabaseReplicaFromFeatureServiceView {
     /// The view model for the sample.

--- a/Shared/Samples/Snap geometry edits with utility network rules/SnapGeometryEditsWithUtilityNetworkRulesView.Model.swift
+++ b/Shared/Samples/Snap geometry edits with utility network rules/SnapGeometryEditsWithUtilityNetworkRulesView.Model.swift
@@ -262,7 +262,6 @@ extension SubtypeSublayer: Renderable {}
 
 private extension String {
     static let distributionPipe = "Distribution Pipe"
-    static let excessFlowValve = "Excess Flow Valve"
     static let graphics = "Graphics"
     static let pipelineLine = "PipelineLine"
     static let servicePipe = "Service Pipe"


### PR DESCRIPTION
## Description

This PR fixes a couple minor issues with `200.8` samples that were found during certification. (List is in same order as commits):

- Fixes a bug where `Apply color map renderer to raster` wouldn't render when run on-device.
- Removes unused imports and declarations found by running the SwiftLint analyzer rules.
- Adds some missing files to the `Copy Source Code Files` build phase.
- Re-indents `AuthenticateWithPKICertificateView.swift`. There were no code changes in this file.

## Linked Issue(s)

- Closes: `swift/issues/7113`
- `swift/issues/7096`

## How To Test

Ensure the above-mentioned issues are resolved.
