### PR TITLE
[Fix] 300.0.0 verification issues

### DIFF
--- a/Shared/Samples/Filter building scene layer/FilterBuildingSceneLayerView.BuildingGroupSublayerToggleView.swift
+++ b/Shared/Samples/Filter building scene layer/FilterBuildingSceneLayerView.BuildingGroupSublayerToggleView.swift
@@ -33,11 +33,17 @@ extension FilterBuildingSceneLayerView {
                         // for its sublayers should be disabled.
                         .disabled(!isVisible)
                 }
+#if targetEnvironment(macCatalyst)
+                .padding(.horizontal, 4)
+#endif
             } label: {
                 Toggle(groupSublayer.name, isOn: $isVisible)
                     .onChange(of: isVisible) {
                         groupSublayer.isVisible = isVisible
                     }
+#if targetEnvironment(macCatalyst)
+                    .padding(.horizontal, 4)
+#endif
             }
             .onAppear {
                 // Sets the value of the toggle to the

--- a/Shared/Samples/Show device location with NMEA data sources/ShowDeviceLocationWithNMEADataSourcesView.swift
+++ b/Shared/Samples/Show device location with NMEA data sources/ShowDeviceLocationWithNMEADataSourcesView.swift
@@ -267,7 +267,7 @@ private extension NMEAGNSSSystem {
             return "The Quasi-Zenith Satellite System"
         case .navIC:
             return "The Navigation Indian Constellation"
-        default:
+        @unknown default:
             return "Unknown GNSS type"
         }
     }


### PR DESCRIPTION
## Description

This PR fixes some minor issues noticed while working on the 300.0.0 release checklist:
- `Filter building scene layer`: Added padding between the chevrons and toggles in the "Disciplines & Categories"  disclosure group on Mac Catalyst.
- `Show device location with NMEA data sources`: Resolved a `Default will never be executed` warning.

## Linked Issue(s)

- `swift/issues/7901`

## Screenshots

|Before|After|
|:-:|:-:|
| <img width="1193" height="905" alt="Screenshot 2026-04-06 at 11 14 08 AM" src="https://github.com/user-attachments/assets/d747ba2d-f6ea-4bdd-a486-cd01774f837d" /> | <img width="1193" height="905" alt="Screenshot 2026-04-06 at 11 21 19 AM" src="https://github.com/user-attachments/assets/f14ab6a0-f035-4103-8b0e-355c904d31b3" /> |



