### PR TITLE
[Fix] appendInterpolation warning

### DIFF
--- a/Shared/Samples/Manage features/ManageFeaturesView.swift
+++ b/Shared/Samples/Manage features/ManageFeaturesView.swift
@@ -124,7 +124,7 @@ struct ManageFeaturesView: View {
     func featureCalloutContent(feature: Feature, table: ServiceFeatureTable) -> some View {
         HStack {
             VStack(alignment: .leading) {
-                Text("ID: \(feature.attributeValue(forKey: table.objectIDField) ?? "Unknown")")
+                Text("ID: \(feature.attributeValue(forKey: table.objectIDField) as? String ?? "Unknown")")
                 Text("Damage: \(feature.damageKind?.rawValue ?? "Unknown")")
                     .font(.footnote)
                     .foregroundStyle(.secondary)

--- a/Shared/Supporting Files/Models/OnDemandResource.swift
+++ b/Shared/Supporting Files/Models/OnDemandResource.swift
@@ -44,7 +44,7 @@ final class OnDemandResource {
     private(set) var requestState: RequestState
     
     /// The error occurred in downloading resources.
-    private(set) var error: NSError?
+    private(set) var error: (any Error)?
     
     /// The on-demand resource request.
     private let request: NSBundleResourceRequest
@@ -75,7 +75,7 @@ final class OnDemandResource {
             requestState = .downloaded
         } catch {
             if (error as NSError).code != NSUserCancelledError {
-                self.error = error as NSError
+                self.error = error
                 requestState = .error
             } else {
                 cancel()

--- a/Shared/Supporting Files/Models/OnDemandResource.swift
+++ b/Shared/Supporting Files/Models/OnDemandResource.swift
@@ -44,7 +44,7 @@ final class OnDemandResource {
     private(set) var requestState: RequestState
     
     /// The error occurred in downloading resources.
-    private(set) var error: (any Error)?
+    private(set) var error: NSError?
     
     /// The on-demand resource request.
     private let request: NSBundleResourceRequest
@@ -75,7 +75,7 @@ final class OnDemandResource {
             requestState = .downloaded
         } catch {
             if (error as NSError).code != NSUserCancelledError {
-                self.error = error
+                self.error = error as NSError
                 requestState = .error
             } else {
                 cancel()

--- a/Shared/Supporting Files/Views/DownloadOfflineResourcesView.swift
+++ b/Shared/Supporting Files/Views/DownloadOfflineResourcesView.swift
@@ -160,7 +160,7 @@ private struct DownloadOnDemandResourceView: View {
             Label {
                 Text(name)
                 
-                if resource.requestState == .error, let error = resource.error as NSError? {
+                if resource.requestState == .error, let error = resource.error {
                     Text("Error: \(error.localizedDescription)")
                         .foregroundStyle(.red)
                 }

--- a/Shared/Supporting Files/Views/DownloadOfflineResourcesView.swift
+++ b/Shared/Supporting Files/Views/DownloadOfflineResourcesView.swift
@@ -160,8 +160,8 @@ private struct DownloadOnDemandResourceView: View {
             Label {
                 Text(name)
                 
-                if resource.requestState == .error, let error = resource.error as? NSError {
-                    Text("Error: \(error)")
+                if resource.requestState == .error, let error = resource.error as NSError? {
+                    Text("Error: \(error.localizedDescription)")
                         .foregroundStyle(.red)
                 }
             } icon: {

--- a/Shared/Supporting Files/Views/DownloadOfflineResourcesView.swift
+++ b/Shared/Supporting Files/Views/DownloadOfflineResourcesView.swift
@@ -160,7 +160,7 @@ private struct DownloadOnDemandResourceView: View {
             Label {
                 Text(name)
                 
-                if resource.requestState == .error, let error = resource.error {
+                if resource.requestState == .error, let error = resource.error as? NSError {
                     Text("Error: \(error)")
                         .foregroundStyle(.red)
                 }


### PR DESCRIPTION
## Description

This PR fixes the appendInterpolation warning when compiled with Xcode 26. 

## Linked Issue(s)

- `swift/issues/7333`

## How To Test

Build with both Xcode 16.4 and 26.0 and see no warning.
