### PR TITLE
[Fix] Ensure labels update and maintain state instead of resetting

### DIFF
--- a/Shared/Samples/Configure clusters/ConfigureClustersView.Model.swift
+++ b/Shared/Samples/Configure clusters/ConfigureClustersView.Model.swift
@@ -20,7 +20,7 @@ extension ConfigureClustersView {
     /// used in this view.
     @MainActor
     @Observable
-        class Model {
+    class Model {
         /// A Zurich buildings web map.
         let map = Map(
             item: PortalItem(

--- a/Shared/Samples/Configure clusters/ConfigureClustersView.Model.swift
+++ b/Shared/Samples/Configure clusters/ConfigureClustersView.Model.swift
@@ -19,7 +19,8 @@ extension ConfigureClustersView {
     /// The model used to store the geo model and other expensive objects
     /// used in this view.
     @MainActor
-    class Model: ObservableObject {
+    @Observable
+        class Model {
         /// A Zurich buildings web map.
         let map = Map(
             item: PortalItem(

--- a/Shared/Samples/Configure clusters/ConfigureClustersView.SettingsView.swift
+++ b/Shared/Samples/Configure clusters/ConfigureClustersView.SettingsView.swift
@@ -17,7 +17,7 @@ import SwiftUI
 extension ConfigureClustersView {
     struct SettingsView: View {
         /// The model for the sample.
-        @ObservedObject var model: Model
+        @Binding var model: Model
         
         /// The action to dismiss the settings sheet.
         @Environment(\.dismiss) private var dismiss: DismissAction

--- a/Shared/Samples/Configure clusters/ConfigureClustersView.SettingsView.swift
+++ b/Shared/Samples/Configure clusters/ConfigureClustersView.SettingsView.swift
@@ -25,13 +25,6 @@ extension ConfigureClustersView {
         /// The map view's scale.
         let mapViewScale: Double
         
-        /// The radius of feature clusters selected by the user.
-        @State private var selectedRadius = 60
-        
-        /// The maximum scale of feature clusters selected by the user.
-        @State private var selectedMaxScale = 0
-        
-        
         let scales: [Double] = [0, 1000, 5000, 10000, 50000, 100000, 500000]
         
         var body: some View {
@@ -54,10 +47,6 @@ extension ConfigureClustersView {
                                 Text("\(radius)")
                             }
                         }
-//                        .onChange(of: selectedRadius) {
-//                            model.radius = Double(selectedRadius)
-//                        }
-//                        
                         Picker(
                             "Cluster Max Scale",
                             selection: Binding(
@@ -69,9 +58,7 @@ extension ConfigureClustersView {
                                 Text("\(Int(scale))") // show as integer
                             }
                         }
-//                        .onChange(of: selectedMaxScale) {
-//                            model.maxScale = Double(selectedMaxScale)
-//                        }
+
                         
                         LabeledContent(
                             "Current Map Scale",

--- a/Shared/Samples/Configure clusters/ConfigureClustersView.SettingsView.swift
+++ b/Shared/Samples/Configure clusters/ConfigureClustersView.SettingsView.swift
@@ -17,7 +17,7 @@ import SwiftUI
 extension ConfigureClustersView {
     struct SettingsView: View {
         /// The model for the sample.
-        @Binding var model: Model
+        @Bindable var model: Model
         
         /// The action to dismiss the settings sheet.
         @Environment(\.dismiss) private var dismiss: DismissAction
@@ -31,31 +31,19 @@ extension ConfigureClustersView {
             NavigationStack {
                 Form {
                     Section("Cluster Labels Visibility") {
-                        Toggle("Show Labels", isOn: Binding(
-                            get: { model.showsLabels },
-                            set: { model.showsLabels = $0 }
-                        ))
+                        Toggle("Show Labels", isOn: $model.showsLabels)
                             .toggleStyle(.switch)
                     }
                     
                     Section("Clustering Properties") {
-                        Picker("Cluster Radius", selection: Binding(
-                            get: { Int(model.radius) },
-                            set: { model.radius = Double($0) }
-                        )) {
+                        Picker("Cluster Radius", selection: $model.radius) {
                             ForEach([30, 45, 60, 75, 90], id: \.self) { radius in
                                 Text("\(radius)")
                             }
                         }
-                        Picker(
-                            "Cluster Max Scale",
-                            selection: Binding(
-                                get: { model.maxScale },
-                                set: { model.maxScale = $0 }
-                            )
-                        ) {
+                        Picker("Cluster Max Scale", selection: $model.maxScale) {
                             ForEach(scales, id: \.self) { scale in
-                                Text("\(Int(scale))") // show as integer
+                                Text(scale, format: .number)
                             }
                         }
 

--- a/Shared/Samples/Configure clusters/ConfigureClustersView.SettingsView.swift
+++ b/Shared/Samples/Configure clusters/ConfigureClustersView.SettingsView.swift
@@ -31,32 +31,47 @@ extension ConfigureClustersView {
         /// The maximum scale of feature clusters selected by the user.
         @State private var selectedMaxScale = 0
         
+        
+        let scales: [Double] = [0, 1000, 5000, 10000, 50000, 100000, 500000]
+        
         var body: some View {
             NavigationStack {
                 Form {
                     Section("Cluster Labels Visibility") {
-                        Toggle("Show Labels", isOn: $model.showsLabels)
+                        Toggle("Show Labels", isOn: Binding(
+                            get: { model.showsLabels },
+                            set: { model.showsLabels = $0 }
+                        ))
                             .toggleStyle(.switch)
                     }
                     
                     Section("Clustering Properties") {
-                        Picker("Cluster Radius", selection: $selectedRadius) {
+                        Picker("Cluster Radius", selection: Binding(
+                            get: { Int(model.radius) },
+                            set: { model.radius = Double($0) }
+                        )) {
                             ForEach([30, 45, 60, 75, 90], id: \.self) { radius in
                                 Text("\(radius)")
                             }
                         }
-                        .onChange(of: selectedRadius) {
-                            model.radius = Double(selectedRadius)
-                        }
-                        
-                        Picker("Cluster Max Scale", selection: $selectedMaxScale) {
-                            ForEach([0, 1000, 5000, 10000, 50000, 100000, 500000], id: \.self) { scale in
-                                Text(("\(scale)"))
+//                        .onChange(of: selectedRadius) {
+//                            model.radius = Double(selectedRadius)
+//                        }
+//                        
+                        Picker(
+                            "Cluster Max Scale",
+                            selection: Binding(
+                                get: { model.maxScale },
+                                set: { model.maxScale = $0 }
+                            )
+                        ) {
+                            ForEach(scales, id: \.self) { scale in
+                                Text("\(Int(scale))") // show as integer
                             }
                         }
-                        .onChange(of: selectedMaxScale) {
-                            model.maxScale = Double(selectedMaxScale)
-                        }
+//                        .onChange(of: selectedMaxScale) {
+//                            model.maxScale = Double(selectedMaxScale)
+//                        }
                         
                         LabeledContent(
                             "Current Map Scale",

--- a/Shared/Samples/Configure clusters/ConfigureClustersView.SettingsView.swift
+++ b/Shared/Samples/Configure clusters/ConfigureClustersView.SettingsView.swift
@@ -27,6 +27,8 @@ extension ConfigureClustersView {
         
         let scales: [Double] = [0, 1000, 5000, 10000, 50000, 100000, 500000]
         
+        let radii: [Double] = [30, 45, 60, 75, 90]
+        
         var body: some View {
             NavigationStack {
                 Form {
@@ -37,8 +39,8 @@ extension ConfigureClustersView {
                     
                     Section("Clustering Properties") {
                         Picker("Cluster Radius", selection: $model.radius) {
-                            ForEach([30, 45, 60, 75, 90], id: \.self) { radius in
-                                Text("\(radius)")
+                            ForEach(radii, id: \.self) { radius in
+                                Text(radius, format: .number)
                             }
                         }
                         Picker("Cluster Max Scale", selection: $model.maxScale) {

--- a/Shared/Samples/Configure clusters/ConfigureClustersView.SettingsView.swift
+++ b/Shared/Samples/Configure clusters/ConfigureClustersView.SettingsView.swift
@@ -25,9 +25,11 @@ extension ConfigureClustersView {
         /// The map view's scale.
         let mapViewScale: Double
         
-        let scales: [Double] = [0, 1000, 5000, 10000, 50000, 100000, 500000]
-        
+        /// The radius options for feature clusters.
         let radii: [Double] = [30, 45, 60, 75, 90]
+        
+        /// The maximum scale options for feature clusters.
+        let scales: [Double] = [0, 1000, 5000, 10000, 50000, 100000, 500000]
         
         var body: some View {
             NavigationStack {

--- a/Shared/Samples/Configure clusters/ConfigureClustersView.SettingsView.swift
+++ b/Shared/Samples/Configure clusters/ConfigureClustersView.SettingsView.swift
@@ -46,7 +46,6 @@ extension ConfigureClustersView {
                                 Text(scale, format: .number)
                             }
                         }
-
                         
                         LabeledContent(
                             "Current Map Scale",

--- a/Shared/Samples/Configure clusters/ConfigureClustersView.swift
+++ b/Shared/Samples/Configure clusters/ConfigureClustersView.swift
@@ -58,7 +58,7 @@ struct ConfigureClustersView: View {
                             showsSettings = true
                         }
                         .popover(isPresented: $showsSettings) { [mapViewScale] in
-                            SettingsView(model: $model, mapViewScale: mapViewScale)
+                            SettingsView(model: model, mapViewScale: mapViewScale)
                                 .presentationDetents([.fraction(0.5)])
                                 .frame(idealWidth: 320, idealHeight: 340)
                         }

--- a/Shared/Samples/Configure clusters/ConfigureClustersView.swift
+++ b/Shared/Samples/Configure clusters/ConfigureClustersView.swift
@@ -18,7 +18,7 @@ import SwiftUI
 
 struct ConfigureClustersView: View {
     /// The model for the sample.
-    @StateObject private var model = Model()
+    @State private var model = Model()
     
     /// The popup to be shown as the result of the layer identify operation.
     @State private var popup: Popup?
@@ -58,7 +58,7 @@ struct ConfigureClustersView: View {
                             showsSettings = true
                         }
                         .popover(isPresented: $showsSettings) { [mapViewScale] in
-                            SettingsView(model: model, mapViewScale: mapViewScale)
+                            SettingsView(model: $model, mapViewScale: mapViewScale)
                                 .presentationDetents([.fraction(0.5)])
                                 .frame(idealWidth: 320, idealHeight: 340)
                         }


### PR DESCRIPTION
## Description

Fixes issue where labels would not maintain state and would reset to original value after popover was closed.  Previously the selected radius and selected max scale would go back to 0 and 60.

## Linked Issue(s)

- `swift/issues/7561`
