### PR TITLE
[Fix] Remove CODE_SIGN_ENTITLEMENTS

### DIFF
--- a/Samples.xcodeproj/project.pbxproj
+++ b/Samples.xcodeproj/project.pbxproj
@@ -5091,7 +5091,6 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_ENTITLEMENTS = macOS/Samples.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
@@ -5121,7 +5120,6 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_ENTITLEMENTS = macOS/Samples.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;


### PR DESCRIPTION
## Description

This PR removes redundant `CODE_SIGN_ENTITLEMENTS` setting from the project file after #754 forgot to do so.

I was switching to another branch yesterday, so discarded all changes, but forgot to add this back after I created the PR 🤥 