### PR TITLE
[Update] Replace Portland buildings data in Add scene layer from service sample

### DIFF
--- a/Shared/Samples/Add scene layer from service/AddSceneLayerFromServiceView.swift
+++ b/Shared/Samples/Add scene layer from service/AddSceneLayerFromServiceView.swift
@@ -19,7 +19,7 @@ struct AddSceneLayerFromServiceView: View {
     /// A scene with an imagery basemap and a 3D buildings layer.
     @State private var scene: ArcGIS.Scene = {
         // Creates a scene layer using a URL to a scene layer service.
-        let sceneLayer = ArcGISSceneLayer(url: .portlandBuildingService)
+        let sceneLayer = ArcGISSceneLayer(url: .buildingService)
         
         // Creates a scene and adds the scene layer to its operational layers.
         let scene = Scene(basemapStyle: .arcGISImagery)
@@ -30,8 +30,8 @@ struct AddSceneLayerFromServiceView: View {
         scene.baseSurface.addElevationSource(elevationSource)
         
         // Sets the scene's initial viewpoint to center the scene view on the scene layer.
-        let point = Point(x: -122.66949, y: 45.51869, z: 227, spatialReference: .wgs84)
-        let camera = Camera(location: point, heading: 219, pitch: 82, roll: 0)
+        let point = Point(x: -122.670, y: 45.517, z: 175.0, spatialReference: .wgs84)
+        let camera = Camera(location: point, heading: 215, pitch: 75, roll: 0)
         let viewpoint = Viewpoint(latitude: .nan, longitude: .nan, scale: .nan, camera: camera)
         scene.initialViewpoint = viewpoint
         
@@ -45,9 +45,9 @@ struct AddSceneLayerFromServiceView: View {
 }
 
 private extension URL {
-    /// The URL of a scene service containing buildings in Portland, OR, USA.
-    static var portlandBuildingService: URL {
-        URL(string: "https://tiles.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/Buildings_Portland/SceneServer")!
+    /// The URL of a scene service containing global buildings.
+    static var buildingService: URL {
+        URL(string: "https://basemaps3d.arcgis.com/arcgis/rest/services/Esri3D_Buildings_v1/SceneServer")!
     }
     
     /// The URL of the Terrain 3D ArcGIS REST Service.

--- a/Shared/Samples/Add scene layer from service/AddSceneLayerFromServiceView.swift
+++ b/Shared/Samples/Add scene layer from service/AddSceneLayerFromServiceView.swift
@@ -46,7 +46,7 @@ struct AddSceneLayerFromServiceView: View {
 
 private extension URL {
     /// The URL of a scene service containing global buildings.
-    static var buildingService: URL {
+    static var buildingsService: URL {
         URL(string: "https://basemaps3d.arcgis.com/arcgis/rest/services/Esri3D_Buildings_v1/SceneServer")!
     }
     

--- a/Shared/Samples/Add scene layer from service/AddSceneLayerFromServiceView.swift
+++ b/Shared/Samples/Add scene layer from service/AddSceneLayerFromServiceView.swift
@@ -19,7 +19,7 @@ struct AddSceneLayerFromServiceView: View {
     /// A scene with an imagery basemap and a 3D buildings layer.
     @State private var scene: ArcGIS.Scene = {
         // Creates a scene layer using a URL to a scene layer service.
-        let sceneLayer = ArcGISSceneLayer(url: .buildingService)
+        let sceneLayer = ArcGISSceneLayer(url: .buildingsService)
         
         // Creates a scene and adds the scene layer to its operational layers.
         let scene = Scene(basemapStyle: .arcGISImagery)

--- a/Shared/Samples/Add scene layer from service/README.md
+++ b/Shared/Samples/Add scene layer from service/README.md
@@ -30,7 +30,7 @@ Pan and zoom to explore the scene.
 
 ## About the data
 
-This sample shows a [Portland, Oregon USA Scene](https://www.arcgis.com/home/item.html?id=2b721b9e7bef45e2b7ff78a398a33acc) hosted on ArcGIS Online.
+This sample shows data from [Esri 3D Buildings](https://www.arcgis.com/home/item.html?id=b8fec5af7dfe4866b1b8ac2d2800f282) in Portland, Oregon.
 
 ## Tags
 

--- a/Shared/Samples/Show exploratory line of sight between geoelements/ShowExploratoryLineOfSightBetweenGeoelementsView.swift
+++ b/Shared/Samples/Show exploratory line of sight between geoelements/ShowExploratoryLineOfSightBetweenGeoelementsView.swift
@@ -318,7 +318,7 @@ private extension Geometry {
     }
 }
 
-extension URL {
+private extension URL {
     /// The URL of the Terrain 3D ArcGIS REST Service.
     static var elevationService: URL {
         URL(string: "https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer")!


### PR DESCRIPTION
## Description

This PR updates the data in `Add scene layer from service` in `Layers` category. Old data is broken.

## Linked Issue(s)

- `common-samples/issues/4042`

## How To Test

Run the new sample and buildings show up.

## To Discuss

Didn't update screenshot as the buildings look almost the same.