### PR TITLE
[Fix] use APIs from Foundation instead of RegexBuilder

### DIFF
--- a/Shared/Samples/Animate 3D graphic/Animate3DGraphicView.Model.swift
+++ b/Shared/Samples/Animate 3D graphic/Animate3DGraphicView.Model.swift
@@ -288,7 +288,7 @@ extension Animate3DGraphicView {
             // Create a frame for each line.
             frames = lines.map { line in
                 // Spilt the line data into an array.
-                let details = line.split(separator: ",")
+                let details = line.components(separatedBy: ",")
                 let position = Point(
                     x: Double(details[0])!,
                     y: Double(details[1])!,

--- a/Shared/Samples/Apply dictionary renderer to graphics overlay/ApplyDictionaryRendererToGraphicsOverlayView.swift
+++ b/Shared/Samples/Apply dictionary renderer to graphics overlay/ApplyDictionaryRendererToGraphicsOverlayView.swift
@@ -143,9 +143,9 @@ private extension ApplyDictionaryRendererToGraphicsOverlayView {
         ) {
             switch elementName {
             case "_control_points":
-                currentMessage?.controlPoints = currentElementContents.split(separator: ";")
+                currentMessage?.controlPoints = currentElementContents.components(separatedBy: ";")
                     .map { pair in
-                        let coordinates = pair.split(separator: ",")
+                        let coordinates = pair.components(separatedBy: ",")
                         return (x: Double(coordinates.first!)!, y: Double(coordinates.last!)!)
                     }
             case "message":

--- a/Shared/Samples/Style symbols from mobile style file/StyleSymbolsFromMobileStyleFileView.swift
+++ b/Shared/Samples/Style symbols from mobile style file/StyleSymbolsFromMobileStyleFileView.swift
@@ -233,7 +233,7 @@ extension StyleSymbolsFromMobileStyleFileView {
 extension StyleSymbolsFromMobileStyleFileView.SymbolDetails {
     /// The human-readable label of the symbol name.
     var label: String {
-        let splitName = name.replacingOccurrences(of: "-", with: " ").split(separator: " ")
+        let splitName = name.replacingOccurrences(of: "-", with: " ").components(separatedBy: " ")
         return splitName.last?.capitalized ?? name
     }
 }


### PR DESCRIPTION
## Description

Use Foundation API to create substrings using separator instead of RegexBuilder.

## Linked Issue(s)

- `swift/issues/7992 `

## How To Test

Please test the functionality of the samples

## Screenshots

|Before|After|
|:-:|:-:|
|||

## To Discuss

<details><summary>Code Snippet</summary>

```swift
Swift repro code goes here
```

</details>
