### PR TITLE
[Update] Linter rules

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -23,7 +23,6 @@ disabled_rules:
   - force_cast
   - force_try
   - line_length
-  - notification_center_detachment
   - type_body_length
   - type_name
 

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -21,6 +21,7 @@ disabled_rules:
   - file_length
   - for_where
   - force_cast
+  - force_try
   - line_length
   - notification_center_detachment
   - type_body_length

--- a/Shared/Samples/Add vector tiled layer from custom style/AddVectorTiledLayerFromCustomStyleView.swift
+++ b/Shared/Samples/Add vector tiled layer from custom style/AddVectorTiledLayerFromCustomStyleView.swift
@@ -183,7 +183,6 @@ private extension FileManager {
     /// Creates a temporary directory.
     /// - Returns: The URL of the created directory
     static func createTemporaryDirectory() -> URL {
-        // swiftlint:disable:next force_try
         try! FileManager.default.url(
             for: .itemReplacementDirectory,
             in: .userDomainMask,

--- a/Shared/Samples/Apply function to raster from service/ApplyFunctionToRasterFromServiceView.swift
+++ b/Shared/Samples/Apply function to raster from service/ApplyFunctionToRasterFromServiceView.swift
@@ -29,7 +29,7 @@ struct ApplyFunctionToRasterFromServiceView: View {
                         url: URL(string: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/NLCDLandCover2001/ImageServer")!
                     )
                     // Creates a raster function from a json string.
-                    let function = try! RasterFunction.fromJSON(rasterFunctionJSON) // swiftlint:disable:this force_try
+                    let function = try! RasterFunction.fromJSON(rasterFunctionJSON)
                     // Sets the arguments on the function.
                     function.arguments!.setRaster(
                         imageServiceRaster,

--- a/Shared/Samples/Apply scheduled updates to preplanned map area/ApplyScheduledUpdatesToPreplannedMapAreaView.swift
+++ b/Shared/Samples/Apply scheduled updates to preplanned map area/ApplyScheduledUpdatesToPreplannedMapAreaView.swift
@@ -188,7 +188,6 @@ private extension FileManager {
     /// Creates a temporary directory.
     /// - Returns: The URL of the created directory.
     static func createTemporaryDirectory() -> URL {
-        // swiftlint:disable:next force_try
         try! FileManager.default.url(
             for: .itemReplacementDirectory,
             in: .userDomainMask,

--- a/Shared/Samples/Configure electronic navigational charts/ConfigureElectronicNavigationalChartsView.swift
+++ b/Shared/Samples/Configure electronic navigational charts/ConfigureElectronicNavigationalChartsView.swift
@@ -256,7 +256,6 @@ private extension FileManager {
     /// Creates a temporary directory.
     /// - Returns: The URL of the created directory.
     static func createTemporaryDirectory() -> URL {
-        // swiftlint:disable:next force_try
         try! FileManager.default.url(
             for: .itemReplacementDirectory,
             in: .userDomainMask,

--- a/Shared/Samples/Create KML multi-track/CreateKMLMultiTrackView.Model.swift
+++ b/Shared/Samples/Create KML multi-track/CreateKMLMultiTrackView.Model.swift
@@ -141,7 +141,6 @@ private extension FileManager {
     /// Creates a temporary directory.
     /// - Returns: The URL of the created directory.
     static func createTemporaryDirectory() -> URL {
-        // swiftlint:disable:next force_try
         try! FileManager.default.url(
             for: .itemReplacementDirectory,
             in: .userDomainMask,

--- a/Shared/Samples/Create and edit geometries/CreateAndEditGeometriesView.swift
+++ b/Shared/Samples/Create and edit geometries/CreateAndEditGeometriesView.swift
@@ -480,7 +480,6 @@ private class GeometryEditorModel: ObservableObject {
 }
 
 private extension Geometry {
-    // swiftlint:disable force_try
     static func house() -> Point {
         let json = Data(
             """
@@ -517,7 +516,7 @@ private extension Geometry {
                         [-1067889.49,6998483.56],[-1067880.98,6998527.26]]],
                     "spatialReference":{"latestWkid":3857,"wkid":102100}}
             """.utf8
-            )
+        )
         return try! Polyline.fromJSON(json)
     }
     
@@ -555,7 +554,6 @@ private extension Geometry {
         )
         return try! Polygon.fromJSON(json)
     }
-    // swiftlint:enable force_try
 }
 
 private extension Symbol {

--- a/Shared/Samples/Create and save KML file/CreateAndSaveKMLView.swift
+++ b/Shared/Samples/Create and save KML file/CreateAndSaveKMLView.swift
@@ -121,7 +121,6 @@ extension CreateAndSaveKMLView {
 private extension FileManager {
     /// Creates a temporary directory and returns the URL of the created directory.
     static func createTemporaryDirectory() -> URL {
-        // swiftlint:disable:next force_try
         try! FileManager.default.url(
             for: .itemReplacementDirectory,
             in: .userDomainMask,

--- a/Shared/Samples/Download preplanned map area/DownloadPreplannedMapAreaView.Model.swift
+++ b/Shared/Samples/Download preplanned map area/DownloadPreplannedMapAreaView.Model.swift
@@ -310,7 +310,6 @@ private extension DownloadPreplannedMapAreaView.OfflineMapModel {
 private extension FileManager {
     /// Creates a temporary directory and returns the URL of the created directory.
     static func createTemporaryDirectory() -> URL {
-        // swiftlint:disable:next force_try
         try! FileManager.default.url(
             for: .itemReplacementDirectory,
             in: .userDomainMask,

--- a/Shared/Samples/Download vector tiles to local cache/DownloadVectorTilesToLocalCacheView.swift
+++ b/Shared/Samples/Download vector tiles to local cache/DownloadVectorTilesToLocalCacheView.swift
@@ -294,7 +294,6 @@ private extension DownloadVectorTilesToLocalCacheView {
         /// Creates a temporary directory.
         /// - Returns: The URL to the temporary directory.
         private static func createTemporaryDirectory() -> URL {
-            // swiftlint:disable:next force_try
             try! FileManager.default.url(
                 for: .itemReplacementDirectory,
                 in: .userDomainMask,

--- a/Shared/Samples/Edit and sync features with feature service/EditAndSyncFeaturesWithFeatureServiceView.Model.swift
+++ b/Shared/Samples/Edit and sync features with feature service/EditAndSyncFeaturesWithFeatureServiceView.Model.swift
@@ -189,7 +189,6 @@ private extension FileManager {
     /// Creates a temporary directory.
     /// - Returns: The URL of the created directory.
     static func createTemporaryDirectory() -> URL {
-        // swiftlint:disable:next force_try
         try! FileManager.default.url(
             for: .itemReplacementDirectory,
             in: .userDomainMask,

--- a/Shared/Samples/Edit features with feature-linked annotation/EditFeaturesWithFeatureLinkedAnnotationView.Model.swift
+++ b/Shared/Samples/Edit features with feature-linked annotation/EditFeaturesWithFeatureLinkedAnnotationView.Model.swift
@@ -154,7 +154,6 @@ private extension FileManager {
     /// Creates a temporary directory.
     /// - Returns: The URL of the created directory.
     static func createTemporaryDirectory() -> URL {
-        // swiftlint:disable:next force_try
         try! FileManager.default.url(
             for: .itemReplacementDirectory,
             in: .userDomainMask,

--- a/Shared/Samples/Edit geodatabase with transactions/EditGeodatabaseWithTransactionsView.Model.swift
+++ b/Shared/Samples/Edit geodatabase with transactions/EditGeodatabaseWithTransactionsView.Model.swift
@@ -90,7 +90,6 @@ private extension FileManager {
     /// Creates a temporary directory.
     /// - Returns: The URL of the created directory.
     static func createTemporaryDirectory() -> URL {
-        // swiftlint:disable:next force_try
         try! FileManager.default.url(
             for: .itemReplacementDirectory,
             in: .userDomainMask,

--- a/Shared/Samples/Edit geometries with programmatic reticle tool/EditGeometriesWithProgrammaticReticleToolView.swift
+++ b/Shared/Samples/Edit geometries with programmatic reticle tool/EditGeometriesWithProgrammaticReticleToolView.swift
@@ -472,7 +472,6 @@ private extension Geometry {
         }
     }
     
-    // swiftlint:disable force_try
     static var pinkneysGreen: Geometry {
         let json = Data(
             """
@@ -511,7 +510,6 @@ private extension Geometry {
         )
         return try! Multipoint.fromJSON(json)
     }
-    // swiftlint:enable force_try
 }
 
 private extension Symbol {

--- a/Shared/Samples/Generate geodatabase replica from feature service/GenerateGeodatabaseReplicaFromFeatureServiceView.Model.swift
+++ b/Shared/Samples/Generate geodatabase replica from feature service/GenerateGeodatabaseReplicaFromFeatureServiceView.Model.swift
@@ -113,7 +113,6 @@ private extension FileManager {
     /// Creates a temporary directory.
     /// - Returns: The URL of the created directory.
     static func createTemporaryDirectory() -> URL {
-        // swiftlint:disable:next force_try
         try! FileManager.default.url(
             for: .itemReplacementDirectory,
             in: .userDomainMask,

--- a/Shared/Samples/Generate offline map with custom parameters/GenerateOfflineMapWithCustomParametersView.Model.swift
+++ b/Shared/Samples/Generate offline map with custom parameters/GenerateOfflineMapWithCustomParametersView.Model.swift
@@ -147,7 +147,6 @@ extension GenerateOfflineMapWithCustomParametersView {
         
         /// Creates a temporary directory.
         private static func createTemporaryDirectory() -> URL {
-            // swiftlint:disable:next force_try
             try! FileManager.default.url(
                 for: .itemReplacementDirectory,
                 in: .userDomainMask,

--- a/Shared/Samples/Generate offline map with local basemap/GenerateOfflineMapWithLocalBasemapView.swift
+++ b/Shared/Samples/Generate offline map with local basemap/GenerateOfflineMapWithLocalBasemapView.swift
@@ -260,7 +260,6 @@ private extension GenerateOfflineMapWithLocalBasemapView {
         
         /// Creates a temporary directory.
         private static func createTemporaryDirectory() -> URL {
-            // swiftlint:disable:next force_try
             try! FileManager.default.url(
                 for: .itemReplacementDirectory,
                 in: .userDomainMask,

--- a/Shared/Samples/Generate offline map/GenerateOfflineMapView.swift
+++ b/Shared/Samples/Generate offline map/GenerateOfflineMapView.swift
@@ -224,7 +224,6 @@ private extension GenerateOfflineMapView {
         
         /// Creates a temporary directory.
         private static func createTemporaryDirectory() -> URL {
-            // swiftlint:disable:next force_try
             try! FileManager.default.url(
                 for: .itemReplacementDirectory,
                 in: .userDomainMask,

--- a/Shared/Samples/Search for web map/SearchForWebMapView.Model.swift
+++ b/Shared/Samples/Search for web map/SearchForWebMapView.Model.swift
@@ -94,7 +94,6 @@ extension SearchForWebMapView {
 private extension Date {
     /// The date after which web maps are supported, July 2, 2014.
     static var webMapSupportedDate: Date {
-        // swiftlint:disable:next force_try
         try! Date(
             "July 2, 2014",
             strategy: Date.FormatStyle().day().month().year().parseStrategy

--- a/Shared/Samples/Show device location history/ShowDeviceLocationHistoryView.swift
+++ b/Shared/Samples/Show device location history/ShowDeviceLocationHistoryView.swift
@@ -143,7 +143,6 @@ private extension ShowDeviceLocationHistoryView {
         /// Makes the simulated location data source for the sample.
         /// - Returns: A simulated location data source in Los Angeles, CA.
         private static func makeSimulatedLocationDataSource() -> SimulatedLocationDataSource {
-            // swiftlint:disable:next force_try
             let routePolyline = try! Polyline.fromJSON(polylineJSON)
             // Densify the simulated path to make it smoother.
             let densifiedRoute = GeometryEngine.geodeticDensify(

--- a/Shared/Samples/Snap geometry edits with utility network rules/SnapGeometryEditsWithUtilityNetworkRulesView.Model.swift
+++ b/Shared/Samples/Snap geometry edits with utility network rules/SnapGeometryEditsWithUtilityNetworkRulesView.Model.swift
@@ -279,7 +279,7 @@ private extension Data {
 private extension Geodatabase {
     /// Returns a temporary geodatabase with gas utility network data for Naperville.
     static func napervilleGasUtilities() -> Geodatabase {
-        let temporaryGeodatabaseURL = try! FileManager.default  // swiftlint:disable:this force_try
+        let temporaryGeodatabaseURL = try! FileManager.default
             .url(
                 for: .itemReplacementDirectory,
                 in: .userDomainMask,


### PR DESCRIPTION
## Description

This is a redo of #690 since the original was accidentally merged into `main`:

This PR updates some SwiftLint rules to match how they are handled in the SDK:
- `force_try` was disabled (In response to [this feedback](https://github.com/Esri/arcgis-maps-sdk-swift-samples/pull/662#discussion_r2226246455)).
- `notification_center_detachment` was undisabled (since it seemed unneeded).

## Linked Issue(s)

Closes #590

## How To Test

Ensure the project builds without any warnings.

## To Discuss

Below is a diff between the Samples and SDK linter rules after the changes in this PR. (Green lines are the rules that the SDK has and the Samples doesn't. Red is the opposite. Disabled rules are at the top.) Let me know if you think it would make sense to add/remove any other rules.

<img width="406" height="923" alt="Screenshot 2025-08-06 at 4 03 23 PM" src="https://github.com/user-attachments/assets/427cfa35-e564-43a6-af30-2aa5ee5418e1" />
