### PR TITLE
[Update] Disable `nesting` SwiftLint rule

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -23,6 +23,7 @@ disabled_rules:
   - force_cast
   - force_try
   - line_length
+  - nesting
   - type_body_length
   - type_name
 

--- a/Shared/Samples/Add custom dynamic entity data source/AddCustomDynamicEntityDataSourceView.Vessel.swift
+++ b/Shared/Samples/Add custom dynamic entity data source/AddCustomDynamicEntityDataSourceView.Vessel.swift
@@ -33,7 +33,7 @@ extension AddCustomDynamicEntityDataSourceView.Vessel: Decodable {
     init(from decoder: Decoder) throws {
         /// The attributes that define meta data for the vessel.
         struct Attributes: Decodable {
-            enum CodingKeys: String, CodingKey { // swiftlint:disable:this nesting
+            enum CodingKeys: String, CodingKey {
                 case mmsi = "MMSI"
                 case sog = "SOG"
                 case cog = "COG"

--- a/Shared/Samples/Apply stretch renderer/ApplyStretchRendererView.swift
+++ b/Shared/Samples/Apply stretch renderer/ApplyStretchRendererView.swift
@@ -43,7 +43,7 @@ struct ApplyStretchRendererView: View {
     
     /// The settings for a stretch renderer.
     struct RendererSettings: Equatable {
-        enum StretchType: CaseIterable { // swiftlint:disable:this nesting
+        enum StretchType: CaseIterable {
             case minMax, percentClip, standardDeviation
         }
         

--- a/Shared/Samples/Filter features in scene/FilterFeaturesInSceneView.swift
+++ b/Shared/Samples/Filter features in scene/FilterFeaturesInSceneView.swift
@@ -97,7 +97,7 @@ private extension FilterFeaturesInSceneView {
         }()
         
         /// The different states for filtering features in a scene.
-        enum FilterState { // swiftlint:disable:this nesting
+        enum FilterState {
             case filter, showDetailedBuildings, reset
         }
         
@@ -105,7 +105,7 @@ private extension FilterFeaturesInSceneView {
         private(set) var filterState: FilterState = .filter
         
         /// An error that can occur during the model's initialization.
-        enum InitializationError: Error { // swiftlint:disable:this nesting
+        enum InitializationError: Error {
             case missingBuildingsLayer
             case missingDetailedBuildingsLayerExtent
         }


### PR DESCRIPTION
## Description

This PR disables the `nesting` SwiftLint rule to match what is done in the SDK.

## Linked Issue(s)

Closes #740

## How To Test

- Ensure the project still builds without warnings. 
