### PR TITLE
[Fix] `Set up location driven geotriggers` monitoring

### DIFF
--- a/Shared/Samples/Set up location-driven geotriggers/SetUpLocationDrivenGeotriggersView.swift
+++ b/Shared/Samples/Set up location-driven geotriggers/SetUpLocationDrivenGeotriggersView.swift
@@ -38,10 +38,13 @@ struct SetUpLocationDrivenGeotriggersView: View {
         await withThrowingTaskGroup(of: Void.self) { group in
             for monitor in geotriggerMonitors {
                 group.addTask { @MainActor @Sendable in
-                    try await monitor.start()
                     for await newNotification in monitor.notifications where newNotification is FenceGeotriggerNotificationInfo {
                         model.handleGeotriggerNotification(newNotification as! FenceGeotriggerNotificationInfo)
                     }
+                }
+                
+                group.addTask {
+                    try await monitor.start()
                 }
             }
         }


### PR DESCRIPTION
## Description

This PR fixes a bug with `Set up location-driven geotriggers` where the first "Current Section" wouldn't always be available. The solution was to kick off the `GeotriggerMonitor.notifications` monitoring loop before calling `GeotriggerMonitor.start()`.

## How To Test

Open `Set up location-driven geotriggers` a few times and ensure the "Current Section" button is always enabled **before** the location display leaves the "Desert".
