### PR TITLE
[Fix] Add in max scale on downloaded to prevent requesting too many tiles. 

### DIFF
--- a/Shared/Samples/Generate offline map/GenerateOfflineMapView.swift
+++ b/Shared/Samples/Generate offline map/GenerateOfflineMapView.swift
@@ -159,6 +159,8 @@ private extension GenerateOfflineMapView {
         init() {
             // Initializes the online map.
             onlineMap = Map(item: napervillePortalItem)
+            // Sets the min scale to avoid requesting a huge download.
+            onlineMap.minScale = 1e4
         }
         
         deinit {
@@ -182,7 +184,8 @@ private extension GenerateOfflineMapView {
             let parameters = try await offlineMapTask.makeDefaultGenerateOfflineMapParameters(areaOfInterest: areaOfInterest)
             // Limit the levels of detail to reduce tile count.
             // This prevents requesting too many tiles from the service.
-            parameters.maxScale = 2e4
+            parameters.minScale = 2e4
+            parameters.maxScale = 1e4
             return parameters
         }
         

--- a/Shared/Samples/Generate offline map/GenerateOfflineMapView.swift
+++ b/Shared/Samples/Generate offline map/GenerateOfflineMapView.swift
@@ -160,7 +160,12 @@ private extension GenerateOfflineMapView {
             // Initializes the online map.
             onlineMap = Map(item: napervillePortalItem)
             // Sets the min scale to avoid requesting a huge download.
+            // Use a more conservative scale on iPad due to larger screen size.
+            #if os(iOS)
+            onlineMap.minScale = UIDevice.current.userInterfaceIdiom == .pad ? 5e4 : 1e4
+            #else
             onlineMap.minScale = 1e4
+            #endif
         }
         
         deinit {

--- a/Shared/Samples/Generate offline map/GenerateOfflineMapView.swift
+++ b/Shared/Samples/Generate offline map/GenerateOfflineMapView.swift
@@ -159,8 +159,6 @@ private extension GenerateOfflineMapView {
         init() {
             // Initializes the online map.
             onlineMap = Map(item: napervillePortalItem)
-            // Sets the min scale to avoid requesting a huge download.
-            onlineMap.minScale = 1e4
         }
         
         deinit {

--- a/Shared/Samples/Generate offline map/GenerateOfflineMapView.swift
+++ b/Shared/Samples/Generate offline map/GenerateOfflineMapView.swift
@@ -160,7 +160,7 @@ private extension GenerateOfflineMapView {
             // Initializes the online map.
             onlineMap = Map(item: napervillePortalItem)
             // Sets the min scale to avoid requesting a huge download.
-            onlineMap.minScale = 1e4
+            onlineMap.minScale = 5000
         }
         
         deinit {
@@ -181,12 +181,7 @@ private extension GenerateOfflineMapView {
         /// - Returns: A `GenerateOfflineMapParameters` if there are no errors.
         private func makeGenerateOfflineMapParameters(areaOfInterest: Envelope) async throws -> GenerateOfflineMapParameters {
             // Returns the default parameters for the offline map task.
-            let parameters = try await offlineMapTask.makeDefaultGenerateOfflineMapParameters(areaOfInterest: areaOfInterest)
-            // Limit the levels of detail to reduce tile count.
-            // This prevents requesting too many tiles from the service.
-            parameters.minScale = 2e4
-            parameters.maxScale = 1e4
-            return parameters
+            return try await offlineMapTask.makeDefaultGenerateOfflineMapParameters(areaOfInterest: areaOfInterest)
         }
         
         /// Generates the offline map.

--- a/Shared/Samples/Generate offline map/GenerateOfflineMapView.swift
+++ b/Shared/Samples/Generate offline map/GenerateOfflineMapView.swift
@@ -159,6 +159,8 @@ private extension GenerateOfflineMapView {
         init() {
             // Initializes the online map.
             onlineMap = Map(item: napervillePortalItem)
+            // Sets the min scale to avoid requesting a huge download.
+            onlineMap.minScale = 1e4
         }
         
         deinit {

--- a/Shared/Samples/Generate offline map/GenerateOfflineMapView.swift
+++ b/Shared/Samples/Generate offline map/GenerateOfflineMapView.swift
@@ -159,13 +159,6 @@ private extension GenerateOfflineMapView {
         init() {
             // Initializes the online map.
             onlineMap = Map(item: napervillePortalItem)
-            // Sets the min scale to avoid requesting a huge download.
-            // Use a more conservative scale on iPad due to larger screen size.
-            #if os(iOS)
-            onlineMap.minScale = UIDevice.current.userInterfaceIdiom == .pad ? 5e4 : 1e4
-            #else
-            onlineMap.minScale = 1e4
-            #endif
         }
         
         deinit {
@@ -186,7 +179,11 @@ private extension GenerateOfflineMapView {
         /// - Returns: A `GenerateOfflineMapParameters` if there are no errors.
         private func makeGenerateOfflineMapParameters(areaOfInterest: Envelope) async throws -> GenerateOfflineMapParameters {
             // Returns the default parameters for the offline map task.
-            return try await offlineMapTask.makeDefaultGenerateOfflineMapParameters(areaOfInterest: areaOfInterest)
+            let parameters = try await offlineMapTask.makeDefaultGenerateOfflineMapParameters(areaOfInterest: areaOfInterest)
+            // Limit the levels of detail to reduce tile count.
+            // This prevents requesting too many tiles from the service.
+            parameters.maxScale = 2e4
+            return parameters
         }
         
         /// Generates the offline map.

--- a/Shared/Samples/Generate offline map/GenerateOfflineMapView.swift
+++ b/Shared/Samples/Generate offline map/GenerateOfflineMapView.swift
@@ -32,6 +32,9 @@ struct GenerateOfflineMapView: View {
         GeometryReader { geometry in
             MapViewReader { mapView in
                 MapView(map: model.offlineMap ?? model.onlineMap)
+                    .onScaleChanged { scale in
+                        model.mapViewScale = scale
+                    }
                     .interactionModes(isGeneratingOfflineMap ? [] : [.pan, .zoom])
                     .errorAlert(presentingError: $error)
                     .task {
@@ -141,6 +144,9 @@ private extension GenerateOfflineMapView {
         /// The generate offline map job.
         @Published private(set) var generateOfflineMapJob: GenerateOfflineMapJob!
         
+        /// The current scale of the map view.
+        @Published var mapViewScale: Double = 0
+        
         /// The offline map task.
         private var offlineMapTask: OfflineMapTask!
         
@@ -159,8 +165,6 @@ private extension GenerateOfflineMapView {
         init() {
             // Initializes the online map.
             onlineMap = Map(item: napervillePortalItem)
-            // Sets the min scale to avoid requesting a huge download.
-            onlineMap.minScale = 5000
         }
         
         deinit {
@@ -181,7 +185,12 @@ private extension GenerateOfflineMapView {
         /// - Returns: A `GenerateOfflineMapParameters` if there are no errors.
         private func makeGenerateOfflineMapParameters(areaOfInterest: Envelope) async throws -> GenerateOfflineMapParameters {
             // Returns the default parameters for the offline map task.
-            return try await offlineMapTask.makeDefaultGenerateOfflineMapParameters(areaOfInterest: areaOfInterest)
+            let parameters = try await offlineMapTask.makeDefaultGenerateOfflineMapParameters(areaOfInterest: areaOfInterest)
+            if mapViewScale > 0 {
+                parameters.maxScale = mapViewScale / 2
+                parameters.minScale = mapViewScale * 2
+            }
+            return parameters
         }
         
         /// Generates the offline map.


### PR DESCRIPTION
## Description
This PR fixes an issue in the Generate Offline Maps sample where the request throws error because too many times are requested

## Linked Issue(s)

- `swift/issues/7706`

