### PR TITLE
[Update] Use `AuthenticationManager.signOut()`

### DIFF
--- a/Shared/Samples/Add items to portal/AddItemsToPortalView.swift
+++ b/Shared/Samples/Add items to portal/AddItemsToPortalView.swift
@@ -85,7 +85,7 @@ struct AddItemsToPortalView: View {
             ArcGISEnvironment.authenticationManager.handleChallenges(using: authenticator)
             
             // In real world applications, uncomment this code to persist
-            // credentials in the keychain and remove `signOut()` from `onDisappear`.
+            // credentials in the keychain and remove `signOut()` from `onTeardown`.
             // Task { try await setupPersistentCredentialStorage() }
             
             // Temporarily unsets the API key for this sample to use OAuth.
@@ -103,7 +103,9 @@ struct AddItemsToPortalView: View {
             
             // Sets the API key back to the original value.
             ArcGISEnvironment.apiKey = apiKey
-            await signOut()
+            
+            // Signs out from the portal by revoking OAuth tokens and clearing credential stores.
+            await ArcGISEnvironment.authenticationManager.signOut()
         }
     }
     
@@ -171,12 +173,6 @@ struct AddItemsToPortalView: View {
                 ($0.creationDate ?? .distantPast) > ($1.creationDate ?? .distantPast)
             }
         }
-    }
-    
-    /// Signs out from the portal by revoking OAuth tokens and clearing credential stores.
-    private func signOut() async {
-        await ArcGISEnvironment.authenticationManager.revokeOAuthTokens()
-        await ArcGISEnvironment.authenticationManager.clearCredentialStores()
     }
     
     /// Sets up new ArcGIS and Network credential stores that will be persisted in the keychain.

--- a/Shared/Samples/Authenticate with Integrated Windows Authentication/AuthenticateWithIntegratedWindowsAuthenticationView.swift
+++ b/Shared/Samples/Authenticate with Integrated Windows Authentication/AuthenticateWithIntegratedWindowsAuthenticationView.swift
@@ -125,7 +125,7 @@ extension AuthenticateWithIntegratedWindowsAuthenticationView {
             setupAuthenticator()
         }
         
-        /// Connects to the portal and finds a batch of webmaps.
+        /// Connects to the portal and finds a batch of web maps.
         func connectToPortal() async {
             precondition(portalURL != nil)
             
@@ -166,8 +166,7 @@ extension AuthenticateWithIntegratedWindowsAuthenticationView {
             // point in time based on the workflow desired. For example, it
             // might make sense to remove credentials when the user taps
             // a "sign out" button.
-            await ArcGISEnvironment.authenticationManager.revokeOAuthTokens()
-            await ArcGISEnvironment.authenticationManager.clearCredentialStores()
+            await ArcGISEnvironment.authenticationManager.signOut()
         }
         
         /// Sets up new ArcGIS and Network credential stores that will be persisted in the keychain.

--- a/Shared/Samples/Authenticate with OAuth/AuthenticateWithOAuthView.swift
+++ b/Shared/Samples/Authenticate with OAuth/AuthenticateWithOAuthView.swift
@@ -50,7 +50,7 @@ struct AuthenticateWithOAuthView: View {
                 ArcGISEnvironment.authenticationManager.handleChallenges(using: authenticator)
                 
                 // In real world applications, uncomment this code to persist credentials in the
-                // keychain and remove `signOut()` from `onDisappear`.
+                // keychain and remove `signOut()` from `onTeardown`.
                 // setupPersistentCredentialStorage()
             }
             .onTeardown {
@@ -61,14 +61,9 @@ struct AuthenticateWithOAuthView: View {
                 // Resets challenge handlers.
                 ArcGISEnvironment.authenticationManager.handleChallenges(using: nil)
                 
-                await signOut()
+                // Signs out from the portal by revoking OAuth tokens and clearing credential stores.
+                await ArcGISEnvironment.authenticationManager.signOut()
             }
-    }
-    
-    /// Signs out from the portal by revoking OAuth tokens and clearing credential stores.
-    private func signOut() async {
-        await ArcGISEnvironment.authenticationManager.revokeOAuthTokens()
-        await ArcGISEnvironment.authenticationManager.clearCredentialStores()
     }
     
     /// Sets up new ArcGIS and Network credential stores that will be persisted in the keychain.

--- a/Shared/Samples/Authenticate with PKI certificate/AuthenticateWithPKICertificateView.swift
+++ b/Shared/Samples/Authenticate with PKI certificate/AuthenticateWithPKICertificateView.swift
@@ -125,7 +125,7 @@ extension AuthenticateWithPKICertificateView {
             setupAuthenticator()
         }
         
-        /// Connects to the portal and finds a batch of webmaps.
+        /// Connects to the portal and finds a batch of web maps.
         func connectToPortal() async {
             precondition(portalURL != nil)
             
@@ -166,8 +166,7 @@ extension AuthenticateWithPKICertificateView {
             // point in time based on the workflow desired. For example, it
             // might make sense to remove credentials when the user taps
             // a "sign out" button.
-            await ArcGISEnvironment.authenticationManager.revokeOAuthTokens()
-            await ArcGISEnvironment.authenticationManager.clearCredentialStores()
+            await ArcGISEnvironment.authenticationManager.signOut()
         }
         
         /// Sets up new ArcGIS and Network credential stores that will be persisted in the keychain.

--- a/Shared/Samples/Authenticate with token/AuthenticateWithTokenView.swift
+++ b/Shared/Samples/Authenticate with token/AuthenticateWithTokenView.swift
@@ -86,8 +86,7 @@ private extension AuthenticateWithTokenView {
         // point in time based on the workflow desired. For example, it
         // might make sense to remove credentials when the user taps
         // a "sign out" button.
-        await ArcGISEnvironment.authenticationManager.revokeOAuthTokens()
-        await ArcGISEnvironment.authenticationManager.clearCredentialStores()
+        await ArcGISEnvironment.authenticationManager.signOut()
     }
     
     /// Sets up new ArcGIS and Network credential stores that will be persisted in the keychain.

--- a/Shared/Samples/Create and save map/CreateAndSaveMapView.swift
+++ b/Shared/Samples/Create and save map/CreateAndSaveMapView.swift
@@ -395,8 +395,7 @@ private extension CreateAndSaveMapView {
         // point in time based on the workflow desired. For example, it
         // might make sense to remove credentials when the user taps
         // a "sign out" button.
-        await ArcGISEnvironment.authenticationManager.revokeOAuthTokens()
-        await ArcGISEnvironment.authenticationManager.clearCredentialStores()
+        await ArcGISEnvironment.authenticationManager.signOut()
     }
     
     /// Sets up new ArcGIS and Network credential stores that will be persisted in the keychain.

--- a/Shared/Samples/Show portal user info/ShowPortalUserInfoView.swift
+++ b/Shared/Samples/Show portal user info/ShowPortalUserInfoView.swift
@@ -130,8 +130,7 @@ private extension ShowPortalUserInfoView {
         
         /// Signs out from the portal by revoking OAuth tokens and clearing credential stores.
         func signOut() async {
-            await ArcGISEnvironment.authenticationManager.revokeOAuthTokens()
-            await ArcGISEnvironment.authenticationManager.clearCredentialStores()
+            await ArcGISEnvironment.authenticationManager.signOut()
             portalUser = nil
             portalInfo = nil
             isLoading = false


### PR DESCRIPTION
## Description

This PR uses replaces custom authentication methods with [`AuthenticationManager.signOut()`](https://developers.arcgis.com/swift/toolkit-api-reference/documentation/arcgistoolkit/arcgis/authenticationmanager/signout()) in response to this feedback https://github.com/Esri/arcgis-maps-sdk-swift-samples/pull/667#discussion_r2226759344 (and fixes a couple of comment issues I noticed in the process).

## Linked Issue(s)

Closes #671

## How To Test

Ensure the affected samples still perform as expected.


