### PR TITLE
[Fix] Fix segment view 

### DIFF
--- a/Shared/Supporting Files/Views/SampleInfoView.swift
+++ b/Shared/Supporting Files/Views/SampleInfoView.swift
@@ -36,7 +36,7 @@ struct SampleInfoView: View {
         .ignoresSafeArea(edges: [.horizontal, .bottom])
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
-            ToolbarItem(placement: .principal) {
+            ToolbarItem(placement: .automatic) {
                 Picker("Information Mode", selection: $informationMode) {
                     ForEach(InformationMode.allCases, id: \.self) { mode in
                         Text(mode.label)


### PR DESCRIPTION
## Description

Fixes issue where segment bar did not show up on iPhone

<img width="500" height="1087" alt="Simulator Screenshot - iPhone 17 Pro - 2025-11-26 at 20 43 35" src="https://github.com/user-attachments/assets/4d4957ce-4527-47de-821d-336c5cda2b73" />

<img width="417" height="600" alt="Simulator Screenshot - iPad (A16) - 2025-12-01 at 08 13 08" src="https://github.com/user-attachments/assets/0a6e8428-8349-4541-a18e-008ba9b7c68c" />


## Linked Issue
- `swift/issues/7592`
