### PR TITLE
[Update] `Add custom dynamic entity data source` - Remove custom Geometry type

### DIFF
--- a/Shared/Samples/Add custom dynamic entity data source/AddCustomDynamicEntityDataSourceView.Vessel.swift
+++ b/Shared/Samples/Add custom dynamic entity data source/AddCustomDynamicEntityDataSourceView.Vessel.swift
@@ -12,19 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import ArcGIS
+
 extension AddCustomDynamicEntityDataSourceView {
     /// A marine vessel that can be decoded from the vessel JSON.
     struct Vessel {
-        /// A geometry that gives the location of the vessel.
-        struct Geometry: Decodable { // swiftlint:disable:this nesting
-            /// The x coordinate of the geometry.
-            let x: Double
-            /// The y coordinate of the geometry.
-            let y: Double
-        }
-        
         /// The location of the vessel.
-        let geometry: Geometry
+        let geometry: Point
         /// The attributes of the vessel.
         let attributes: [String: any Sendable]
     }
@@ -56,7 +50,7 @@ extension AddCustomDynamicEntityDataSourceView.Vessel: Decodable {
         
         let container = try decoder.container(keyedBy: CodingKeys.self)
         
-        let geometry = try container.decode(Geometry.self, forKey: .geometry)
+        let geometry = try container.decode(Point.self, forKey: .geometry)
         let attributes: [String: any Sendable] = try {
             let attributes = try container.decode(Attributes.self, forKey: .attributes)
             return [

--- a/Shared/Samples/Add custom dynamic entity data source/AddCustomDynamicEntityDataSourceView.swift
+++ b/Shared/Samples/Add custom dynamic entity data source/AddCustomDynamicEntityDataSourceView.swift
@@ -127,13 +127,10 @@ private struct VesselFeed: CustomDynamicEntityFeed {
             from: line.data(using: .utf8)!
         )
         
-        // The location of the vessel that was decoded from the JSON.
-        let location = vessel.geometry
-        
         // We successfully decoded the vessel JSON so we should
         // add that vessel as a new observation.
         return CustomDynamicEntityFeedEvent.newObservation(
-            geometry: Point(x: location.x, y: location.y, spatialReference: .wgs84),
+            geometry: vessel.geometry,
             attributes: vessel.attributes
         )
     }


### PR DESCRIPTION
## Description

This PR updates `Add custom dynamic entity data source` to remove its custom `Geometry` type since `Point` is Decodable and can be used instead. See https://github.com/Esri/arcgis-maps-sdk-swift-samples/pull/684#discussion_r2277364282.

## How To Test

- Ensure that the dynamic entities in `Add custom dynamic entity data source` still move as expected.

