### PR TITLE
[Update] (300.0) Make legacy analysis APIs "Exploratory"

### DIFF
--- a/Shared/Samples/Measure distance in scene/MeasureDistanceInSceneView.swift
+++ b/Shared/Samples/Measure distance in scene/MeasureDistanceInSceneView.swift
@@ -128,7 +128,7 @@ private extension MeasureDistanceInSceneView {
         let analysisOverlay = AnalysisOverlay()
         
         /// The location distance measurement.
-        let locationDistanceMeasurement = LocationDistanceMeasurement(
+        let locationDistanceMeasurement = ExploratoryLocationDistanceMeasurement(
             startLocation: Point(x: -4.494677, y: 48.384472, z: 24.772694, spatialReference: .wgs84),
             endLocation: Point(x: -4.495646, y: 48.384377, z: 58.501115, spatialReference: .wgs84)
         )

--- a/Shared/Samples/Measure distance in scene/README.md
+++ b/Shared/Samples/Measure distance in scene/README.md
@@ -22,11 +22,11 @@ Choose a unit system for the measurement in the segmented control. Tap any locat
 ## Relevant API
 
 * AnalysisOverlay
-* LocationDistanceMeasurement
+* ExploratoryLocationDistanceMeasurement
 
 ## Additional information
 
-The `LocationDistanceMeasurement` analysis only performs planar distance calculations. This may not be appropriate for large distances where the Earth's curvature must be considered.
+The `ExploratoryLocationDistanceMeasurement` analysis only performs planar distance calculations. This may not be appropriate for large distances where the Earth's curvature must be considered.
 
 ## Tags
 

--- a/Shared/Samples/Measure distance in scene/README.md
+++ b/Shared/Samples/Measure distance in scene/README.md
@@ -15,7 +15,7 @@ Choose a unit system for the measurement in the segmented control. Tap any locat
 ## How it works
 
 1. Create an `AnalysisOverlay` object and add it to the analysis overlay collection of the `SceneView` object.
-2. Specify the start location and end location to create a `LocationDistanceMeasurement` object. Initially, the start and end locations can be the same point.
+2. Specify the start location and end location to create a `ExploratoryLocationDistanceMeasurement` object. Initially, the start and end locations can be the same point.
 3. Add the location distance measurement analysis to the analysis overlay.
 4. Use the `for-await-in` syntax to get the measurements updates from `locationDistanceMeasurement.measurements` asynchronous stream. You can get the new values for the `directDistance`, `horizontalDistance`, and `verticalDistance` from the measurements update.
 

--- a/Shared/Samples/Measure distance in scene/README.md
+++ b/Shared/Samples/Measure distance in scene/README.md
@@ -15,7 +15,7 @@ Choose a unit system for the measurement in the segmented control. Tap any locat
 ## How it works
 
 1. Create an `AnalysisOverlay` object and add it to the analysis overlay collection of the `SceneView` object.
-2. Specify the start location and end location to create a `ExploratoryLocationDistanceMeasurement` object. Initially, the start and end locations can be the same point.
+2. Specify the start location and end location to create an `ExploratoryLocationDistanceMeasurement` object. Initially, the start and end locations can be the same point.
 3. Add the location distance measurement analysis to the analysis overlay.
 4. Use the `for-await-in` syntax to get the measurements updates from `locationDistanceMeasurement.measurements` asynchronous stream. You can get the new values for the `directDistance`, `horizontalDistance`, and `verticalDistance` from the measurements update.
 

--- a/Shared/Samples/Measure distance in scene/README.metadata.json
+++ b/Shared/Samples/Measure distance in scene/README.metadata.json
@@ -11,12 +11,12 @@
         "distance",
         "measure",
         "AnalysisOverlay",
-        "LocationDistanceMeasurement"
+        "ExploratoryLocationDistanceMeasurement"
     ],
     "redirect_from": [],
     "relevant_apis": [
         "AnalysisOverlay",
-        "LocationDistanceMeasurement"
+        "ExploratoryLocationDistanceMeasurement"
     ],
     "snippets": [
         "MeasureDistanceInSceneView.swift"

--- a/Shared/Samples/Show line of sight between geoelements/README.md
+++ b/Shared/Samples/Show line of sight between geoelements/README.md
@@ -8,7 +8,7 @@ Show a line of sight between two moving objects.
 
 A line of sight between `GeoElement`s (i.e. observer and target) will not remain constant whilst one or both are on the move.
 
-A `ExploratoryGeoElementLineOfSight` is therefore useful in cases where visibility between two `GeoElement`s requires monitoring over a period of time in a partially obstructed field of view (such as buildings in a city).
+An `ExploratoryGeoElementLineOfSight` is therefore useful in cases where visibility between two `GeoElement`s requires monitoring over a period of time in a partially obstructed field of view (such as buildings in a city).
 
 ## How to use the sample
 
@@ -17,7 +17,7 @@ A line of sight will display between a point on the Empire State Building (obser
 ## How it works
 
 1. Instantiate an `AnalysisOverlay` and add it to the `SceneView`'s analysis overlays collection.
-2. Instantiate a `ExploratoryGeoElementLineOfSight`, passing in observer and target `GeoElement`s (features or graphics). Add the line of sight to the analysis overlay's analyses collection.
+2. Instantiate an `ExploratoryGeoElementLineOfSight`, passing in observer and target `GeoElement`s (features or graphics). Add the line of sight to the analysis overlay's analyses collection.
 3. To get the target visibility when it changes, react to the target visibility changing on the `ExploratoryGeoElementLineOfSight` instance.
 
 ## Relevant API

--- a/Shared/Samples/Show line of sight between geoelements/README.md
+++ b/Shared/Samples/Show line of sight between geoelements/README.md
@@ -8,7 +8,7 @@ Show a line of sight between two moving objects.
 
 A line of sight between `GeoElement`s (i.e. observer and target) will not remain constant whilst one or both are on the move.
 
-A `GeoElementLineOfSight` is therefore useful in cases where visibility between two `GeoElement`s requires monitoring over a period of time in a partially obstructed field of view (such as buildings in a city).
+A `ExploratoryGeoElementLineOfSight` is therefore useful in cases where visibility between two `GeoElement`s requires monitoring over a period of time in a partially obstructed field of view (such as buildings in a city).
 
 ## How to use the sample
 
@@ -17,14 +17,14 @@ A line of sight will display between a point on the Empire State Building (obser
 ## How it works
 
 1. Instantiate an `AnalysisOverlay` and add it to the `SceneView`'s analysis overlays collection.
-2. Instantiate a `GeoElementLineOfSight`, passing in observer and target `GeoElement`s (features or graphics). Add the line of sight to the analysis overlay's analyses collection.
-3. To get the target visibility when it changes, react to the target visibility changing on the `GeoElementLineOfSight` instance.
+2. Instantiate a `ExploratoryGeoElementLineOfSight`, passing in observer and target `GeoElement`s (features or graphics). Add the line of sight to the analysis overlay's analyses collection.
+3. To get the target visibility when it changes, react to the target visibility changing on the `ExploratoryGeoElementLineOfSight` instance.
 
 ## Relevant API
 
 * AnalysisOverlay
-* GeoElementLineOfSight
-* LineOfSight.TargetVisibility
+* ExploratoryGeoElementLineOfSight
+* ExploratoryGeoElementLineOfSight.TargetVisibility
 
 ## Offline data
 

--- a/Shared/Samples/Show line of sight between geoelements/README.metadata.json
+++ b/Shared/Samples/Show line of sight between geoelements/README.metadata.json
@@ -11,8 +11,8 @@
         "visibility",
         "visibility analysis",
         "AnalysisOverlay",
-        "GeoElementLineOfSight",
-        "LineOfSight.TargetVisibility"
+        "ExploratoryGeoElementLineOfSight",
+        "ExploratoryGeoElementLineOfSight.TargetVisibility"
     ],
     "redirect_from": [],
     "offline_data": [
@@ -20,8 +20,8 @@
     ],
     "relevant_apis": [
         "AnalysisOverlay",
-        "GeoElementLineOfSight",
-        "LineOfSight.TargetVisibility"
+        "ExploratoryGeoElementLineOfSight",
+        "ExploratoryGeoElementLineOfSight.TargetVisibility"
     ],
     "snippets": [
         "ShowLineOfSightBetweenGeoelementsView.swift"

--- a/Shared/Samples/Show line of sight between geoelements/ShowLineOfSightBetweenGeoelementsView.swift
+++ b/Shared/Samples/Show line of sight between geoelements/ShowLineOfSightBetweenGeoelementsView.swift
@@ -171,7 +171,7 @@ private extension ShowLineOfSightBetweenGeoelementsView {
         let analysisOverlay = AnalysisOverlay()
         
         /// A line of sight analysis between the observer and the taxi graphic.
-        private let lineOfSight: GeoElementLineOfSight
+        private let lineOfSight: ExploratoryGeoElementLineOfSight
         
         /// A graphic representing the taxi model that will be animated.
         private let taxiGraphic: Graphic = {
@@ -201,11 +201,11 @@ private extension ShowLineOfSightBetweenGeoelementsView {
         @ObservationIgnored private var displayLink: CADisplayLink!
         
         /// The target visibility of the taxi graphic from the point of view of the observer.
-        var targetVisibility: GeoElementLineOfSight.TargetVisibility = .unknown
+        var targetVisibility: ExploratoryGeoElementLineOfSight.TargetVisibility = .unknown
         
         init() {
             graphicsOverlay.addGraphics([observerGraphic, taxiGraphic])
-            lineOfSight = GeoElementLineOfSight(observer: observerGraphic, target: taxiGraphic)
+            lineOfSight = ExploratoryGeoElementLineOfSight(observer: observerGraphic, target: taxiGraphic)
             lineOfSight.targetOffsetZ = 2
             analysisOverlay.addAnalysis(lineOfSight)
         }
@@ -289,7 +289,7 @@ private extension ShowLineOfSightBetweenGeoelementsView {
     }
 }
 
-private extension GeoElementLineOfSight.TargetVisibility {
+private extension ExploratoryGeoElementLineOfSight.TargetVisibility {
     /// A human-readable label for each target visibility.
     var label: String {
         switch self {

--- a/Shared/Samples/Show line of sight between points/README.md
+++ b/Shared/Samples/Show line of sight between points/README.md
@@ -15,14 +15,14 @@ Tap on the map to set the observer location. Tap and hold to set the line of sig
 ## How it works
 
 1. Create an `AnalysisOverlay` and add it to the scene view.
-2. Create a `LocationLineOfSight` with initial observer and target locations and add it to the analysis overlay.
+2. Create an `ExploratoryLocationLineOfSight` with initial observer and target locations and add it to the analysis overlay.
 3. Track the screen taps using the `onSingleTapGesture` and `onLongPressGesture`.
 4. Use the scene point to update the target location with `lineOfSight.targetLocation` and the observer location with `lineOfSight.observerLocation`.
 
 ## Relevant API
 
 * AnalysisOverlay
-* LocationLineOfSight
+* ExploratoryLocationLineOfSight
 * SceneView
 
 ## Tags

--- a/Shared/Samples/Show line of sight between points/README.metadata.json
+++ b/Shared/Samples/Show line of sight between points/README.metadata.json
@@ -11,13 +11,13 @@
         "visibility",
         "visibility analysis",
         "AnalysisOverlay",
-        "LocationLineOfSight",
+        "ExploratoryLocationLineOfSight",
         "SceneView"
     ],
     "redirect_from": [],
     "relevant_apis": [
         "AnalysisOverlay",
-        "LocationLineOfSight",
+        "ExploratoryLocationLineOfSight",
         "SceneView"
     ],
     "snippets": [

--- a/Shared/Samples/Show line of sight between points/ShowLineOfSightBetweenPointsView.swift
+++ b/Shared/Samples/Show line of sight between points/ShowLineOfSightBetweenPointsView.swift
@@ -37,7 +37,7 @@ struct ShowLineOfSightBetweenPointsView: View {
     @State private var analysisOverlay = AnalysisOverlay()
     
     /// The line of sight analysis.
-    @State private var lineOfSight: LocationLineOfSight?
+    @State private var lineOfSight: ExploratoryLocationLineOfSight?
     
     /// A Boolean value indicating whether to show the target instructions.
     @State private var shouldShowTargetInstruction = false
@@ -49,7 +49,7 @@ struct ShowLineOfSightBetweenPointsView: View {
                 guard let scenePoint else { return }
                 if lineOfSight == nil {
                     // Create and set initial line of sight analysis with tapped scene point.
-                    lineOfSight = LocationLineOfSight(observerLocation: scenePoint, targetLocation: scenePoint)
+                    lineOfSight = ExploratoryLocationLineOfSight(observerLocation: scenePoint, targetLocation: scenePoint)
                     analysisOverlay.addAnalysis(lineOfSight!)
                     shouldShowTargetInstruction = true
                 } else {

--- a/Shared/Samples/Show viewshed from camera in scene/README.md
+++ b/Shared/Samples/Show viewshed from camera in scene/README.md
@@ -15,7 +15,7 @@ The sample will start with a viewshed created from the initial camera location, 
 ## How it works
 
 1. Get the current camera.
-2. Create a `LocationViewshed`, passing in the `Camera` and a min/max distance.
+2. Create an `ExploratoryLocationViewshed`, passing in the `Camera` and a min/max distance.
 3. Update the viewshed from a camera.
 
 ## Relevant API
@@ -23,8 +23,8 @@ The sample will start with a viewshed created from the initial camera location, 
 * AnalysisOverlay
 * ArcGISTiledElevationSource
 * Camera
+* ExploratoryLocationViewshed
 * IntegratedMeshLayer
-* LocationViewshed
 * Scene
 * SceneView
 

--- a/Shared/Samples/Show viewshed from camera in scene/README.metadata.json
+++ b/Shared/Samples/Show viewshed from camera in scene/README.metadata.json
@@ -13,8 +13,8 @@
         "AnalysisOverlay",
         "ArcGISTiledElevationSource",
         "Camera",
+        "ExploratoryLocationViewshed",
         "IntegratedMeshLayer",
-        "LocationViewshed",
         "Scene",
         "SceneView"
     ],
@@ -23,8 +23,8 @@
         "AnalysisOverlay",
         "ArcGISTiledElevationSource",
         "Camera",
+        "ExploratoryLocationViewshed",
         "IntegratedMeshLayer",
-        "LocationViewshed",
         "Scene",
         "SceneView"
     ],

--- a/Shared/Samples/Show viewshed from camera in scene/ShowViewshedFromCameraInSceneView.swift
+++ b/Shared/Samples/Show viewshed from camera in scene/ShowViewshedFromCameraInSceneView.swift
@@ -20,7 +20,7 @@ struct ShowViewshedFromCameraInSceneView: View {
     @State private var camera: Camera?
     
     /// The viewshed which is updated by the camera.
-    @State private var viewshed: LocationViewshed
+    @State private var viewshed: ExploratoryLocationViewshed
     
     /// A 3D Scene setup with imagery basemap, elevation, and mesh layer.
     @State private var scene: ArcGIS.Scene = {
@@ -55,15 +55,15 @@ struct ShowViewshedFromCameraInSceneView: View {
         )
         self.camera = camera
         
-        self.viewshed = LocationViewshed(
+        self.viewshed = ExploratoryLocationViewshed(
             camera: camera,
             minDistance: 1.0,
             maxDistance: 1_000.0
         )
         
         // Set visual appearance of the viewshed.
-        Viewshed.visibleColor = .green.withAlphaComponent(0.5)
-        Viewshed.obstructedColor = .red.withAlphaComponent(0.5)
+        ExploratoryViewshed.visibleColor = .green.withAlphaComponent(0.5)
+        ExploratoryViewshed.obstructedColor = .red.withAlphaComponent(0.5)
         
         // Add the new viewshed to the overlay.
         analysisOverlay.addAnalysis(viewshed)

--- a/Shared/Samples/Show viewshed from geoelement in scene/README.md
+++ b/Shared/Samples/Show viewshed from geoelement in scene/README.md
@@ -17,15 +17,15 @@ Tap to set a destination for the vehicle (a `GeoElement`). The vehicle will 'dri
 1. Create and show the scene, with an elevation source and a buildings layer.
 2. Add a model (the `GeoElement`) to represent the observer (in this case, a tank).
     * Use a `SimpleRenderer` which has a heading expression set in the `GraphicsOverlay`. This way you can relate the viewshed's heading to the `GeoElement` object's heading.
-3. Create a `GeoElementViewshed` with configuration for the viewshed analysis.
+3. Create an `ExploratoryGeoElementViewshed` with configuration for the viewshed analysis.
 4. Add the viewshed to an `AnalysisOverlay` and add the overlay to the scene.
 5. Configure the SceneView `CameraController` to orbit the vehicle.
 
 ## Relevant API
 
 * AnalysisOverlay
+* ExploratoryGeoElementViewshed
 * GeodeticDistanceResult
-* GeoElementViewshed
 * ModelSceneSymbol
 * OrbitGeoElementCameraController
 * static GeometryEngine.geodeticDistance(from:to:distanceUnit:azimuthUnit:curveType:)

--- a/Shared/Samples/Show viewshed from geoelement in scene/README.metadata.json
+++ b/Shared/Samples/Show viewshed from geoelement in scene/README.metadata.json
@@ -14,7 +14,7 @@
         "viewshed",
         "visibility analysis",
         "AnalysisOverlay",
-        "GeoElementViewshed",
+        "ExploratoryGeoElementViewshed",
         "GeodeticDistanceResult",
         "ModelSceneSymbol",
         "OrbitGeoElementCameraController",
@@ -26,7 +26,7 @@
     "redirect_from": [],
     "relevant_apis": [
         "AnalysisOverlay",
-        "GeoElementViewshed",
+        "ExploratoryGeoElementViewshed",
         "GeodeticDistanceResult",
         "ModelSceneSymbol",
         "OrbitGeoElementCameraController",

--- a/Shared/Samples/Show viewshed from geoelement in scene/ShowViewshedFromGeoelementInSceneView.swift
+++ b/Shared/Samples/Show viewshed from geoelement in scene/ShowViewshedFromGeoelementInSceneView.swift
@@ -119,7 +119,7 @@ private extension ShowViewshedFromGeoelementInSceneView {
             graphicsOverlay.addGraphic(tankGraphic)
             
             // Create a viewshed to attach to the tank.
-            let geoElementViewshed = GeoElementViewshed(
+            let geoElementViewshed = ExploratoryGeoElementViewshed(
                 geoElement: tankGraphic,
                 horizontalAngle: 90,
                 verticalAngle: 40,

--- a/Shared/Samples/Show viewshed from point in scene/README.md
+++ b/Shared/Samples/Show viewshed from point in scene/README.md
@@ -16,7 +16,7 @@ Tap on the map to add an observer location. Use the sliders to change the proper
 
 ## How it works
 
-1. Create a `LocationViewshed` passing in the observer location, heading, pitch, horizontal/vertical angles, and min/max distances.
+1. Create an `ExploratoryLocationViewshed` passing in the observer location, heading, pitch, horizontal/vertical angles, and min/max distances.
 2. Set the property values on the viewshed instance for location, direction, range, and visibility properties.
 
 ## Relevant API
@@ -24,8 +24,8 @@ Tap on the map to add an observer location. Use the sliders to change the proper
 * AnalysisOverlay
 * ArcGISSceneLayer
 * ArcGISTiledElevationSource
-* LocationViewshed
-* Viewshed
+* ExploratoryLocationViewshed
+* ExploratoryViewshed
 
 ## About the data
 

--- a/Shared/Samples/Show viewshed from point in scene/README.metadata.json
+++ b/Shared/Samples/Show viewshed from point in scene/README.metadata.json
@@ -14,16 +14,16 @@
         "AnalysisOverlay",
         "ArcGISSceneLayer",
         "ArcGISTiledElevationSource",
-        "LocationViewshed",
-        "Viewshed"
+        "ExploratoryLocationViewshed",
+        "ExploratoryViewshed"
     ],
     "redirect_from": [],
     "relevant_apis": [
         "AnalysisOverlay",
         "ArcGISSceneLayer",
         "ArcGISTiledElevationSource",
-        "LocationViewshed",
-        "Viewshed"
+        "ExploratoryLocationViewshed",
+        "ExploratoryViewshed"
     ],
     "snippets": [
         "ShowViewshedFromPointInSceneView.swift",

--- a/Shared/Samples/Show viewshed from point in scene/ShowViewshedFromPointInSceneView.Model.swift
+++ b/Shared/Samples/Show viewshed from point in scene/ShowViewshedFromPointInSceneView.Model.swift
@@ -20,7 +20,7 @@ extension ShowViewshedFromPointInSceneView {
     /// used in this view.
     class Model: ObservableObject {
         /// The location viewshed used in the sample.
-        let viewshed: LocationViewshed
+        let viewshed: ExploratoryLocationViewshed
         
         /// An analysis overlay that contains a location viewshed analysis.
         let analysisOverlay: AnalysisOverlay
@@ -29,23 +29,23 @@ extension ShowViewshedFromPointInSceneView {
         let scene = makeScene()
         
         /// The color used to display non-visible areas of a viewshed.
-        @Published var obstructedAreaColor = Color(uiColor: Viewshed.obstructedColor) {
+        @Published var obstructedAreaColor = Color(uiColor: ExploratoryViewshed.obstructedColor) {
             didSet {
-                Viewshed.obstructedColor = UIColor(obstructedAreaColor)
+                ExploratoryViewshed.obstructedColor = UIColor(obstructedAreaColor)
             }
         }
         
         /// The color used to display visible areas of a viewshed.
-        @Published var visibleColor = Color(uiColor: Viewshed.visibleColor) {
+        @Published var visibleColor = Color(uiColor: ExploratoryViewshed.visibleColor) {
             didSet {
-                Viewshed.visibleColor = UIColor(visibleColor)
+                ExploratoryViewshed.visibleColor = UIColor(visibleColor)
             }
         }
         
         /// The color used to render the frustum outline.
-        @Published var frustumOutlineColor = Color(uiColor: Viewshed.frustumOutlineColor) {
+        @Published var frustumOutlineColor = Color(uiColor: ExploratoryViewshed.frustumOutlineColor) {
             didSet {
-                Viewshed.frustumOutlineColor = UIColor(frustumOutlineColor)
+                ExploratoryViewshed.frustumOutlineColor = UIColor(frustumOutlineColor)
             }
         }
         
@@ -109,7 +109,7 @@ extension ShowViewshedFromPointInSceneView {
         }
         
         init() {
-            self.viewshed = LocationViewshed(
+            self.viewshed = ExploratoryLocationViewshed(
                 location: Point(x: -4.50, y: 48.4, z: 100, spatialReference: .wgs84),
                 heading: 20,
                 pitch: 70,


### PR DESCRIPTION
## Description

This PR adds the "Exploratory" prefix to many legacy spatial analysis APIs in `Analysis` category.

## Linked Issue(s)

- `swift/issues/7878`

## How To Test

- Use the latest daily build 4895, build and see no error or warnings
- Read through the README changes and make sure they still read correct

