### PR TITLE
[Fix] `Validate utility network topology view` build error

### DIFF
--- a/Shared/Samples/Validate utility network topology/ValidateUtilityNetworkTopologyView.Model.swift
+++ b/Shared/Samples/Validate utility network topology/ValidateUtilityNetworkTopologyView.Model.swift
@@ -255,7 +255,7 @@ extension ValidateUtilityNetworkTopologyView {
             let portalItem = PortalItem(portal: portal, id: .napervilleElectric)
             
             // Create and load a map using the portal item.
-            map = .init(item: portalItem)
+            map = Map(item: portalItem)
             map.initialViewpoint = Viewpoint(center: Point(x: -9815160, y: 5128880), scale: 3640)
             try await map.load()
             


### PR DESCRIPTION
## Description

This PR fixes a build error in `Validate utility network topology view`, that was caused by a recent `ArcGIS Maps SDK for Swift` API change.

## Linked Issue(s)

- `swift/issues/7240`
- `runtimecore/pull/33545`

## How To Test

Ensure the project builds with the latest `swift-toolkit-daily` and the sample still loads as expected.
