### PR TITLE
[Setup] Add button for verifying API key expiration date for the release

### DIFF
--- a/Shared/Supporting Files/Views/AboutView.swift
+++ b/Shared/Supporting Files/Views/AboutView.swift
@@ -222,10 +222,11 @@ private extension AboutView {
             // API key access token. The response contains an `appInfo` object,
             // which has the expiration date of the API key.
             // https://developers.arcgis.com/rest/users-groups-and-items/self/
-            let (data, _) = try await ArcGISEnvironment.urlSession.data(
-                from: URL(string: "https://www.arcgis.com/sharing/rest/Community/self")!,
-                queryParameters: ["f": "json", "token": apiKey.rawValue]
+            var request = URLRequest(
+                url: URL(string: "https://www.arcgis.com/sharing/rest/Community/self?f=json")!
             )
+            request.setValue("Bearer \(apiKey.rawValue)", forHTTPHeaderField: "X-Esri-Authorization")
+            let (data, _) = try await ArcGISEnvironment.urlSession.data(for: request)
             
             let decoder = JSONDecoder()
             decoder.dateDecodingStrategy = .millisecondsSince1970

--- a/Shared/Supporting Files/Views/AboutView.swift
+++ b/Shared/Supporting Files/Views/AboutView.swift
@@ -177,7 +177,14 @@ private extension AboutView {
                 switch apiKeyExpirationDate {
                 case .success(let expirationDate):
                     // Shows the expiration date of the API key in-use.
-                    Text(expirationDate, format: .dateTime.year().month().day())
+                    if let monthsRemaining = Calendar.current.dateComponents([.month], from: .now, to: expirationDate).month,
+                       monthsRemaining <= 4 {
+                        // Reminder when the API key is expiring within 4 months,
+                        // which is the typical release cycle.
+                        Text("\(expirationDate, format: .dateTime.year().month().day()). Expires in ^[\(monthsRemaining) month](inflect: true).")
+                    } else {
+                        Text(expirationDate, format: .dateTime.year().month().day())
+                    }
                 case .failure(let error):
                     // Shows the error when fail to get the expiration date.
                     switch error {

--- a/Shared/Supporting Files/Views/AboutView.swift
+++ b/Shared/Supporting Files/Views/AboutView.swift
@@ -29,14 +29,16 @@ struct AboutView: View {
     /// A Boolean value indicating whether the download offline resources cover is presented.
     @State private var isResourceDownloaderPresented = false
     /// The API key entered in the alert.
-    @State private var apiKey = ""
+    @State private var apiKeyInput = ""
     
     // MARK: Debug
     
     /// A Boolean value indicating whether the API key alert is presented.
     @State private var isAPIKeyAlertPresented = false
-    /// A Boolean value indicating whether the API key verification alert is presented.
-    @State private var isAPIKeyVerificationAlertPresented = false
+    /// A Boolean value indicating whether the API key expiration date alert is presented.
+    @State private var isExpirationDateAlertPresented = false
+    /// The expiration date of the API key in-use.
+    @State private var apiKeyExpirationDate: Date?
     
     var body: some View {
         NavigationStack {
@@ -124,7 +126,7 @@ private extension URL {
     static let writeReview = URL(string: "https://apps.apple.com/app/id1630449018?action=write-review")!
 }
 
-extension AboutView {
+private extension AboutView {
     /// A section for debugging purposes.
     var debugSection: some View {
         Section {
@@ -132,41 +134,65 @@ extension AboutView {
                 isAPIKeyAlertPresented = true
             }
             .alert("Enter API Key", isPresented: $isAPIKeyAlertPresented) {
-                TextField("Enter API Key Here", text: $apiKey, axis: .vertical)
+                TextField("Enter API Key Here", text: $apiKeyInput, axis: .vertical)
                     .textInputAutocapitalization(.never)
                     .autocorrectionDisabled()
                     .textEditorStyle(.plain)
                 Button("Cancel", role: .cancel) {}
                 Button("Submit") {
-                    ArcGISEnvironment.apiKey = APIKey(apiKey)!
+                    ArcGISEnvironment.apiKey = APIKey(apiKeyInput)!
                 }
-                .disabled(apiKey.isEmpty)
+                .disabled(apiKeyInput.isEmpty)
                 Button("Reset") {
                     ArcGISEnvironment.apiKey = .iOS
-                    apiKey.removeAll()
-                }
-                Button("Verify") {
-                    // Click "Show partial API key" to get the most recent key
-                    // from the Swift Sample Viewer Release portal item.
-                    // Paste the partial key into the text field and tap Verify.
-                    // An alert will indicate whether the most recent API key
-                    // is in use.
-                    isAPIKeyVerificationAlertPresented = true
+                    apiKeyInput.removeAll()
                 }
             }
-            .alert("API Key Verification Result", isPresented: $isAPIKeyVerificationAlertPresented) {
-            } message: {
-                let message: String
-                if let currentApiKey = ArcGISEnvironment.apiKey,
-                   currentApiKey.rawValue.hasSuffix(apiKey) {
-                    message = "Success: The most recent API key is in use."
-                } else {
-                    message = "Failure: The most recent API key is not in use."
+            
+            Button("Verify Expiration Date") {
+                // An alert shows the expiration date for the API key in-use.
+                // Compare it with the date in the Swift Sample Viewer Release
+                // portal item.
+                Task {
+                    apiKeyExpirationDate = try await getAPIKeyExpirationDate()
+                    isExpirationDateAlertPresented = true
                 }
-                return Text(message)
+            }
+            .alert("API Key Expiration Date", isPresented: $isExpirationDateAlertPresented) {
+            } message: {
+                Text(apiKeyExpirationDate == nil ? "Failed to get expiration date" : apiKeyExpirationDate!.formatted(date: .abbreviated, time: .omitted))
             }
         } footer: {
             Text("The section above is for testing purposes only.")
         }
+    }
+    
+    /// Gets the expiration date of the API key in-use by making a request to
+    /// the ArcGIS REST API.
+    func getAPIKeyExpirationDate() async throws -> Date? {
+        guard let apiKey = ArcGISEnvironment.apiKey else { return nil }
+        
+        struct APIResponse: Decodable {
+            let appInfo: AppInfo
+            
+            struct AppInfo: Decodable {
+                let expirationDate: Date
+            }
+        }
+        
+        // An endpoint to get the current authenticated user identified by the
+        // API key access token. The response contains an `appInfo` object,
+        // which has the expiration date of the API key.
+        // https://developers.arcgis.com/rest/users-groups-and-items/self/
+        let (data, _) = try await ArcGISEnvironment.urlSession.data(
+            from: URL(string: "https://www.arcgis.com/sharing/rest/Community/self")!,
+            queryParameters: ["f": "json", "token": apiKey.rawValue]
+        )
+        
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .millisecondsSince1970
+        let jsonResponse = try decoder.decode(APIResponse.self, from: data)
+        let expirationDate = jsonResponse.appInfo.expirationDate
+        return expirationDate
     }
 }

--- a/Shared/Supporting Files/Views/AboutView.swift
+++ b/Shared/Supporting Files/Views/AboutView.swift
@@ -140,6 +140,12 @@ extension AboutView {
                     ArcGISEnvironment.apiKey = .iOS
                 }
             }
+            
+            Button("Print API Key") {
+                if let apiKey = ArcGISEnvironment.apiKey {
+                    print("API key: \(apiKey)")
+                }
+            }
         } footer: {
             Text("The section above is for testing purposes only.")
         }

--- a/Shared/Supporting Files/Views/AboutView.swift
+++ b/Shared/Supporting Files/Views/AboutView.swift
@@ -166,7 +166,7 @@ private extension AboutView {
                     apiKeyExpirationDateMessage = apiKeyExpirationDate.formatted(date: .abbreviated, time: .omitted)
                 } catch let error as ArcGISAuthenticationError {
                     switch error {
-                    case .invalidAPIKey:
+                    case .invalidAPIKey, .invalidToken:
                         apiKeyExpirationDateMessage = "Invalid API key"
                     default:
                         apiKeyExpirationDateMessage = "Authentication error: \(error.localizedDescription)"

--- a/Shared/Supporting Files/Views/AboutView.swift
+++ b/Shared/Supporting Files/Views/AboutView.swift
@@ -26,12 +26,17 @@ struct AboutView: View {
     ? Bundle.arcGIS.shortVersion
     : "\(Bundle.arcGIS.shortVersion) (\(Bundle.arcGIS.version))"
     
-    /// A Boolean value indicating whether the API key alert is presented.
-    @State private var isAPIKeyAlertPresented = false
     /// A Boolean value indicating whether the download offline resources cover is presented.
     @State private var isResourceDownloaderPresented = false
     /// The API key entered in the alert.
     @State private var apiKey = ""
+    
+    // MARK: Debug
+    
+    /// A Boolean value indicating whether the API key alert is presented.
+    @State private var isAPIKeyAlertPresented = false
+    /// A Boolean value indicating whether the API key verification alert is presented.
+    @State private var isAPIKeyVerificationAlertPresented = false
     
     var body: some View {
         NavigationStack {
@@ -138,13 +143,27 @@ extension AboutView {
                 .disabled(apiKey.isEmpty)
                 Button("Reset") {
                     ArcGISEnvironment.apiKey = .iOS
+                    apiKey.removeAll()
+                }
+                Button("Verify") {
+                    // Click "Show partial API key" to get the most recent key
+                    // from the Swift Sample Viewer Release portal item.
+                    // Paste the partial key into the text field and tap Verify.
+                    // An alert will indicate whether the most recent API key
+                    // is in use.
+                    isAPIKeyVerificationAlertPresented = true
                 }
             }
-            
-            Button("Print API Key") {
-                if let apiKey = ArcGISEnvironment.apiKey {
-                    print("API key: \(apiKey)")
+            .alert("API Key Verification Result", isPresented: $isAPIKeyVerificationAlertPresented) {
+            } message: {
+                let message: String
+                if let currentApiKey = ArcGISEnvironment.apiKey,
+                   currentApiKey.rawValue.hasSuffix(apiKey) {
+                    message = "Success: The most recent API key is in use."
+                } else {
+                    message = "Failure: The most recent API key is not in use."
                 }
+                return Text(message)
             }
         } footer: {
             Text("The section above is for testing purposes only.")

--- a/Shared/Supporting Files/Views/AboutView.swift
+++ b/Shared/Supporting Files/Views/AboutView.swift
@@ -210,7 +210,7 @@ private extension AboutView {
                 throw ArcGISAuthenticationError.invalidAPIKey
             }
             
-            struct APIResponse: Decodable {
+            struct APIKeyInfoResponse: Decodable {
                 let appInfo: AppInfo
                 
                 struct AppInfo: Decodable {
@@ -229,7 +229,7 @@ private extension AboutView {
             
             let decoder = JSONDecoder()
             decoder.dateDecodingStrategy = .millisecondsSince1970
-            let jsonResponse = try decoder.decode(APIResponse.self, from: data)
+            let jsonResponse = try decoder.decode(APIKeyInfoResponse.self, from: data)
             let expirationDate = jsonResponse.appInfo.expirationDate
             return expirationDate
         }

--- a/Shared/Supporting Files/Views/AboutView.swift
+++ b/Shared/Supporting Files/Views/AboutView.swift
@@ -173,6 +173,7 @@ private extension AboutView {
     
     /// Gets the expiration date of the API key in-use by making a request to
     /// the ArcGIS REST API.
+    /// - Returns: The expiration date of the API key if available.
     func getAPIKeyExpirationDate() async throws -> Date? {
         guard let apiKey = ArcGISEnvironment.apiKey else { return nil }
         

--- a/Shared/Supporting Files/Views/AboutView.swift
+++ b/Shared/Supporting Files/Views/AboutView.swift
@@ -160,7 +160,11 @@ private extension AboutView {
             }
             .alert("API Key Expiration Date", isPresented: $isExpirationDateAlertPresented) {
             } message: {
-                Text(apiKeyExpirationDate == nil ? "Failed to get expiration date" : apiKeyExpirationDate!.formatted(date: .abbreviated, time: .omitted))
+                Text(
+                    apiKeyExpirationDate == nil
+                    ? "Failed to get expiration date"
+                    : apiKeyExpirationDate!.formatted(date: .abbreviated, time: .omitted)
+                )
             }
         } footer: {
             Text("The section above is for testing purposes only.")

--- a/Shared/Supporting Files/Views/AboutView.swift
+++ b/Shared/Supporting Files/Views/AboutView.swift
@@ -19,7 +19,7 @@ struct AboutView: View {
     @Environment(\.dismiss) private var dismiss: DismissAction
     
     private var copyrightText: Text {
-        Text("Copyright © 2022 - 2025 Esri. All Rights Reserved.")
+        Text("Copyright © 2022 - 2026 Esri. All Rights Reserved.")
     }
     
     private let arcGISVersion = Bundle.arcGIS.version.isEmpty

--- a/Shared/Supporting Files/Views/AboutView.swift
+++ b/Shared/Supporting Files/Views/AboutView.swift
@@ -122,8 +122,8 @@ private extension URL {
 #if DEBUG
 private extension AboutView {
     struct DebugView: View {
-        /// The message to show in the API key expiration date alert.
-        @State private var apiKeyExpirationDateMessage = ""
+        /// The result to show in the API key expiration date alert.
+        @State private var apiKeyExpirationDate: Result<Date, any Error>?
         /// The API key entered in the alert.
         @State private var apiKeyInput = ""
         /// A Boolean value indicating whether the API key alert is presented.
@@ -154,41 +154,51 @@ private extension AboutView {
             }
             
             Button("View API Key Expiration Date") {
-                apiKeyExpirationDateMessage.removeAll()
+                apiKeyExpirationDate = nil
                 verifyingAPIKey = true
             }
             .disabled(verifyingAPIKey)
             .task(id: verifyingAPIKey) {
                 guard verifyingAPIKey else { return }
                 defer { verifyingAPIKey = false }
-                do {
-                    let apiKeyExpirationDate = try await getAPIKeyExpirationDate()
-                    apiKeyExpirationDateMessage = apiKeyExpirationDate.formatted(date: .abbreviated, time: .omitted)
-                } catch let error as ArcGISAuthenticationError {
-                    switch error {
-                    case .invalidAPIKey, .invalidToken:
-                        apiKeyExpirationDateMessage = "Invalid API key"
-                    default:
-                        apiKeyExpirationDateMessage = "Authentication error: \(error.localizedDescription)"
-                    }
-                } catch let error as DecodingError {
-                    switch error {
-                    case .keyNotFound:
-                        apiKeyExpirationDateMessage = "Failed to get expiration date. Check if you are using a legacy key"
-                    default:
-                        apiKeyExpirationDateMessage = "Decoding error: \(error.localizedDescription)"
-                    }
-                } catch {
-                    apiKeyExpirationDateMessage = "Error: \(error.localizedDescription)"
-                }
+                
+                apiKeyExpirationDate = await Result { try await getAPIKeyExpirationDate() }
                 isExpirationDateAlertPresented = true
             }
-            .alert("API Key Expiration Date", isPresented: $isExpirationDateAlertPresented) {
+            .alert(
+                "API Key Expiration Date",
+                isPresented: $isExpirationDateAlertPresented,
+                presenting: apiKeyExpirationDate
+            ) { _ in
                 // An alert shows the expiration date for the API key in-use.
                 // Compare it with the date in the Swift Sample Viewer Release
                 // portal item.
-            } message: {
-                Text(apiKeyExpirationDateMessage)
+            } message: { apiKeyExpirationDate in
+                switch apiKeyExpirationDate {
+                case .success(let expirationDate):
+                    // Shows the expiration date of the API key in-use.
+                    Text(expirationDate, format: .dateTime.year().month().day())
+                case .failure(let error):
+                    // Shows the error when fail to get the expiration date.
+                    switch error {
+                    case let error as ArcGISAuthenticationError:
+                        switch error {
+                        case .invalidAPIKey, .invalidToken:
+                            Text("Invalid API key")
+                        default:
+                            Text("Authentication error: \(error.localizedDescription)")
+                        }
+                    case let error as DecodingError:
+                        switch error {
+                        case .keyNotFound:
+                            Text("Failed to get expiration date. Check if you are using a legacy key")
+                        default:
+                            Text("Decoding error: \(error.localizedDescription)")
+                        }
+                    default:
+                        Text("Error: \(error.localizedDescription)")
+                    }
+                }
             }
         }
         

--- a/Shared/Supporting Files/Views/AboutView.swift
+++ b/Shared/Supporting Files/Views/AboutView.swift
@@ -29,7 +29,6 @@ struct AboutView: View {
     /// A Boolean value indicating whether the download offline resources cover is presented.
     @State private var isResourceDownloaderPresented = false
     
-    
     var body: some View {
         NavigationStack {
             List {

--- a/Shared/Supporting Files/Views/AboutView.swift
+++ b/Shared/Supporting Files/Views/AboutView.swift
@@ -28,17 +28,7 @@ struct AboutView: View {
     
     /// A Boolean value indicating whether the download offline resources cover is presented.
     @State private var isResourceDownloaderPresented = false
-    /// The API key entered in the alert.
-    @State private var apiKeyInput = ""
     
-    // MARK: Debug
-    
-    /// A Boolean value indicating whether the API key alert is presented.
-    @State private var isAPIKeyAlertPresented = false
-    /// A Boolean value indicating whether the API key expiration date alert is presented.
-    @State private var isExpirationDateAlertPresented = false
-    /// The expiration date of the API key in-use.
-    @State private var apiKeyExpirationDate: Date?
     
     var body: some View {
         NavigationStack {
@@ -90,7 +80,11 @@ struct AboutView: View {
                 }
 #endif
 #if DEBUG
-                debugSection
+                Section {
+                    DebugView()
+                } footer: {
+                    Text("The section above is for testing purposes only.")
+                }
 #endif
             }
             .navigationTitle("About")
@@ -126,10 +120,21 @@ private extension URL {
     static let writeReview = URL(string: "https://apps.apple.com/app/id1630449018?action=write-review")!
 }
 
+#if DEBUG
 private extension AboutView {
-    /// A section for debugging purposes.
-    var debugSection: some View {
-        Section {
+    struct DebugView: View {
+        /// The message to show in the API key expiration date alert.
+        @State private var apiKeyExpirationDateMessage = ""
+        /// The API key entered in the alert.
+        @State private var apiKeyInput = ""
+        /// A Boolean value indicating whether the API key alert is presented.
+        @State private var isAPIKeyAlertPresented = false
+        /// A Boolean value indicating whether the API key expiration date alert is presented.
+        @State private var isExpirationDateAlertPresented = false
+        /// A Boolean value indicating whether the API key expiration date is being verified.
+        @State private var verifyingAPIKey = false
+        
+        var body: some View {
             Button("Enter API Key") {
                 isAPIKeyAlertPresented = true
             }
@@ -149,55 +154,76 @@ private extension AboutView {
                 }
             }
             
-            Button("Verify Expiration Date") {
+            Button("View API Key Expiration Date") {
+                apiKeyExpirationDateMessage.removeAll()
+                verifyingAPIKey = true
+            }
+            .disabled(verifyingAPIKey)
+            .task(id: verifyingAPIKey) {
+                guard verifyingAPIKey else { return }
+                defer { verifyingAPIKey = false }
+                do {
+                    let apiKeyExpirationDate = try await getAPIKeyExpirationDate()
+                    apiKeyExpirationDateMessage = apiKeyExpirationDate.formatted(date: .abbreviated, time: .omitted)
+                } catch let error as ArcGISAuthenticationError {
+                    switch error {
+                    case .invalidAPIKey:
+                        apiKeyExpirationDateMessage = "Invalid API key"
+                    default:
+                        apiKeyExpirationDateMessage = "Authentication error: \(error.localizedDescription)"
+                    }
+                } catch let error as DecodingError {
+                    switch error {
+                    case .keyNotFound:
+                        apiKeyExpirationDateMessage = "Failed to get expiration date. Check if you are using a legacy key"
+                    default:
+                        apiKeyExpirationDateMessage = "Decoding error: \(error.localizedDescription)"
+                    }
+                } catch {
+                    apiKeyExpirationDateMessage = "Error: \(error.localizedDescription)"
+                }
+                isExpirationDateAlertPresented = true
+            }
+            .alert("API Key Expiration Date", isPresented: $isExpirationDateAlertPresented) {
                 // An alert shows the expiration date for the API key in-use.
                 // Compare it with the date in the Swift Sample Viewer Release
                 // portal item.
-                Task {
-                    apiKeyExpirationDate = try await getAPIKeyExpirationDate()
-                    isExpirationDateAlertPresented = true
+            } message: {
+                Text(apiKeyExpirationDateMessage)
+            }
+        }
+        
+        /// Gets the expiration date of the API key in-use by making a request to
+        /// the ArcGIS REST API.
+        /// - Returns: The expiration date of the API key if available.
+        func getAPIKeyExpirationDate() async throws -> Date {
+            guard let apiKey = ArcGISEnvironment.apiKey else {
+                throw ArcGISAuthenticationError.invalidAPIKey
+            }
+            
+            struct APIResponse: Decodable {
+                let appInfo: AppInfo
+                
+                struct AppInfo: Decodable {
+                    let expirationDate: Date
                 }
             }
-            .alert("API Key Expiration Date", isPresented: $isExpirationDateAlertPresented) {
-            } message: {
-                Text(
-                    apiKeyExpirationDate == nil
-                    ? "Failed to get expiration date"
-                    : apiKeyExpirationDate!.formatted(date: .abbreviated, time: .omitted)
-                )
-            }
-        } footer: {
-            Text("The section above is for testing purposes only.")
-        }
-    }
-    
-    /// Gets the expiration date of the API key in-use by making a request to
-    /// the ArcGIS REST API.
-    /// - Returns: The expiration date of the API key if available.
-    func getAPIKeyExpirationDate() async throws -> Date? {
-        guard let apiKey = ArcGISEnvironment.apiKey else { return nil }
-        
-        struct APIResponse: Decodable {
-            let appInfo: AppInfo
             
-            struct AppInfo: Decodable {
-                let expirationDate: Date
-            }
+            // An endpoint to get the current authenticated user identified by the
+            // API key access token. The response contains an `appInfo` object,
+            // which has the expiration date of the API key.
+            // https://developers.arcgis.com/rest/users-groups-and-items/self/
+            let (data, _) = try await ArcGISEnvironment.urlSession.data(
+                from: URL(string: "https://www.arcgis.com/sharing/rest/Community/self")!,
+                queryParameters: ["f": "json", "token": apiKey.rawValue]
+            )
+            
+            let decoder = JSONDecoder()
+            decoder.dateDecodingStrategy = .millisecondsSince1970
+            let jsonResponse = try decoder.decode(APIResponse.self, from: data)
+            let expirationDate = jsonResponse.appInfo.expirationDate
+            return expirationDate
         }
-        
-        // An endpoint to get the current authenticated user identified by the
-        // API key access token. The response contains an `appInfo` object,
-        // which has the expiration date of the API key.
-        // https://developers.arcgis.com/rest/users-groups-and-items/self/
-        let (data, _) = try await ArcGISEnvironment.urlSession.data(
-            from: URL(string: "https://www.arcgis.com/sharing/rest/Community/self")!,
-            queryParameters: ["f": "json", "token": apiKey.rawValue]
-        )
-        
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .millisecondsSince1970
-        let jsonResponse = try decoder.decode(APIResponse.self, from: data)
-        let expirationDate = jsonResponse.appInfo.expirationDate
-        return expirationDate
     }
 }
+#endif

--- a/Shared/Supporting Files/Views/AboutView.swift
+++ b/Shared/Supporting Files/Views/AboutView.swift
@@ -177,11 +177,11 @@ private extension AboutView {
                 switch apiKeyExpirationDate {
                 case .success(let expirationDate):
                     // Shows the expiration date of the API key in-use.
-                    if let monthsRemaining = Calendar.current.dateComponents([.month], from: .now, to: expirationDate).month,
-                       monthsRemaining <= 4 {
+                    let monthsRemaining = Calendar.current.dateComponents([.month], from: .now, to: expirationDate).month!
+                    if monthsRemaining <= 4 {
                         // Reminder when the API key is expiring within 4 months,
                         // which is the typical release cycle.
-                        Text("\(expirationDate, format: .dateTime.year().month().day()). Expires in ^[\(monthsRemaining) month](inflect: true).")
+                        Text("\(expirationDate, format: .dateTime.year().month().day()). Expires in ^[\(max(monthsRemaining, 0)) month](inflect: true).")
                     } else {
                         Text(expirationDate, format: .dateTime.year().month().day())
                     }


### PR DESCRIPTION
## Description

This PR adds a button to verify the API key's expiration date, by making a request to the ArcGIS REST endpoint, when the project is built in Debug configuration.

The non-expiring legacy keys would be retired in July 2026. As part of our future release checklist, we need to verify that we are using the latest API key for the daily builds before a release. This button would make verification easier.

Similar to #673 

## Linked Issue(s)

- `devops/issues/5590`

## How To Test

Build the app in debug vs release (scheme > run > info > release), and see if the button show up in debug and doesn't in release. Press the button to see if an alert shows the correct expiration date of the key you use.

## To Discuss

~~I went for the simplest way to verify the API key in use by printing it out. If the public release is handled correctly, it should not present any risk.~~

~~Edit: after consulting some security guidelines, I decided to use input verify partial key to reduce security risk.~~

Edit 2: after discussing with Nimesh, I decided to compare expiration date instead of the key itself.

<details><summary>Other alternatives considered:</summary>

- Print a truncated key for less risk of key exposure (like core's `truncate_API_key` method). Since this button will be stripped out in release config, I figured it is not necessary to truncate.
- Show it in an alert - could have done that, but wanted to keep it simple.
- Compare hash from an input - this would be the least risky, but would require a few additional steps

</details>

Please share your thoughts on which way do you prefer.
