### PR TITLE
[Setup] Refactor offline data download script

### DIFF
--- a/Scripts/DownloadPortalItemData.swift
+++ b/Scripts/DownloadPortalItemData.swift
@@ -325,7 +325,7 @@ func run() async throws { // swiftlint:disable:this function_body_length cycloma
                 to: destinationURL
             )
             downloadedItems.updateValue(downloadName, forKey: portalItem.identifier)
-            print("note: (\(index)/\(portalItems.count)) Downloaded item: \(portalItem.identifier)")
+            print("note: (\(index + 1)/\(portalItems.count)) Downloaded item: \(portalItem.identifier)")
             fflush(stdout)
         } catch {
             print("error: Failed to download item \(portalItem.identifier), \(error.localizedDescription)")


### PR DESCRIPTION
## Description

This PR refactors the `Scripts/DownloadPortalItemData.swift` script that downloads the offline data for the samples app from AGOL, when the app is built for the first time.

It mainly resolves 3 problems

1. Reduce the amount of concurrent downloads
    - Previously, we kick off all 51 portal item download at once, which tends to cause some downloads become dormant and eventually timeout.
    - By limiting the `maxConcurrentTasks` to 4, even at ADSL bandwidth, the script can still download all items without timeout.
2. Fix the task cancellation logics
    - Previously, the script won't exit until all tasks finish/throw error.
    - Changed the logic to let the task group throw immediately when a child task throws, and cancel all remaining tasks.
3. Add better error handling
    - Previously, errors are kind of scattered around the script. 
    - Added a `ScriptError` to provide more useful error stages to debug.

I didn't add logic to retry as the new approach shouldn't require that. However, if you still manage to encounter an error, let's chat.

## Linked Issue(s)

- `swift/issues/7303`
- Close #640

## How To Test

### Light

For a quick ad-hoc test, simply do the following

- Download the main/v.next zip, build and run the app. If you have good network, it may build successfully; otherwise, you'll see the script report an error. Retry the build and it is likely to fail again. (Use the Network Link Conditioner with a slower profile if you are in the office, or on 1Gb fiber at home 😬)
- Download the zip for this branch, build and run the app. It should successfully build. (if it fails, ping me 🛎️) 

<details><summary>More comprehensive test</summary>

### Full

To fully test the script, a few suggestions:

1. Try to mess up the Portal Data folder, and see if the script can handle that. Ideas like: delete the hidden plist; randomly delete a few portal item folders; delete the whole folder.
    - however, if the folder is messed up by hand, the progress would always report (51/51). This is an edge case that I don't plan to handle.
2. Use [Network Link Conditioner](https://nshipster.com/network-link-conditioner/) (from [Downloads for Apple Developers](https://developer.apple.com/download/more/?q=Additional%20Tools), if you haven't installed it already) to select a bad network profile.
    - I've tested all the way down to DSL profile and it still succeeds. It may timeout in Very Bad Network profile, but a retry with normal network should succeed.
    - LTE breezed through easily, whereas `main` branch is almost guaranteed to fail in LTE.

<img width="996" height="706" alt="nlc-profile" src="https://github.com/user-attachments/assets/8d5f6268-b366-4161-b3f8-dbff6aab327a" />

3. Extract the script into a macOS Command Line Tool project, and set the arguments as well as copy over the `Samples` folder that contains all source code files and metadata JSONs. Tweak and play with it to see if something can break it.

<img width="950" height="517" alt="arguments" src="https://github.com/user-attachments/assets/b15b32dd-19e4-468e-91b5-38e60b2be944" />

</details>

## Screenshots

Running on ADSL bandwidth, it's mostly full throttle.

<img width="1018" height="641" alt="DSL" src="https://github.com/user-attachments/assets/23c59487-b12c-49e6-a58f-b703c34c2bfe" />
