### PR TITLE
[Fix] Adjust the logic for Teardown > Non-Teardown

### DIFF
--- a/Shared/Supporting Files/Views/CategoriesView.swift
+++ b/Shared/Supporting Files/Views/CategoriesView.swift
@@ -97,8 +97,12 @@ struct CategoriesView: View {
                             }
                     }
                 } else {
-                    SampleDetailView(sample: sample)
-                        .id(sampleName)
+                    if sampleNeedingTearDown != nil {
+                        ProgressView("Loading sample…")
+                    } else {
+                        SampleDetailView(sample: sample)
+                            .id(sampleName)
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Description

This PR fixes a problem with the teardown logic.

Currently, if I go from a sample that requires teardown to a sample that doesn't require teardown, it will load the incoming sample synchronously. However, sometimes if the outgoing sample needs to reset the API key from `nil` to production, if the incoming sample doesn't wait for that, it won't be able to show the basemap.

This PR should fix that.

## Linked Issue(s)

- `swift/issues/7143`
- https://github.com/Esri/arcgis-maps-sdk-swift-samples/pull/667#discussion_r2231635828

## How To Test

On iPad, go to All category. Open Add items to portal, tap Cancel, then open Add integrated mesh layer…

- v.next, the incoming sample prints invalid API key error to console
- this branch, the incoming sample shows correctly