### PR TITLE
[Update] Remove use of formatters

### DIFF
--- a/Shared/Samples/Apply scheduled updates to preplanned map area/ApplyScheduledUpdatesToPreplannedMapAreaView.swift
+++ b/Shared/Samples/Apply scheduled updates to preplanned map area/ApplyScheduledUpdatesToPreplannedMapAreaView.swift
@@ -73,14 +73,11 @@ struct ApplyScheduledUpdatesToPreplannedMapAreaView: View {
                 }
             } message: {
                 // Get the download size for the update.
-                let downloadSizeString = ByteCountFormatter.string(
-                    from: Measurement(
-                        value: Double(model.updatesInfo?.scheduledUpdatesDownloadSize ?? .zero),
-                        unit: .bytes
-                    ),
-                    countStyle: .file
+                let downloadSize = Measurement<UnitInformationStorage>(
+                    value: Double(model.updatesInfo?.scheduledUpdatesDownloadSize ?? .zero),
+                    unit: .bytes
                 )
-                Text("A \(downloadSizeString) update is available. Would you like to apply it?")
+                Text("A \(downloadSize, format: .byteCount(style: .file)) update is available. Would you like to apply it?")
             }
             .alert("Scheduled Updates Unavailable", isPresented: $noUpdatesAlertIsPresented) {
             } message: {

--- a/Shared/Samples/Navigate route/NavigateRouteView.swift
+++ b/Shared/Samples/Navigate route/NavigateRouteView.swift
@@ -131,14 +131,6 @@ private extension NavigateRouteView {
         /// The graphics overlay for the route.
         private let routeGraphicsOverlay: GraphicsOverlay
         
-        /// Formats the time remaining for display.
-        private let timeFormatter: DateComponentsFormatter = {
-            let formatter = DateComponentsFormatter()
-            formatter.allowedUnits = [.hour, .minute, .second]
-            formatter.unitsStyle = .full
-            return formatter
-        }()
-        
         /// The map's graphics overlays.
         var graphicsOverlays: [GraphicsOverlay] {
             return [stopGraphicsOverlay, routeGraphicsOverlay]
@@ -260,9 +252,12 @@ private extension NavigateRouteView {
                     
                     switch status.destinationStatus {
                     case .notReached, .approaching:
+                        let currentDate = Date()
+                        let arrivalDate = currentDate.addingTimeInterval(status.routeProgress.remainingTime)
+                        let interval = currentDate..<arrivalDate
                         statusText = """
                         Distance remaining: \(status.routeProgress.remainingDistance.distanceRemainingText)
-                        Time remaining: \(timeFormatter.string(from: status.routeProgress.remainingTime)!)
+                        Time remaining: \(interval.formatted(.components(style: .wide, fields: [.hour, .minute, .second])))
                         """
                         if status.currentManeuverIndex + 1 < directions.count {
                             statusText.append("\nNext direction: \(directions[status.currentManeuverIndex + 1].text)")

--- a/Shared/Samples/Set up location-driven geotriggers/SetUpLocationDrivenGeotriggersView.swift
+++ b/Shared/Samples/Set up location-driven geotriggers/SetUpLocationDrivenGeotriggersView.swift
@@ -29,9 +29,6 @@ struct SetUpLocationDrivenGeotriggersView: View {
     /// A string for the fence geotrigger notification status.
     @State private var fenceGeotriggerText = ""
     
-    /// A string for the display name of the currently nearby feature.
-    @State private var nearbyFeaturesText = ""
-    
     /// Starts the geotrigger monitors and handles posted notifications.
     /// - Parameter geotriggerMonitors: The geotrigger monitors to start.
     private func startGeotriggerMonitors(_ geotriggerMonitors: [GeotriggerMonitor]) async throws {
@@ -72,14 +69,6 @@ struct SetUpLocationDrivenGeotriggersView: View {
             .task(id: model.fenceGeotriggerStatus) {
                 // Set fence geotrigger text.
                 fenceGeotriggerText = model.fenceGeotriggerStatus.label
-                
-                // Set nearby features text.
-                let features = model.nearbyFeatures
-                if features.isEmpty {
-                    nearbyFeaturesText = "No nearby features."
-                } else {
-                    nearbyFeaturesText = String(format: "Nearby: %@", ListFormatter.localizedString(byJoining: features.keys.sorted()))
-                }
             }
             .overlay(alignment: .top) {
                 // Status text overlay.
@@ -87,7 +76,13 @@ struct SetUpLocationDrivenGeotriggersView: View {
                     Text(fenceGeotriggerText)
                         .frame(maxWidth: .infinity, alignment: .leading)
                     
-                    Text(nearbyFeaturesText)
+                    let nearbyFeatures = model.nearbyFeatures
+                    let nearbyFeaturesText = if !nearbyFeatures.isEmpty {
+                        Text("Nearby: \(nearbyFeatures.keys.sorted(), format: .list(type: .and))")
+                    } else {
+                        Text("No nearby features.")
+                    }
+                    nearbyFeaturesText
                         .foregroundStyle(.orange)
                         .frame(maxWidth: .infinity, alignment: .leading)
                 }

--- a/Shared/Samples/Set up location-driven geotriggers/SetUpLocationDrivenGeotriggersView.swift
+++ b/Shared/Samples/Set up location-driven geotriggers/SetUpLocationDrivenGeotriggersView.swift
@@ -26,9 +26,6 @@ struct SetUpLocationDrivenGeotriggersView: View {
     /// A Boolean value indicating whether to show the popup.
     @State private var isShowingPopup = false
     
-    /// A string for the fence geotrigger notification status.
-    @State private var fenceGeotriggerText = ""
-    
     /// Starts the geotrigger monitors and handles posted notifications.
     /// - Parameter geotriggerMonitors: The geotrigger monitors to start.
     private func startGeotriggerMonitors(_ geotriggerMonitors: [GeotriggerMonitor]) async throws {
@@ -66,14 +63,10 @@ struct SetUpLocationDrivenGeotriggersView: View {
                     self.error = error
                 }
             }
-            .task(id: model.fenceGeotriggerStatus) {
-                // Set fence geotrigger text.
-                fenceGeotriggerText = model.fenceGeotriggerStatus.label
-            }
             .overlay(alignment: .top) {
                 // Status text overlay.
                 VStack {
-                    Text(fenceGeotriggerText)
+                    Text(model.fenceGeotriggerStatus.label)
                         .frame(maxWidth: .infinity, alignment: .leading)
                     
                     let nearbyFeatures = model.nearbyFeatures

--- a/Shared/Samples/Show realistic light and shadows/ShowRealisticLightAndShadowsView.swift
+++ b/Shared/Samples/Show realistic light and shadows/ShowRealisticLightAndShadowsView.swift
@@ -22,18 +22,11 @@ struct ShowRealisticLightAndShadowsView: View {
     /// The date second value controlled by the slider.
     @State private var dateSecond: Float = Model.dateSecondsNoon
     
-    /// The formatted text of the date controlled by the slider.
-    @State private var dateTimeText: String = DateFormatter.localizedString(
-        from: .startOfDay.advanced(by: TimeInterval(Model.dateSecondsNoon)),
-        dateStyle: .medium,
-        timeStyle: .short
-    )
-    
     /// The sun lighting mode of the scene view.
     @State private var lightingMode: SceneView.SunLighting = .lightAndShadows
     
     /// The sun date that gets passed into the scene view.
-    @State private var sunDate = Date.startOfDay.advanced(by: TimeInterval(Model.dateSecondsNoon))
+    var sunDate: Date { .startOfDay.advanced(by: TimeInterval(dateSecond)) }
     
     var body: some View {
         VStack {
@@ -50,9 +43,6 @@ struct ShowRealisticLightAndShadowsView: View {
                 Text("PM")
             }
             .frame(maxWidth: 540)
-            .onChange(of: dateSecond) {
-                sliderValueChanged(toValue: dateSecond)
-            }
             .padding(.horizontal)
         }
         .overlay(alignment: .top) {
@@ -71,19 +61,10 @@ struct ShowRealisticLightAndShadowsView: View {
     
     /// An overlay showing the date time adjusted by the slider.
     private var dateTimeOverlay: some View {
-        Text(dateTimeText)
+        Text(sunDate.formatted(date: .abbreviated, time: .shortened))
             .frame(maxWidth: .infinity)
             .padding(.vertical, 6)
             .background(.thinMaterial, ignoresSafeAreaEdges: .horizontal)
-    }
-    
-    /// Handles slider value changed event and set the scene view's sun date.
-    /// - Parameter value: The slider's value.
-    private func sliderValueChanged(toValue value: Float) {
-        // A DateComponents struct to encapsulate the second value from the slider.
-        let dateComponents = DateComponents(second: Int(value))
-        sunDate = Calendar.current.date(byAdding: dateComponents, to: .startOfDay)!
-        dateTimeText = DateFormatter.localizedString(from: sunDate, dateStyle: .medium, timeStyle: .short)
     }
 }
 
@@ -140,7 +121,7 @@ private extension SceneView.SunLighting {
 }
 
 private extension Date {
-    static let startOfDay = Calendar.current.startOfDay(for: .now)
+    static var startOfDay: Self { Calendar.current.startOfDay(for: .now) }
 }
 
 #Preview {

--- a/Shared/Samples/Show realistic light and shadows/ShowRealisticLightAndShadowsView.swift
+++ b/Shared/Samples/Show realistic light and shadows/ShowRealisticLightAndShadowsView.swift
@@ -61,7 +61,7 @@ struct ShowRealisticLightAndShadowsView: View {
     
     /// An overlay showing the date time adjusted by the slider.
     private var dateTimeOverlay: some View {
-        Text(sunDate.formatted(date: .abbreviated, time: .shortened))
+        Text(sunDate, format: Date.FormatStyle(date: .abbreviated, time: .shortened))
             .frame(maxWidth: .infinity)
             .padding(.vertical, 6)
             .background(.thinMaterial, ignoresSafeAreaEdges: .horizontal)


### PR DESCRIPTION
I happened to notice that formatters (subclasses of `Formatter`) are being used in multiple places. But [according to Apple](https://developer.apple.com/documentation/foundation/data-formatting), formatters should only be used in Objective-C. In Swift, format styles should be used instead. This removes uses of formatters by updating the code to use format styles instead.