### PR TITLE
[Fix] Add back missing identity for `SampleDetailView`

### DIFF
--- a/Shared/Supporting Files/Views/CategoriesView.swift
+++ b/Shared/Supporting Files/Views/CategoriesView.swift
@@ -87,6 +87,7 @@ struct CategoriesView: View {
                         ProgressView("Loading sample…")
                     } else {
                         SampleDetailView(sample: sample)
+                            .id(sampleName)
                             .onAppear {
                                 sampleNeedingTearDown = sampleName
                             }
@@ -97,6 +98,7 @@ struct CategoriesView: View {
                     }
                 } else {
                     SampleDetailView(sample: sample)
+                        .id(sampleName)
                 }
             }
         }


### PR DESCRIPTION
## Description

The `SampleDetailView` needs an identity to force reinitialize. Because its underlying sample body is `AnyView`, SwiftUI cannot effectively tell the views apart without identity. Thus, if we switch between samples with ODR, the ODR won't re-initialize, which would lead to wrong behaviors or crash.

I missed it when I reviewed #667 [here](https://github.com/Esri/arcgis-maps-sdk-swift-samples/pull/667/files#diff-b35bada8896ea735015d09e0ca6da223c794c71c1d61a74f487ee11934a31c00L36), so adding it back.

## Linked Issue(s)

- `swift/issues/7143`
- #234 

## How To Test

On iPad…

- Before change: open 2 ODR samples one by one and see the second sample behaves incorrectly.
    - for example, Add raster from file, then Add point cloud layer from file 
- After change: all ODR samples should work correctly.
