### PR TITLE
[Update] Address `ExistentialAny` warnings for `Error`

### DIFF
--- a/Shared/Samples/Add WFS layer/AddWFSLayerView.swift
+++ b/Shared/Samples/Add WFS layer/AddWFSLayerView.swift
@@ -63,7 +63,7 @@ struct AddWFSLayerView: View {
     @State private var isPopulating = false
     
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     var body: some View {
         MapView(map: map)

--- a/Shared/Samples/Add WMTS layer/AddWMTSLayerView.swift
+++ b/Shared/Samples/Add WMTS layer/AddWMTSLayerView.swift
@@ -23,7 +23,7 @@ struct AddWMTSLayerView: View {
     @State private var selectedLayerSource = WMTSLayerSource.wmtsLayerInfo
     
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     var body: some View {
         MapView(map: model.map)

--- a/Shared/Samples/Add feature collection layer from portal item/AddFeatureCollectionLayerFromPortalItemView.swift
+++ b/Shared/Samples/Add feature collection layer from portal item/AddFeatureCollectionLayerFromPortalItemView.swift
@@ -20,7 +20,7 @@ struct AddFeatureCollectionLayerFromPortalItemView: View {
     @State private var map = Map(basemapStyle: .arcGISOceans)
     
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     var body: some View {
         MapView(map: map)

--- a/Shared/Samples/Add feature collection layer from query/AddFeatureCollectionLayerFromQueryView.swift
+++ b/Shared/Samples/Add feature collection layer from query/AddFeatureCollectionLayerFromQueryView.swift
@@ -20,7 +20,7 @@ struct AddFeatureCollectionLayerFromQueryView: View {
     @State private var map = Map(basemapStyle: .arcGISOceans)
     
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     var body: some View {
         MapView(map: map)

--- a/Shared/Samples/Add feature collection layer from table/AddFeatureCollectionLayerFromTableView.swift
+++ b/Shared/Samples/Add feature collection layer from table/AddFeatureCollectionLayerFromTableView.swift
@@ -28,7 +28,7 @@ struct AddFeatureCollectionLayerFromTableView: View {
     }()
     
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     var body: some View {
         MapView(map: map)

--- a/Shared/Samples/Add feature layers/AddFeatureLayersView.swift
+++ b/Shared/Samples/Add feature layers/AddFeatureLayersView.swift
@@ -17,7 +17,7 @@ import SwiftUI
 
 struct AddFeatureLayersView: View {
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     /// The current viewpoint of the map view.
     @State private var viewpoint: Viewpoint?

--- a/Shared/Samples/Add features with contingent values/AddFeaturesWithContingentValuesView.swift
+++ b/Shared/Samples/Add features with contingent values/AddFeaturesWithContingentValuesView.swift
@@ -26,7 +26,7 @@ struct AddFeaturesWithContingentValuesView: View {
     @State private var addFeatureSheetIsPresented = false
     
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     var body: some View {
         GeometryReader { geometryProxy in

--- a/Shared/Samples/Add items to portal/AddItemsToPortalView.swift
+++ b/Shared/Samples/Add items to portal/AddItemsToPortalView.swift
@@ -27,7 +27,7 @@ struct AddItemsToPortalView: View {
     /// A Boolean value indicating whether the delete alert is presented.
     @State private var deleteAlertIsPresented = false
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     /// The portal item to delete when the delete alert is presented.
     @State private var portalItemToDelete: PortalItem?
     /// A list of portal items when the portal is logged in.

--- a/Shared/Samples/Add raster from file/AddRasterFromFileView.swift
+++ b/Shared/Samples/Add raster from file/AddRasterFromFileView.swift
@@ -20,7 +20,7 @@ struct AddRasterFromFileView: View {
     @State private var map = Map(basemapStyle: .arcGISImageryStandard)
     
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     /// The current viewpoint of the map view.
     @State private var viewpoint: Viewpoint?

--- a/Shared/Samples/Add raster from service/AddRasterFromServiceView.swift
+++ b/Shared/Samples/Add raster from service/AddRasterFromServiceView.swift
@@ -17,7 +17,7 @@ import SwiftUI
 
 struct AddRasterFromServiceView: View {
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     /// The current draw status of the map.
     @State private var currentDrawStatus: DrawStatus = .inProgress

--- a/Shared/Samples/Add rasters and feature tables from geopackage/AddRastersAndFeatureTablesFromGeopackageView.swift
+++ b/Shared/Samples/Add rasters and feature tables from geopackage/AddRastersAndFeatureTablesFromGeopackageView.swift
@@ -20,7 +20,7 @@ struct AddRastersAndFeatureTablesFromGeopackageView: View {
     @State private var map = Map(basemapStyle: .arcGISLightGray)
     
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     /// The current viewpoint of the map view.
     @State private var viewpoint: Viewpoint?

--- a/Shared/Samples/Add vector tiled layer from custom style/AddVectorTiledLayerFromCustomStyleView.swift
+++ b/Shared/Samples/Add vector tiled layer from custom style/AddVectorTiledLayerFromCustomStyleView.swift
@@ -26,7 +26,7 @@ struct AddVectorTiledLayerFromCustomStyleView: View {
     @State private var selectedStyleLabel = "Default"
     
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     var body: some View {
         MapView(map: model.map, viewpoint: viewpoint)

--- a/Shared/Samples/Analyze hotspots/AnalyzeHotspotsView.swift
+++ b/Shared/Samples/Analyze hotspots/AnalyzeHotspotsView.swift
@@ -31,7 +31,7 @@ struct AnalyzeHotspotsView: View {
         url: URL(string: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/911CallsHotspot/GPServer/911%20Calls%20Hotspot")!
     )
     /// The error thrown by geoprocessing job.
-    @State private var analysisError: Error?
+    @State private var analysisError: (any Error)?
     /// A Boolean value indicating whether the geoprocessing job is running.
     @State private var isAnalyzing = false
     /// A Boolean value that indicates whether the analysis sheet is presented.

--- a/Shared/Samples/Analyze network with subnetwork trace/AnalyzeNetworkWithSubnetworkTraceView.swift
+++ b/Shared/Samples/Analyze network with subnetwork trace/AnalyzeNetworkWithSubnetworkTraceView.swift
@@ -44,7 +44,7 @@ struct AnalyzeNetworkWithSubnetworkTraceView: View {
     @State private var includesContainers = true
     
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     var body: some View {
         if !model.isSetUp {

--- a/Shared/Samples/Apply class breaks renderer to sublayer/ApplyClassBreaksRendererToSublayerView.swift
+++ b/Shared/Samples/Apply class breaks renderer to sublayer/ApplyClassBreaksRendererToSublayerView.swift
@@ -46,7 +46,7 @@ struct ApplyClassBreaksRendererToSublayerView: View {
     }()
 
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
 
     var body: some View {
         MapView(map: map)

--- a/Shared/Samples/Apply colormap renderer to raster/ApplyColormapRendererToRasterView.swift
+++ b/Shared/Samples/Apply colormap renderer to raster/ApplyColormapRendererToRasterView.swift
@@ -40,7 +40,7 @@ struct ApplyColormapRendererToRasterView: View {
     /// The map displayed by the map view.
     @State private var map = makeMap()
     /// The error if the raster layer load operation failed, otherwise `nil`.
-    @State private var rasterLayerLoadError: Error?
+    @State private var rasterLayerLoadError: (any Error)?
     
     /// The raster layer from the map.
     var rasterLayer: RasterLayer { map.operationalLayers.first as! RasterLayer }

--- a/Shared/Samples/Apply dictionary renderer to feature layer/ApplyDictionaryRendererToFeatureLayerView.swift
+++ b/Shared/Samples/Apply dictionary renderer to feature layer/ApplyDictionaryRendererToFeatureLayerView.swift
@@ -23,7 +23,7 @@ struct ApplyDictionaryRendererToFeatureLayerView: View {
     @State private var viewpoint: Viewpoint?
     
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     var body: some View {
         MapView(map: map, viewpoint: viewpoint)

--- a/Shared/Samples/Apply dictionary renderer to graphics overlay/ApplyDictionaryRendererToGraphicsOverlayView.swift
+++ b/Shared/Samples/Apply dictionary renderer to graphics overlay/ApplyDictionaryRendererToGraphicsOverlayView.swift
@@ -26,7 +26,7 @@ struct ApplyDictionaryRendererToGraphicsOverlayView: View {
     @State private var camera: Camera?
     
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     var body: some View {
         SceneView(scene: scene, camera: $camera, graphicsOverlays: [graphicsOverlay])

--- a/Shared/Samples/Apply mosaic rule to rasters/ApplyMosaicRuleToRastersView.swift
+++ b/Shared/Samples/Apply mosaic rule to rasters/ApplyMosaicRuleToRastersView.swift
@@ -20,7 +20,7 @@ struct ApplyMosaicRuleToRastersView: View {
     @State private var isLoading = false
     
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     /// The data model for the sample.
     @StateObject private var model = Model()

--- a/Shared/Samples/Apply raster rendering rule/ApplyRasterRenderingRuleView.swift
+++ b/Shared/Samples/Apply raster rendering rule/ApplyRasterRenderingRuleView.swift
@@ -29,7 +29,7 @@ struct ApplyRasterRenderingRuleView: View {
     @State private var viewpoint: Viewpoint?
     
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     var body: some View {
         MapView(map: map, viewpoint: viewpoint)

--- a/Shared/Samples/Apply scheduled updates to preplanned map area/ApplyScheduledUpdatesToPreplannedMapAreaView.swift
+++ b/Shared/Samples/Apply scheduled updates to preplanned map area/ApplyScheduledUpdatesToPreplannedMapAreaView.swift
@@ -28,7 +28,7 @@ struct ApplyScheduledUpdatesToPreplannedMapAreaView: View {
     @State private var noUpdatesAlertIsPresented = false
     
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     var body: some View {
         MapView(map: model.map)

--- a/Shared/Samples/Apply stretch renderer/ApplyStretchRendererView.swift
+++ b/Shared/Samples/Apply stretch renderer/ApplyStretchRendererView.swift
@@ -37,7 +37,7 @@ struct ApplyStretchRendererView: View {
     /// The map displayed by the map view.
     @State private var map = makeMap()
     /// The error if the raster layer load operation failed, otherwise `nil`.
-    @State private var rasterLayerLoadError: Error?
+    @State private var rasterLayerLoadError: (any Error)?
     /// A Boolean value that indicates whether the settings sheet is presented.
     @State private var isSettingsFormPresented = false
     

--- a/Shared/Samples/Apply style to WMS layer/ApplyStyleToWMSLayerView.swift
+++ b/Shared/Samples/Apply style to WMS layer/ApplyStyleToWMSLayerView.swift
@@ -28,7 +28,7 @@ struct ApplyStyleToWMSLayerView: View {
     /// A WMS layer with multiple styles.
     @State private var wmsSublayer: WMSSublayer?
     /// The error thrown by the WMS sublayer load operation.
-    @State private var wmsSublayerLoadError: Error?
+    @State private var wmsSublayerLoadError: (any Error)?
     
     /// The styles of the WMS layer.
     @State private var styles: [String] = []

--- a/Shared/Samples/Augment reality to collect data/AugmentRealityToCollectDataView.swift
+++ b/Shared/Samples/Augment reality to collect data/AugmentRealityToCollectDataView.swift
@@ -27,7 +27,7 @@ struct AugmentRealityToCollectDataView: View {
     /// A Boolean value indicating whether the tree health action sheet is presented.
     @State private var treeHealthSheetIsPresented = false
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     var body: some View {
         VStack(spacing: 0) {

--- a/Shared/Samples/Augment reality to navigate route/AugmentRealityToNavigateRouteView.ARSceneView.swift
+++ b/Shared/Samples/Augment reality to navigate route/AugmentRealityToNavigateRouteView.ARSceneView.swift
@@ -28,7 +28,7 @@ extension AugmentRealityToNavigateRouteView {
         @State private var isNavigating = false
         
         /// The error shown in the error alert.
-        @State private var error: Error?
+        @State private var error: (any Error)?
         
         var body: some View {
             VStack(spacing: 0) {

--- a/Shared/Samples/Augment reality to navigate route/AugmentRealityToNavigateRouteView.swift
+++ b/Shared/Samples/Augment reality to navigate route/AugmentRealityToNavigateRouteView.swift
@@ -22,7 +22,7 @@ struct AugmentRealityToNavigateRouteView: View {
     @StateObject private var model = MapModel()
     
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     /// The point on the map where the user tapped.
     @State private var tapLocation: Point?

--- a/Shared/Samples/Augment reality to show hidden infrastructure/AugmentRealityToShowHiddenInfrastructureView.swift
+++ b/Shared/Samples/Augment reality to show hidden infrastructure/AugmentRealityToShowHiddenInfrastructureView.swift
@@ -37,7 +37,7 @@ struct AugmentRealityToShowHiddenInfrastructureView: View {
     @State private var elevationAlertIsPresented = false
     
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     var body: some View {
         MapView(map: model.map, graphicsOverlays: [model.pipesGraphicsOverlay])

--- a/Shared/Samples/Augment reality to show tabletop scene/AugmentRealityToShowTabletopSceneView.swift
+++ b/Shared/Samples/Augment reality to show tabletop scene/AugmentRealityToShowTabletopSceneView.swift
@@ -22,7 +22,7 @@ struct AugmentRealityToShowTabletopSceneView: View {
     @State private var scene = ArcGIS.Scene()
     
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     /// The location point of the scene that will be anchored on a physical surface.
     private let anchorPoint = Point(

--- a/Shared/Samples/Authenticate with Integrated Windows Authentication/AuthenticateWithIntegratedWindowsAuthenticationView.swift
+++ b/Shared/Samples/Authenticate with Integrated Windows Authentication/AuthenticateWithIntegratedWindowsAuthenticationView.swift
@@ -110,7 +110,7 @@ extension AuthenticateWithIntegratedWindowsAuthenticationView {
         @Published var portalURLString = ""
         
         /// The fetched portal content.
-        @Published var portalContent: Result<PortalQueryResultSet<PortalItem>, Error>?
+        @Published var portalContent: Result<PortalQueryResultSet<PortalItem>, any Error>?
         
         /// A Boolean value indicating if a portal connection is in progress.
         @Published var isConnecting = false

--- a/Shared/Samples/Authenticate with PKI certificate/AuthenticateWithPKICertificateView.swift
+++ b/Shared/Samples/Authenticate with PKI certificate/AuthenticateWithPKICertificateView.swift
@@ -110,7 +110,7 @@ extension AuthenticateWithPKICertificateView {
         @Published var portalURLString = ""
         
         /// The fetched portal content.
-        @Published var portalContent: Result<PortalQueryResultSet<PortalItem>, Error>?
+        @Published var portalContent: Result<PortalQueryResultSet<PortalItem>, any Error>?
         
         /// A Boolean value indicating if a portal connection is in progress.
         @Published var isConnecting = false

--- a/Shared/Samples/Authenticate with token/AuthenticateWithTokenView.swift
+++ b/Shared/Samples/Authenticate with token/AuthenticateWithTokenView.swift
@@ -36,7 +36,7 @@ struct AuthenticateWithTokenView: View {
     }()
     
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     var body: some View {
         MapView(map: map)

--- a/Shared/Samples/Browse OGC API feature service/BrowseOGCAPIFeatureServiceView.swift
+++ b/Shared/Samples/Browse OGC API feature service/BrowseOGCAPIFeatureServiceView.swift
@@ -17,7 +17,7 @@ import SwiftUI
 
 struct BrowseOGCAPIFeatureServiceView: View {
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     /// A Boolean value indicating whether the text field alert should be presented.
     @State private var textFieldAlertIsPresented = false

--- a/Shared/Samples/Browse WFS layers/BrowseWFSLayersView.swift
+++ b/Shared/Samples/Browse WFS layers/BrowseWFSLayersView.swift
@@ -55,7 +55,7 @@ private struct WFSServiceView: View {
     /// The loaded WFS service.
     @State private var service: WFSService?
     /// The error if the service failed to load, otherwise `nil`.
-    @State private var serviceLoadError: Error?
+    @State private var serviceLoadError: (any Error)?
     /// A Boolean value indicating whether the service failed to load.
     @State private var serviceLoadDidFail = false
     
@@ -109,7 +109,7 @@ private struct WFSServiceLayerView: View {
     /// The area of the map to display.
     @State private var viewpoint: Viewpoint?
     /// The error if the populate operation failed, otherwise `nil`.
-    @State private var populateError: Error?
+    @State private var populateError: (any Error)?
     /// A Boolean value indicating whether a query operation is in progress.
     @State private var isQuerying = false
     /// A Boolean value indicating whether the axis order should be swapped.

--- a/Shared/Samples/Browse WMS layers/BrowseWMSLayersView.swift
+++ b/Shared/Samples/Browse WMS layers/BrowseWMSLayersView.swift
@@ -26,7 +26,7 @@ struct BrowseWMSLayersView: View {
     )
     
     /// The error, if any, that occurred.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     /// The selected visible layers to display in the `WMSLayer`.
     @State private var selection: [WMSLayerModel] = []

--- a/Shared/Samples/Browse building floors/BrowseBuildingFloorsView.swift
+++ b/Shared/Samples/Browse building floors/BrowseBuildingFloorsView.swift
@@ -18,7 +18,7 @@ import SwiftUI
 
 struct BrowseBuildingFloorsView: View {
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     /// The current viewpoint of the map.
     @State private var viewpoint: Viewpoint?

--- a/Shared/Samples/Configure electronic navigational charts/ConfigureElectronicNavigationalChartsView.swift
+++ b/Shared/Samples/Configure electronic navigational charts/ConfigureElectronicNavigationalChartsView.swift
@@ -29,7 +29,7 @@ struct ConfigureElectronicNavigationalChartsView: View {
     @State private var isShowingDisplaySettings = false
     
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     var body: some View {
         MapViewReader { mapViewProxy in

--- a/Shared/Samples/Control annotation sublayer visibility/ControlAnnotationSublayerVisibilityView.swift
+++ b/Shared/Samples/Control annotation sublayer visibility/ControlAnnotationSublayerVisibilityView.swift
@@ -20,7 +20,7 @@ struct ControlAnnotationSublayerVisibilityView: View {
     @State private var model = Model()
     
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     var body: some View {
         MapView(map: model.map)

--- a/Shared/Samples/Create KML multi-track/CreateKMLMultiTrackView.swift
+++ b/Shared/Samples/Create KML multi-track/CreateKMLMultiTrackView.swift
@@ -26,7 +26,7 @@ struct CreateKMLMultiTrackView: View {
     @State private var isRecenterEnabled = false
     
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     /// Represents the various states of the sample.
     private enum SampleState {

--- a/Shared/Samples/Create and save KML file/CreateAndSaveKMLView.Model.swift
+++ b/Shared/Samples/Create and save KML file/CreateAndSaveKMLView.Model.swift
@@ -61,7 +61,7 @@ extension CreateAndSaveKMLView {
         @Published var fileExporterButtonIsDisabled = true
         
         /// The error shown in the error alert.
-        @Published var error: Error?
+        @Published var error: (any Error)?
         
         /// Creates the model for this view.
         init() {

--- a/Shared/Samples/Create and save map/CreateAndSaveMapView.swift
+++ b/Shared/Samples/Create and save map/CreateAndSaveMapView.swift
@@ -31,7 +31,7 @@ struct CreateAndSaveMapView: View {
     @State private var map: Map?
     
     /// The error that occurred, if any, when trying to save the map to the portal.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     /// The status of the sample workflow.
     @State private var status: Status = .loadingPortal

--- a/Shared/Samples/Create dynamic basemap gallery/CreateDynamicBasemapGalleryView.swift
+++ b/Shared/Samples/Create dynamic basemap gallery/CreateDynamicBasemapGalleryView.swift
@@ -23,7 +23,7 @@ struct CreateDynamicBasemapGalleryView: View {
     @State private var isShowingBasemapGallery = false
     
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     var body: some View {
         MapView(map: model.map)

--- a/Shared/Samples/Create load report/CreateLoadReportView.Model.swift
+++ b/Shared/Samples/Create load report/CreateLoadReportView.Model.swift
@@ -56,7 +56,7 @@ extension CreateLoadReportView {
         @Published private(set) var statusText: String?
         
         /// An error that occurred during setup.
-        private(set) var setupError: Error? {
+        private(set) var setupError: (any Error)? {
             didSet {
                 updateAllowsCreateLoadReport()
                 error = setupError
@@ -64,7 +64,7 @@ extension CreateLoadReportView {
         }
         
         /// The error shown in the error alert.
-        @Published var error: Error?
+        @Published var error: (any Error)?
         
         // MARK: Methods
         

--- a/Shared/Samples/Create mobile geodatabase/CreateMobileGeodatabaseView.swift
+++ b/Shared/Samples/Create mobile geodatabase/CreateMobileGeodatabaseView.swift
@@ -29,7 +29,7 @@ struct CreateMobileGeodatabaseView: View {
     @State private var fileExporterIsShowing = false
     
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     var body: some View {
         MapView(map: model.map)

--- a/Shared/Samples/Display OGC API collection/DisplayOGCAPICollectionView.swift
+++ b/Shared/Samples/Display OGC API collection/DisplayOGCAPICollectionView.swift
@@ -55,7 +55,7 @@ struct DisplayOGCAPICollectionView: View {
     /// A Boolean value indicating whether the map view is navigating.
     @State private var isNavigating = false
     /// The error if the populate operation failed, otherwise `nil`.
-    @State private var populateError: Error?
+    @State private var populateError: (any Error)?
     /// The OGC feature collection table.
     private var ogcFeatureTable: OGCFeatureCollectionTable {
         (map.operationalLayers.first as! FeatureLayer).featureTable as! OGCFeatureCollectionTable

--- a/Shared/Samples/Display annotation/DisplayAnnotationView.swift
+++ b/Shared/Samples/Display annotation/DisplayAnnotationView.swift
@@ -24,7 +24,7 @@ struct DisplayAnnotationView: View {
     }()
     
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     var body: some View {
         // Create a map view with a map.

--- a/Shared/Samples/Display clusters/DisplayClustersView.swift
+++ b/Shared/Samples/Display clusters/DisplayClustersView.swift
@@ -47,7 +47,7 @@ struct DisplayClustersView: View {
     @State private var showsFeatureReduction = true
     
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     var body: some View {
         MapViewReader { proxy in

--- a/Shared/Samples/Display dimensions/DisplayDimensionsView.swift
+++ b/Shared/Samples/Display dimensions/DisplayDimensionsView.swift
@@ -29,7 +29,7 @@ struct DisplayDimensionsView: View {
     @State private var definitionExpressionIsSet = false
     
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     var body: some View {
         MapView(map: map)

--- a/Shared/Samples/Display map from mobile map package/DisplayMapFromMobileMapPackageView.swift
+++ b/Shared/Samples/Display map from mobile map package/DisplayMapFromMobileMapPackageView.swift
@@ -23,7 +23,7 @@ struct DisplayMapFromMobileMapPackageView: View {
     @State private var mobileMapPackage: MobileMapPackage!
     
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     /// Loads a local mobile map package.
     private func loadMobileMapPackage() async throws {

--- a/Shared/Samples/Display route layer/DisplayRouteLayerView.swift
+++ b/Shared/Samples/Display route layer/DisplayRouteLayerView.swift
@@ -36,7 +36,7 @@ struct DisplayRouteLayerView: View {
     @State private var isShowingDirections = false
     
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     var body: some View {
         MapView(map: map)

--- a/Shared/Samples/Display scene from mobile scene package/DisplaySceneFromMobileScenePackageView.swift
+++ b/Shared/Samples/Display scene from mobile scene package/DisplaySceneFromMobileScenePackageView.swift
@@ -20,7 +20,7 @@ struct DisplaySceneFromMobileScenePackageView: View {
     @State private var scene = ArcGIS.Scene()
     
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     var body: some View {
         // Create a scene view with the scene.

--- a/Shared/Samples/Download preplanned map area/DownloadPreplannedMapAreaView.MapPicker.swift
+++ b/Shared/Samples/Download preplanned map area/DownloadPreplannedMapAreaView.MapPicker.swift
@@ -113,7 +113,7 @@ extension DownloadPreplannedMapAreaView {
         }
         
         /// The color of the title for a given result.
-        private func titleColor(for result: Result<MobileMapPackage, Error>?) -> Color {
+        private func titleColor(for result: Result<MobileMapPackage, any Error>?) -> Color {
             switch model.result {
             case .success:
                 return .primary

--- a/Shared/Samples/Download preplanned map area/DownloadPreplannedMapAreaView.Model.swift
+++ b/Shared/Samples/Download preplanned map area/DownloadPreplannedMapAreaView.Model.swift
@@ -45,7 +45,7 @@ extension DownloadPreplannedMapAreaView {
         private let temporaryDirectory: URL
         
         /// The offline map information.
-        @Published private(set) var offlineMapModels: Result<[OfflineMapModel], Error>?
+        @Published private(set) var offlineMapModels: Result<[OfflineMapModel], any Error>?
         
         /// All the offline map models or an empty array in the case of an error.
         private var allOfflineMapModels: [OfflineMapModel] {
@@ -181,7 +181,7 @@ extension DownloadPreplannedMapAreaView {
         @Published private(set) var job: DownloadPreplannedOfflineMapJob?
         
         /// The result of the download job.
-        @Published private(set) var result: Result<MobileMapPackage, Error>?
+        @Published private(set) var result: Result<MobileMapPackage, any Error>?
         
         init?(preplannedMapArea: PreplannedMapArea, offlineMapTask: OfflineMapTask, temporaryDirectory: URL) {
             self.preplannedMapArea = preplannedMapArea

--- a/Shared/Samples/Download vector tiles to local cache/DownloadVectorTilesToLocalCacheView.swift
+++ b/Shared/Samples/Download vector tiles to local cache/DownloadVectorTilesToLocalCacheView.swift
@@ -29,7 +29,7 @@ struct DownloadVectorTilesToLocalCacheView: View {
     @State private var mapViewScale = Double.zero
     
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     /// The view model for this sample.
     @StateObject private var model = Model()

--- a/Shared/Samples/Edit and sync features with feature service/EditAndSyncFeaturesWithFeatureServiceView.swift
+++ b/Shared/Samples/Edit and sync features with feature service/EditAndSyncFeaturesWithFeatureServiceView.swift
@@ -26,7 +26,7 @@ struct EditAndSyncFeaturesWithFeatureServiceView: View {
     @State private var statusText = ""
     
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     var body: some View {
         GeometryReader { geometryProxy in

--- a/Shared/Samples/Edit feature attachments/EditFeatureAttachmentsView.swift
+++ b/Shared/Samples/Edit feature attachments/EditFeatureAttachmentsView.swift
@@ -17,7 +17,7 @@ import SwiftUI
 
 struct EditFeatureAttachmentsView: View {
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     /// The data model for the sample.
     @StateObject private var model = Model()
     /// The location that the user tapped on the screen.
@@ -85,7 +85,7 @@ struct EditFeatureAttachmentsView: View {
 private extension EditFeatureAttachmentsView {
     struct AttachmentSheetView: View {
         /// The error shown in the error alert.
-        @State private var error: Error?
+        @State private var error: (any Error)?
         /// The data model for the sample.
         @ObservedObject var model: Model
         /// The action to dismiss the sheet.

--- a/Shared/Samples/Edit features using feature forms/EditFeaturesUsingFeatureFormsView.swift
+++ b/Shared/Samples/Edit features using feature forms/EditFeaturesUsingFeatureFormsView.swift
@@ -38,7 +38,7 @@ struct EditFeaturesUsingFeatureFormsView: View {
     @State private var isApplyingEdits = false
     
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     /// The text explaining the next step in the sample's workflow.
     private var instructionText: String {

--- a/Shared/Samples/Edit features with feature-linked annotation/EditFeaturesWithFeatureLinkedAnnotationView.swift
+++ b/Shared/Samples/Edit features with feature-linked annotation/EditFeaturesWithFeatureLinkedAnnotationView.swift
@@ -41,7 +41,7 @@ struct EditFeaturesWithFeatureLinkedAnnotationView: View {
     @State private var moveConfirmationAlertIsPresented = false
     
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     var body: some View {
         MapViewReader { mapViewProxy in

--- a/Shared/Samples/Edit geodatabase with transactions/EditGeodatabaseWithTransactionsView.swift
+++ b/Shared/Samples/Edit geodatabase with transactions/EditGeodatabaseWithTransactionsView.swift
@@ -41,7 +41,7 @@ struct EditGeodatabaseWithTransactionsView: View {
     @State private var endTransactionAlertIsPresented = false
     
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     var body: some View {
         MapView(map: model.map)

--- a/Shared/Samples/Edit with branch versioning/EditWithBranchVersioningView.swift
+++ b/Shared/Samples/Edit with branch versioning/EditWithBranchVersioningView.swift
@@ -44,7 +44,7 @@ struct EditWithBranchVersioningView: View {
     @State private var isSettingDamageType = false
     
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     var body: some View {
         MapViewReader { mapViewProxy in

--- a/Shared/Samples/Filter by definition expression or display filter/FilterByDefinitionExpressionOrDisplayFilterView.swift
+++ b/Shared/Samples/Filter by definition expression or display filter/FilterByDefinitionExpressionOrDisplayFilterView.swift
@@ -23,7 +23,7 @@ struct FilterByDefinitionExpressionOrDisplayFilterView: View {
     @State private var drawStatus: DrawStatus?
     
     /// The result of counting the features in the current extent of the map view.
-    @State private var featureCountResult: Result<Int, Error>?
+    @State private var featureCountResult: Result<Int, any Error>?
     
     /// The filtering mode selected in the picker.
     @State private var selectedFilterMode: FilterMode = .none

--- a/Shared/Samples/Filter features in scene/FilterFeaturesInSceneView.swift
+++ b/Shared/Samples/Filter features in scene/FilterFeaturesInSceneView.swift
@@ -20,7 +20,7 @@ struct FilterFeaturesInSceneView: View {
     @StateObject private var model = Model()
     
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     var body: some View {
         SceneView(scene: model.scene, graphicsOverlays: [model.graphicsOverlay])

--- a/Shared/Samples/Find address with reverse geocode/FindAddressWithReverseGeocodeView.swift
+++ b/Shared/Samples/Find address with reverse geocode/FindAddressWithReverseGeocodeView.swift
@@ -29,7 +29,7 @@ struct FindAddressWithReverseGeocodeView: View {
     @State private var calloutText: String?
     
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     var body: some View {
         MapView(map: model.map, graphicsOverlays: [model.graphicsOverlay])

--- a/Shared/Samples/Find closest facility from point/FindClosestFacilityFromPointView.swift
+++ b/Shared/Samples/Find closest facility from point/FindClosestFacilityFromPointView.swift
@@ -26,7 +26,7 @@ struct FindClosestFacilityFromPointView: View {
     @State private var routingIsDisabled = true
     
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     var body: some View {
         MapViewReader { mapViewProxy in

--- a/Shared/Samples/Find closest facility to multiple points/FindClosestFacilityToMultiplePointsView.swift
+++ b/Shared/Samples/Find closest facility to multiple points/FindClosestFacilityToMultiplePointsView.swift
@@ -23,7 +23,7 @@ struct FindClosestFacilityToMultiplePointsView: View {
     @State private var tapLocation: Point?
     
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     var body: some View {
         MapView(

--- a/Shared/Samples/Find route around barriers/FindRouteAroundBarriersView.swift
+++ b/Shared/Samples/Find route around barriers/FindRouteAroundBarriersView.swift
@@ -29,7 +29,7 @@ struct FindRouteAroundBarriersView: View {
     @State private var directionGeometry: Geometry?
     
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     var body: some View {
         MapViewReader { mapViewProxy in

--- a/Shared/Samples/Find route in mobile map package/FindRouteInMobileMapPackageView.MobileMapView.swift
+++ b/Shared/Samples/Find route in mobile map package/FindRouteInMobileMapPackageView.MobileMapView.swift
@@ -34,7 +34,7 @@ extension FindRouteInMobileMapPackageView {
         @State private var resetDisabled = true
         
         /// The error shown in the error alert.
-        @State private var error: Error?
+        @State private var error: (any Error)?
         
         init(map: Map, locatorTask: LocatorTask) {
             let model = Model(map: map, locatorTask: locatorTask)

--- a/Shared/Samples/Find route in mobile map package/FindRouteInMobileMapPackageView.Models.swift
+++ b/Shared/Samples/Find route in mobile map package/FindRouteInMobileMapPackageView.Models.swift
@@ -24,7 +24,7 @@ extension FindRouteInMobileMapPackageView {
         @Published private(set) var mapPackages: [MobileMapPackage] = []
         
         /// The error shown in the error alert.
-        @Published var error: Error?
+        @Published var error: (any Error)?
         
         /// The list of file URLs that have been securely accessed.
         private var accessedURLs: [URL] = []

--- a/Shared/Samples/Find route/FindRouteView.swift
+++ b/Shared/Samples/Find route/FindRouteView.swift
@@ -17,7 +17,7 @@ import SwiftUI
 
 struct FindRouteView: View {
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     /// A Boolean value indicating whether to show the directions.
     @State private var isShowingDirections = false

--- a/Shared/Samples/Generate geodatabase replica from feature service/GenerateGeodatabaseReplicaFromFeatureServiceView.swift
+++ b/Shared/Samples/Generate geodatabase replica from feature service/GenerateGeodatabaseReplicaFromFeatureServiceView.swift
@@ -26,7 +26,7 @@ struct GenerateGeodatabaseReplicaFromFeatureServiceView: View {
     @State private var isGeneratingGeodatabase = false
     
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     var body: some View {
         GeometryReader { geometryProxy in

--- a/Shared/Samples/Generate offline map with custom parameters/GenerateOfflineMapWithCustomParametersView.CustomParameters.swift
+++ b/Shared/Samples/Generate offline map with custom parameters/GenerateOfflineMapWithCustomParametersView.CustomParameters.swift
@@ -26,7 +26,7 @@ extension GenerateOfflineMapWithCustomParametersView {
         @Binding var isGeneratingOfflineMap: Bool
         
         /// The error shown in the error alert.
-        @State private var error: Error?
+        @State private var error: (any Error)?
         
         /// The min scale level for the output. Note that lower values are zoomed further out,
         /// i.e. 0 has the least detail, but one tile covers the entire Earth.

--- a/Shared/Samples/Generate offline map with custom parameters/GenerateOfflineMapWithCustomParametersView.swift
+++ b/Shared/Samples/Generate offline map with custom parameters/GenerateOfflineMapWithCustomParametersView.swift
@@ -23,7 +23,7 @@ struct GenerateOfflineMapWithCustomParametersView: View {
     @State private var isCancellingJob = false
     
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     /// The view model for this sample.
     @StateObject private var model = Model()

--- a/Shared/Samples/Generate offline map with local basemap/GenerateOfflineMapWithLocalBasemapView.swift
+++ b/Shared/Samples/Generate offline map with local basemap/GenerateOfflineMapWithLocalBasemapView.swift
@@ -26,7 +26,7 @@ struct GenerateOfflineMapWithLocalBasemapView: View {
     @State private var isCancellingJob = false
     
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     /// The title to show in the confirmation dialog.
     private let basemapChoiceTitle: String = {

--- a/Shared/Samples/Generate offline map/GenerateOfflineMapView.swift
+++ b/Shared/Samples/Generate offline map/GenerateOfflineMapView.swift
@@ -23,7 +23,7 @@ struct GenerateOfflineMapView: View {
     @State private var isCancellingJob = false
     
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     /// The view model for this sample.
     @StateObject private var model = Model()

--- a/Shared/Samples/Identify KML features/IdentifyKMLFeaturesView.swift
+++ b/Shared/Samples/Identify KML features/IdentifyKMLFeaturesView.swift
@@ -34,7 +34,7 @@ struct IdentifyKMLFeaturesView: View {
     @State private var calloutText = AttributedString()
     
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     var body: some View {
         MapViewReader { mapViewProxy in

--- a/Shared/Samples/Identify features in WMS layer/IdentifyFeaturesInWMSLayerView.swift
+++ b/Shared/Samples/Identify features in WMS layer/IdentifyFeaturesInWMSLayerView.swift
@@ -40,7 +40,7 @@ struct IdentifyFeaturesInWMSLayerView: View {
     private let overlayText = "Tap on the map to identify features in the WMS layer."
     
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     init() {
         map.addOperationalLayer(waterInfoLayer)

--- a/Shared/Samples/Identify graphics/IdentifyGraphicsView.swift
+++ b/Shared/Samples/Identify graphics/IdentifyGraphicsView.swift
@@ -54,7 +54,7 @@ struct IdentifyGraphicsView: View {
     }
     
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     var body: some View {
         MapViewReader { mapViewProxy in

--- a/Shared/Samples/Identify layer features/IdentifyLayerFeaturesView.swift
+++ b/Shared/Samples/Identify layer features/IdentifyLayerFeaturesView.swift
@@ -33,7 +33,7 @@ struct IdentifyLayerFeaturesView: View {
     @State private var overlayText = "Tap on the map to identify feature layers."
     
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     var body: some View {
         ZStack {

--- a/Shared/Samples/Identify raster cell/IdentifyRasterCellView.swift
+++ b/Shared/Samples/Identify raster cell/IdentifyRasterCellView.swift
@@ -77,7 +77,7 @@ private extension IdentifyRasterCellView {
         @Published var calloutShouldOffset = false
         
         /// The error shown in the error alert.
-        @Published var error: Error?
+        @Published var error: (any Error)?
         
         /// Creates a callout displaying the data of a raster cell at a given screen point.
         /// - Parameters:

--- a/Shared/Samples/List contents of KML file/ListContentsOfKMLFileView.swift
+++ b/Shared/Samples/List contents of KML file/ListContentsOfKMLFileView.swift
@@ -70,7 +70,7 @@ private extension ListContentsOfKMLFileView {
         @Published private(set) var nodeViewpoints: [String: Viewpoint] = [:]
         
         /// The error shown in the error alert.
-        @Published var error: Error?
+        @Published var error: (any Error)?
         
         /// A scene for displaying the KML data.
         let scene: ArcGIS.Scene = {

--- a/Shared/Samples/List geodatabase versions/ListGeodatabaseVersionsView.swift
+++ b/Shared/Samples/List geodatabase versions/ListGeodatabaseVersionsView.swift
@@ -17,7 +17,7 @@ import SwiftUI
 
 struct ListGeodatabaseVersionsView: View {
     /// The analysis error shown in the error alert.
-    @State private var analysisError: Error?
+    @State private var analysisError: (any Error)?
     /// The task used to perform geoprocessing jobs.
     @State private var geoprocessingTask = GeoprocessingTask(
         url: URL(string: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/GDBVersions/GPServer/ListVersions")!

--- a/Shared/Samples/List spatial reference transformations/ListSpatialReferenceTransformationsView.swift
+++ b/Shared/Samples/List spatial reference transformations/ListSpatialReferenceTransformationsView.swift
@@ -29,7 +29,7 @@ struct ListSpatialReferenceTransformationsView: View {
     @State private var fileImporterIsPresented = false
     
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     var body: some View {
         VStack(spacing: 0) {

--- a/Shared/Samples/Manage bookmarks/ManageBookmarksView.swift
+++ b/Shared/Samples/Manage bookmarks/ManageBookmarksView.swift
@@ -55,7 +55,7 @@ struct ManageBookmarksView: View {
     @State private var newBookmarkAlertIsPresented = false
     
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     var body: some View {
         MapViewReader { mapViewProxy in

--- a/Shared/Samples/Manage features/ManageFeaturesView.swift
+++ b/Shared/Samples/Manage features/ManageFeaturesView.swift
@@ -17,7 +17,7 @@ import SwiftUI
 
 struct ManageFeaturesView: View {
     /// The data for the view.
-    @State private var data: Result<Data, Error>?
+    @State private var data: Result<Data, any Error>?
     
     /// The result of the latest action.
     @State private var status = ""

--- a/Shared/Samples/Navigate route with rerouting/NavigateRouteWithReroutingView.swift
+++ b/Shared/Samples/Navigate route with rerouting/NavigateRouteWithReroutingView.swift
@@ -26,7 +26,7 @@ struct NavigateRouteWithReroutingView: View {
     @State private var canReset = false
     
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     var body: some View {
         MapView(

--- a/Shared/Samples/Navigate route/NavigateRouteView.swift
+++ b/Shared/Samples/Navigate route/NavigateRouteView.swift
@@ -86,7 +86,7 @@ private extension NavigateRouteView {
         @Published var isResettingRoute = false
         
         /// The error shown in the error alert.
-        @Published var error: Error?
+        @Published var error: (any Error)?
         
         /// The viewpoint of the map.
         @Published var viewpoint: Viewpoint?

--- a/Shared/Samples/Orbit camera around object/OrbitCameraAroundObjectView.swift
+++ b/Shared/Samples/Orbit camera around object/OrbitCameraAroundObjectView.swift
@@ -29,7 +29,7 @@ struct OrbitCameraAroundObjectView: View {
     @State private var sceneIsDisabled = false
     
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     var body: some View {
         SceneView(

--- a/Shared/Samples/Play KML tour/PlayKMLTourView.swift
+++ b/Shared/Samples/Play KML tour/PlayKMLTourView.swift
@@ -40,7 +40,7 @@ struct PlayKMLTourView: View {
     @State private var tourStatus: KMLTour.Status = .notInitialized
     
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     /// A Boolean value that indicates whether to disable the tour buttons.
     private var tourDisabled: Bool {

--- a/Shared/Samples/Query feature count and extent/QueryFeatureCountAndExtentView.swift
+++ b/Shared/Samples/Query feature count and extent/QueryFeatureCountAndExtentView.swift
@@ -26,7 +26,7 @@ struct QueryFeatureCountAndExtentView: View {
     @State private var showFeatureCountBar = false
     
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     /// The current viewpoint of the map.
     @State private var viewpoint: Viewpoint?

--- a/Shared/Samples/Query feature table/QueryFeatureTableView.swift
+++ b/Shared/Samples/Query feature table/QueryFeatureTableView.swift
@@ -19,7 +19,7 @@ struct QueryFeatureTableView: View {
     @StateObject private var model = Model()
     
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     /// The text in the search bar.
     @State private var searchBarText = ""

--- a/Shared/Samples/Query features with Arcade expression/QueryFeaturesWithArcadeExpressionView.swift
+++ b/Shared/Samples/Query features with Arcade expression/QueryFeaturesWithArcadeExpressionView.swift
@@ -26,7 +26,7 @@ struct QueryFeaturesWithArcadeExpressionView: View {
     @State private var calloutPlacement: CalloutPlacement?
     
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     var body: some View {
         MapViewReader { mapViewProxy in

--- a/Shared/Samples/Query map image sublayer/QueryMapImageSublayerView.swift
+++ b/Shared/Samples/Query map image sublayer/QueryMapImageSublayerView.swift
@@ -29,7 +29,7 @@ struct QueryMapImageSublayerView: View {
     @State private var minimumPopulation: Int?
     
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     var body: some View {
         MapView(map: model.map, viewpoint: viewpoint, graphicsOverlays: [model.graphicsOverlay])

--- a/Shared/Samples/Query related features/QueryRelatedFeaturesView.swift
+++ b/Shared/Samples/Query related features/QueryRelatedFeaturesView.swift
@@ -49,7 +49,7 @@ struct QueryRelatedFeaturesView: View {
     @State private var queryResults: RelatedFeatureQueryResults?
     
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     var body: some View {
         MapViewReader { mapViewProxy in

--- a/Shared/Samples/Query table statistics group and sort/QueryTableStatisticsGroupAndSortView.swift
+++ b/Shared/Samples/Query table statistics group and sort/QueryTableStatisticsGroupAndSortView.swift
@@ -45,7 +45,7 @@ struct QueryTableStatisticsGroupAndSortView: View {
     @State private var presentedSheetView: SheetView?
     
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     /// A Boolean value indicating whether edits have been made to the from.
     private var formHasEdits: Bool {

--- a/Shared/Samples/Query table statistics/QueryTableStatisticsView.swift
+++ b/Shared/Samples/Query table statistics/QueryTableStatisticsView.swift
@@ -43,7 +43,7 @@ struct QueryTableStatisticsView: View {
     @State private var isShowingStatistics = false
     
     /// An error thrown from a query.
-    @State private var queryError: Error?
+    @State private var queryError: (any Error)?
     
     var body: some View {
         MapView(map: model.map, viewpoint: viewpoint)

--- a/Shared/Samples/Query with CQL filters/QueryWithCQLFiltersView.swift
+++ b/Shared/Samples/Query with CQL filters/QueryWithCQLFiltersView.swift
@@ -29,7 +29,7 @@ struct QueryWithCQLFiltersView: View {
     @State private var isShowingCQLFiltersForm = false
     
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     var body: some View {
         MapViewReader { mapViewProxy in

--- a/Shared/Samples/Query with time extent/QueryWithTimeExtentView.swift
+++ b/Shared/Samples/Query with time extent/QueryWithTimeExtentView.swift
@@ -27,7 +27,7 @@ struct QueryWithTimeExtentView: View {
     }()
     
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     var body: some View {
         MapView(map: map)

--- a/Shared/Samples/Search for web map/SearchForWebMapView.Views.swift
+++ b/Shared/Samples/Search for web map/SearchForWebMapView.Views.swift
@@ -25,7 +25,7 @@ extension SearchForWebMapView {
         @State private var mapIsLoading = false
         
         /// The error shown in the error alert.
-        @State private var error: Error?
+        @State private var error: (any Error)?
         
         var body: some View {
             ZStack {

--- a/Shared/Samples/Search for web map/SearchForWebMapView.swift
+++ b/Shared/Samples/Search for web map/SearchForWebMapView.swift
@@ -26,7 +26,7 @@ struct SearchForWebMapView: View {
     @State private var resultsAreLoading = false
     
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     var body: some View {
         ScrollView {

--- a/Shared/Samples/Search symbol style dictionary/SearchSymbolStyleDictionaryView.swift
+++ b/Shared/Samples/Search symbol style dictionary/SearchSymbolStyleDictionaryView.swift
@@ -17,7 +17,7 @@ import SwiftUI
 
 struct SearchSymbolStyleDictionaryView: View {
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     /// The view model for the sample.
     @State private var model = Model()
     /// The search results from the symbol style search.
@@ -104,7 +104,7 @@ private extension SearchSymbolStyleDictionaryView {
         /// The search result to create a swatch.
         let searchResult: SymbolStyleSearchResult
         /// The result of creating the swatch image.
-        @State private var result: Result<UIImage, Error>?
+        @State private var result: Result<UIImage, any Error>?
         
         var body: some View {
             Group {

--- a/Shared/Samples/Select features in feature layer/SelectFeaturesInFeatureLayerView.swift
+++ b/Shared/Samples/Select features in feature layer/SelectFeaturesInFeatureLayerView.swift
@@ -23,7 +23,7 @@ struct SelectFeaturesInFeatureLayerView: View {
     @State private var identifyPoint: CGPoint?
     
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     /// The view model for the sample.
     @StateObject private var model = Model()

--- a/Shared/Samples/Select features in scene layer/SelectFeaturesInSceneLayerView.swift
+++ b/Shared/Samples/Select features in scene layer/SelectFeaturesInSceneLayerView.swift
@@ -17,7 +17,7 @@ import SwiftUI
 
 struct SelectFeaturesInSceneLayerView: View {
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     /// The point on the screen where the user tapped.
     @State private var tapPoint: CGPoint?

--- a/Shared/Samples/Set feature request mode/SetFeatureRequestModeView.swift
+++ b/Shared/Samples/Set feature request mode/SetFeatureRequestModeView.swift
@@ -29,7 +29,7 @@ struct SetFeatureRequestModeView: View {
     @State private var isPopulating = false
     
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     var body: some View {
         GeometryReader { geometryProxy in

--- a/Shared/Samples/Set map image layer sublayer visibility/SetMapImageLayerSublayerVisibilityView.swift
+++ b/Shared/Samples/Set map image layer sublayer visibility/SetMapImageLayerSublayerVisibilityView.swift
@@ -17,7 +17,7 @@ import SwiftUI
 
 struct SetMapImageLayerSublayerVisibilityView: View {
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     /// A map with no specified style and initial viewpoint.
     @State private var map: Map = {

--- a/Shared/Samples/Set up location-driven geotriggers/SetUpLocationDrivenGeotriggersView.swift
+++ b/Shared/Samples/Set up location-driven geotriggers/SetUpLocationDrivenGeotriggersView.swift
@@ -21,7 +21,7 @@ struct SetUpLocationDrivenGeotriggersView: View {
     @StateObject private var model = Model()
     
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     /// A Boolean value indicating whether to show the popup.
     @State private var isShowingPopup = false

--- a/Shared/Samples/Set visibility of subtype sublayer/SetVisibilityOfSubtypeSublayerView.swift
+++ b/Shared/Samples/Set visibility of subtype sublayer/SetVisibilityOfSubtypeSublayerView.swift
@@ -23,7 +23,7 @@ struct SetVisibilityOfSubtypeSublayerView: View {
     @State private var isShowingSettings = false
     
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     var body: some View {
         MapView(map: model.map)

--- a/Shared/Samples/Show device location history/ShowDeviceLocationHistoryView.swift
+++ b/Shared/Samples/Show device location history/ShowDeviceLocationHistoryView.swift
@@ -17,7 +17,7 @@ import SwiftUI
 
 struct ShowDeviceLocationHistoryView: View {
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     /// A Boolean value indicating whether the tracking button is disabled.
     @State private var trackingButtonIsDisabled = true

--- a/Shared/Samples/Show device location using indoor positioning/ShowDeviceLocationUsingIndoorPositioningView.swift
+++ b/Shared/Samples/Show device location using indoor positioning/ShowDeviceLocationUsingIndoorPositioningView.swift
@@ -20,7 +20,7 @@ struct ShowDeviceLocationUsingIndoorPositioningView: View {
     /// The data model for the sample.
     @StateObject private var model = Model()
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     var body: some View {
         MapView(map: model.map)

--- a/Shared/Samples/Show device location with NMEA data sources/ShowDeviceLocationWithNMEADataSourcesView.swift
+++ b/Shared/Samples/Show device location with NMEA data sources/ShowDeviceLocationWithNMEADataSourcesView.swift
@@ -20,7 +20,7 @@ struct ShowDeviceLocationWithNMEADataSourcesView: View {
     @StateObject private var model = Model()
     
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     /// A string for GPS accuracy.
     @State private var accuracyStatus = "Accuracy info will be shown here."

--- a/Shared/Samples/Show device location/ShowDeviceLocationView.swift
+++ b/Shared/Samples/Show device location/ShowDeviceLocationView.swift
@@ -18,7 +18,7 @@ import SwiftUI
 
 struct ShowDeviceLocationView: View {
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     /// A Boolean value indicating whether the settings button is disabled.
     @State private var settingsButtonIsDisabled = true

--- a/Shared/Samples/Show labels on layer in 3D/ShowLabelsOnLayerIn3DView.swift
+++ b/Shared/Samples/Show labels on layer in 3D/ShowLabelsOnLayerIn3DView.swift
@@ -31,7 +31,7 @@ struct ShowLabelsOnLayerIn3DView: View {
     }
     
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     var body: some View {
         SceneView(scene: scene)

--- a/Shared/Samples/Show labels on layer/ShowLabelsOnLayerView.swift
+++ b/Shared/Samples/Show labels on layer/ShowLabelsOnLayerView.swift
@@ -27,7 +27,7 @@ struct ShowLabelsOnLayerView: View {
     }()
     
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     var body: some View {
         MapView(map: map)

--- a/Shared/Samples/Show mobile map package expiration date/ShowMobileMapPackageExpirationDateView.swift
+++ b/Shared/Samples/Show mobile map package expiration date/ShowMobileMapPackageExpirationDateView.swift
@@ -23,7 +23,7 @@ struct ShowMobileMapPackageExpirationDateView: View {
     @State private var mapPackage = MobileMapPackage(fileURL: .lothianRiversAnno)
     
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     var body: some View {
         ZStack {

--- a/Shared/Samples/Show portal user info/ShowPortalUserInfoView.swift
+++ b/Shared/Samples/Show portal user info/ShowPortalUserInfoView.swift
@@ -20,7 +20,7 @@ struct ShowPortalUserInfoView: View {
     /// The data model that helps determine the view.
     @State private var model = Model()
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     var body: some View {
         VStack {

--- a/Shared/Samples/Show result of spatial relationships/ShowResultOfSpatialRelationshipsView.swift
+++ b/Shared/Samples/Show result of spatial relationships/ShowResultOfSpatialRelationshipsView.swift
@@ -17,7 +17,7 @@ import SwiftUI
 
 struct ShowResultOfSpatialRelationshipsView: View {
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     /// The point indicating where to identify a graphic.
     @State private var identifyPoint: CGPoint?

--- a/Shared/Samples/Show service area/ShowServiceAreaView.swift
+++ b/Shared/Samples/Show service area/ShowServiceAreaView.swift
@@ -23,7 +23,7 @@ struct ShowServiceAreaView: View {
     /// Used to track whether to add facilities or barriers to the map.
     @State private var selectedGraphicType: GraphicType = .facility
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     /// First time break property set in first stepper.
     @State private var firstTimeBreak: Int = 3
     /// Second time break property set in second stepper.

--- a/Shared/Samples/Show service areas for multiple facilities/ShowServiceAreasForMultipleFacilitiesView.swift
+++ b/Shared/Samples/Show service areas for multiple facilities/ShowServiceAreasForMultipleFacilitiesView.swift
@@ -30,7 +30,7 @@ struct ShowServiceAreasForMultipleFacilitiesView: View {
     @State private var graphicsOverlay = GraphicsOverlay()
     
     /// The error that occurred during calculating the service area.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     /// A Boolean value indicating if the service area is being calculated.
     @State private var isCalculatingServiceArea = false

--- a/Shared/Samples/Show shapefile metadata/ShowShapefileMetadataView.swift
+++ b/Shared/Samples/Show shapefile metadata/ShowShapefileMetadataView.swift
@@ -19,7 +19,7 @@ struct ShowShapefileMetadataView: View {
     /// Model which contains the logic for loading and setting the data.
     @State private var model = Model()
     /// The error that occurred, if any, when trying to load the shapefile or display its metadata.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     /// A Boolean value specifying whether the metadata view should be shown
     @State private var showMetadata: Bool = false
     

--- a/Shared/Samples/Show viewshed from point on map/ShowViewshedFromPointOnMapView.swift
+++ b/Shared/Samples/Show viewshed from point on map/ShowViewshedFromPointOnMapView.swift
@@ -17,7 +17,7 @@ import SwiftUI
 
 struct ShowViewshedFromPointOnMapView: View {
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     /// The point on the map where the user tapped.
     @State private var tapLocation: Point?

--- a/Shared/Samples/Snap geometry edits with utility network rules/SnapGeometryEditsWithUtilityNetworkRulesView.swift
+++ b/Shared/Samples/Snap geometry edits with utility network rules/SnapGeometryEditsWithUtilityNetworkRulesView.swift
@@ -47,7 +47,7 @@ struct SnapGeometryEditsWithUtilityNetworkRulesView: View {
     @State private var sourcesListIsPresented = false
     
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     /// The instruction text indicating the next step in the sample's workflow.
     private var instructionText: String {

--- a/Shared/Samples/Snap geometry edits/SnapGeometryEditsView.swift
+++ b/Shared/Samples/Snap geometry edits/SnapGeometryEditsView.swift
@@ -35,7 +35,7 @@ struct SnapGeometryEditsView: View {
     @StateObject private var model = GeometryEditorModel()
     
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     /// A Boolean value indicating whether all the snap sources on the map view are loaded.
     @State private var snapSourcesAreLoaded = false

--- a/Shared/Samples/Style symbols from mobile style file/StyleSymbolsFromMobileStyleFileView.swift
+++ b/Shared/Samples/Style symbols from mobile style file/StyleSymbolsFromMobileStyleFileView.swift
@@ -104,7 +104,7 @@ extension StyleSymbolsFromMobileStyleFileView {
         )
         
         /// The error shown in the error alert.
-        @Published var error: Error?
+        @Published var error: (any Error)?
         
         /// Updates the display scale of the current symbol and symbols list.
         func updateDisplayScale(using displayScale: Double) async {

--- a/Shared/Samples/Validate utility network topology/ValidateUtilityNetworkTopologyView.swift
+++ b/Shared/Samples/Validate utility network topology/ValidateUtilityNetworkTopologyView.swift
@@ -32,7 +32,7 @@ struct ValidateUtilityNetworkTopologyView: View {
     @State private var editSheetIsPresented = false
     
     /// The error shown in the error alert.
-    @State private var error: Error?
+    @State private var error: (any Error)?
     
     var body: some View {
         MapViewReader { mapViewProxy in

--- a/Shared/Supporting Files/Extensions/View+ErrorAlert.swift
+++ b/Shared/Supporting Files/Extensions/View+ErrorAlert.swift
@@ -20,7 +20,7 @@ extension View {
     /// it is not `nil`. When the user taps "OK", this value is set to `nil`, and the alert is dismissed.
     ///
     /// If the given `error` is a `CancellationError`, it is ignored, and the alert is not presented.
-    func errorAlert(presentingError error: Binding<Error?>) -> some View {
+    func errorAlert(presentingError error: Binding<(some Error)?>) -> some View {
         /// A binding to a Boolean value indicating whether to present the alert.
         let isPresented: Binding<Bool>
         if error.wrappedValue != nil && !(error.wrappedValue is CancellationError) {

--- a/Shared/Supporting Files/Models/OnDemandResource.swift
+++ b/Shared/Supporting Files/Models/OnDemandResource.swift
@@ -39,7 +39,7 @@ final class OnDemandResource: ObservableObject {
     @Published private(set) var requestState: RequestState = .notStarted
     
     /// The error occurred in downloading resources.
-    @Published private(set) var error: Error?
+    @Published private(set) var error: (any Error)?
     
     /// The on-demand resource request.
     private let request: NSBundleResourceRequest


### PR DESCRIPTION
## Description

This PR partially fixes #656 by changing `Error` > `any Error`.

## Linked Issue(s)

- #656 

## How To Test

1. Build with this upcoming feature enabled

<img width="861" height="434" alt="Screenshot 2025-07-30 at 3 30 43 PM" src="https://github.com/user-attachments/assets/32d6d6e0-9dcc-46d6-828e-93028d996424" />

2. See all the existential any warnings are for other types