### PR TITLE
Add inline docs for underdocumented Swift sample workflows

### DIFF
--- a/Shared/Samples/Add features with contingent values/AddFeaturesWithContingentValuesView.Model.swift
+++ b/Shared/Samples/Add features with contingent values/AddFeaturesWithContingentValuesView.Model.swift
@@ -17,7 +17,12 @@ import Combine
 import Foundation
 
 extension AddFeaturesWithContingentValuesView {
-    /// The view model for the sample.
+    /// Manages contingent-value editing for bird nest features stored in a local geodatabase.
+    ///
+    /// The sample creates or removes a nest feature, updates contingent fields in
+    /// response to UI selections, validates the resulting contingency rules, and
+    /// keeps a derived buffer graphic synchronized with the feature's current
+    /// buffer size attribute.
     @MainActor
     class Model: ObservableObject {
         // MARK: Properties
@@ -64,7 +69,7 @@ extension AddFeaturesWithContingentValuesView {
         
         // MARK: Methods
         
-        /// Loads the features from the geodatabase.
+        /// Loads the geodatabase, exposes its table as a map layer, and builds buffer graphics.
         func loadFeatures() async throws {
             // Get the feature table from the geodatabase.
             try await geodatabaseFile?.geodatabase.load()
@@ -114,7 +119,11 @@ extension AddFeaturesWithContingentValuesView {
             contingenciesAreValid = false
         }
         
-        /// Sets an attribute on the feature to a given value.
+        /// Applies an edited attribute value and immediately re-evaluates the contingency rules.
+        ///
+        /// The sample keeps validation and derived graphics in the same method so
+        /// the UI always reflects whether the current combination of status,
+        /// protection, and buffer size remains valid.
         /// - Parameters:
         ///   - value: The value.
         ///   - key: The key associated with the attribute.

--- a/Shared/Samples/Analyze network with subnetwork trace/AnalyzeNetworkWithSubnetworkTraceView.Model.swift
+++ b/Shared/Samples/Analyze network with subnetwork trace/AnalyzeNetworkWithSubnetworkTraceView.Model.swift
@@ -17,7 +17,11 @@ import Combine
 import Foundation
 
 extension AnalyzeNetworkWithSubnetworkTraceView {
-    /// The view model for this sample.
+    /// Builds and executes subnetwork traces that use conditional traversability expressions.
+    ///
+    /// The model loads the utility network, exposes user-selectable network
+    /// attributes, and maintains a chain of conditional expressions that are
+    /// applied as barriers before each subnetwork trace.
     @MainActor
     class Model: ObservableObject {
         /// An electric utility network in Naperville, Illinois.
@@ -197,7 +201,11 @@ extension AnalyzeNetworkWithSubnetworkTraceView {
             statusText = ""
         }
         
-        /// Chains the conditional expressions together with AND or OR operators.
+        /// Combines the configured conditional expressions into a single traversability rule.
+        ///
+        /// The sample currently uses OR semantics so any expression can block
+        /// traversal. This helper is the single place where that chaining logic
+        /// is assembled before being assigned to the trace configuration.
         /// - Parameter expressions: An array of `UtilityTraceConditionalExpression`s.
         /// - Returns: The chained conditional expression.
         func chainExpressions(
@@ -291,7 +299,11 @@ extension AnalyzeNetworkWithSubnetworkTraceView {
             }
         }
         
-        /// Adds a conditional expression.
+        /// Creates and stores a new attribute comparison for the next trace.
+        ///
+        /// User input may come from either coded value domains or free-form
+        /// numeric input, so the value is first normalized to the attribute's
+        /// data type before the comparison expression is constructed.
         func addConditionalExpression(
             attribute: UtilityNetworkAttribute,
             comparison: UtilityNetworkAttributeComparison.Operator,

--- a/Shared/Samples/Create mobile geodatabase/CreateMobileGeodatabaseView.Model.swift
+++ b/Shared/Samples/Create mobile geodatabase/CreateMobileGeodatabaseView.Model.swift
@@ -19,7 +19,11 @@ import UniformTypeIdentifiers
 extension CreateMobileGeodatabaseView {
     // MARK: Model
     
-    /// The model used to store the geo model and other expensive objects used in the view.
+    /// Creates and populates a mobile geodatabase that can be exported from the sample.
+    ///
+    /// The model owns the temporary geodatabase file, defines the schema for the
+    /// location history table, adds new point features with timestamps, and keeps
+    /// the map and exported file in sync with the current local data.
     @MainActor
     class Model: ObservableObject {
         /// A map with a topographic basemap centered on Harpers Ferry, WV, USA.
@@ -58,7 +62,7 @@ extension CreateMobileGeodatabaseView {
         /// The list of features in the feature table.
         @Published private(set) var features: [FeatureItem] = []
         
-        /// Creates a new feature table from a geodatabase.
+        /// Creates the empty mobile geodatabase, adds its table, and exposes it as a layer.
         func createFeatureTable() async throws {
             // Create a new geodatabase.
             try await geodatabaseFile.createGeodatabase()
@@ -95,7 +99,11 @@ extension CreateMobileGeodatabaseView {
             }
         }
         
-        /// Removes all the existing features from the map.
+        /// Deletes the current mobile geodatabase and clears the map-backed state.
+        ///
+        /// Reset removes both the persisted file contents and the in-memory list of
+        /// captured features so the sample can start over with a brand new
+        /// geodatabase export.
         func resetFeatures() throws {
             // Delete the geodatabase.
             try geodatabaseFile.deleteGeodatabase()

--- a/Shared/Samples/Download preplanned map area/DownloadPreplannedMapAreaView.Model.swift
+++ b/Shared/Samples/Download preplanned map area/DownloadPreplannedMapAreaView.Model.swift
@@ -17,6 +17,11 @@ import Combine
 import Foundation
 
 extension DownloadPreplannedMapAreaView {
+    /// Coordinates browsing, downloading, and removing preplanned map areas.
+    ///
+    /// The model keeps track of the currently displayed map, builds the list of
+    /// downloadable preplanned areas, and swaps between the online map and any
+    /// successfully downloaded mobile map package.
     @MainActor
     class Model: ObservableObject {
         /// The currently selected map.
@@ -91,9 +96,12 @@ extension DownloadPreplannedMapAreaView {
             try? FileManager.default.removeItem(at: temporaryDirectory)
         }
         
-        /// Handles a selection of a map.
-        /// If the selected map is an offline map and it has not yet been taken offline, then
-        /// it will start downloading. Otherwise the selected map will be used as the displayed map.
+        /// Reacts to map selection changes by either opening local content or starting a download.
+        ///
+        /// Selecting a preplanned area does not immediately switch the map view if
+        /// the content is not yet on disk. Instead, the model kicks off the
+        /// download, restores the previous selection, and only switches once a
+        /// mobile map package is available.
         private func selectedMapDidChange(from oldValue: SelectedMap) {
             switch selectedMap {
             case .onlineWebMap:
@@ -166,7 +174,10 @@ extension DownloadPreplannedMapAreaView {
 }
 
 extension DownloadPreplannedMapAreaView {
-    /// An object that encapsulates state about an offline map.
+    /// Encapsulates the download state and local package location for one preplanned map area.
+    ///
+    /// Each model owns the job and result for a single portal-defined area so the
+    /// list UI can independently track progress, success, failure, and cleanup.
     class OfflineMapModel: ObservableObject, Identifiable {
         /// The preplanned map area.
         let preplannedMapArea: PreplannedMapArea
@@ -229,8 +240,11 @@ extension DownloadPreplannedMapAreaView.OfflineMapModel {
 
 @MainActor
 private extension DownloadPreplannedMapAreaView.OfflineMapModel {
-    /// Downloads the given preplanned map area.
-    /// - Parameter preplannedMapArea: The preplanned map area to be downloaded.
+    /// Downloads the preplanned map area into the model's mobile map package directory.
+    ///
+    /// The method first requests default download parameters, then runs the job
+    /// and stores either the resulting `MobileMapPackage` or the encountered
+    /// error so the UI can reflect the finished state.
     /// - Precondition: `canDownload`
     func download() async {
         precondition(canDownload)

--- a/Shared/Samples/Edit and sync features with feature service/EditAndSyncFeaturesWithFeatureServiceView.Model.swift
+++ b/Shared/Samples/Edit and sync features with feature service/EditAndSyncFeaturesWithFeatureServiceView.Model.swift
@@ -16,7 +16,11 @@ import ArcGIS
 import Foundation
 
 extension EditAndSyncFeaturesWithFeatureServiceView {
-    /// The view model for the sample.
+    /// Coordinates the offline geodatabase generation, editing, and sync workflow.
+    ///
+    /// The model can display live service layers, generate a local geodatabase
+    /// clipped to the current extent, apply geometry edits locally, and then push
+    /// those edits back to the backing feature service through a sync job.
     @MainActor
     final class Model: ObservableObject {
         // MARK: Properties
@@ -53,7 +57,10 @@ extension EditAndSyncFeaturesWithFeatureServiceView {
         
         // MARK: Methods
         
-        /// Adds feature layers from the feature service to the map.
+        /// Loads the sync task metadata and adds the service's point layers to the map.
+        ///
+        /// This establishes the online starting state before the sample switches
+        /// over to locally generated geodatabase layers.
         func setUpMap() async throws {
             try await geodatabaseSyncTask.load()
             
@@ -150,7 +157,10 @@ extension EditAndSyncFeaturesWithFeatureServiceView {
             currentJob = nil
         }
         
-        /// Runs a given job.
+        /// Starts a job, exposes it to the UI, and executes follow-up work tied to its output.
+        ///
+        /// Centralizing job startup here keeps generate and sync operations
+        /// consistent and ensures the active job can be cancelled from the view.
         /// - Parameters:
         ///   - job: The job to run.
         ///   - onStartAction: The action to run after the job is started.

--- a/Shared/Samples/Edit with branch versioning/EditWithBranchVersioningView.Model.swift
+++ b/Shared/Samples/Edit with branch versioning/EditWithBranchVersioningView.Model.swift
@@ -16,7 +16,12 @@ import ArcGIS
 import Foundation
 
 extension EditWithBranchVersioningView {
-    /// The view model for the sample.
+    /// Demonstrates version-aware editing against a branch-versioned feature service.
+    ///
+    /// The model loads the service geodatabase, tracks the default and
+    /// user-created versions visible to the sample, and coordinates switching,
+    /// selection, and update behavior so each version transition leaves the local
+    /// edit state in a predictable condition.
     @MainActor
     final class Model: ObservableObject {
         /// The names of the versions added by the user.
@@ -79,7 +84,11 @@ extension EditWithBranchVersioningView {
             return versionInfo.name
         }
         
-        /// Switches the geodatabase version to a version with a given name.
+        /// Switches the service geodatabase to a different branch-versioning context.
+        ///
+        /// The sample explicitly discards local edits on default and applies them
+        /// on user-created versions so the transition behavior matches the edit
+        /// policy demonstrated in the UI.
         /// - Parameter versionName: The name of the version to connect to.
         func switchToVersion(named versionName: String) async throws {
             if onDefaultVersion {

--- a/Shared/Samples/Find route in transport network/FindRouteInTransportNetworkView.Model.swift
+++ b/Shared/Samples/Find route in transport network/FindRouteInTransportNetworkView.Model.swift
@@ -17,7 +17,11 @@ import Combine
 import UIKit
 
 extension FindRouteInTransportNetworkView {
-    /// The view model for the sample.
+    /// Builds a route incrementally through a local transport network dataset.
+    ///
+    /// Each new stop extends or replaces the last solved segment, while the model
+    /// keeps separate overlays for stops and route graphics and accumulates the
+    /// combined time and distance shown in the UI.
     @MainActor
     class Model: ObservableObject {
         // MARK: Properties
@@ -89,7 +93,10 @@ extension FindRouteInTransportNetworkView {
             addRoute(replacingLast: replacingLast)
         }
         
-        /// Creates a route using the route parameters and adds a graphic for the route to the map.
+        /// Solves the current segment and merges its result into the displayed route totals.
+        ///
+        /// The sample solves one segment at a time from the active stop subset
+        /// rather than recomputing one large multi-stop result for every tap.
         /// - Parameter replacingLast: A Boolean value indicating whether to replace the last route with the new one.
         func addRoute(replacingLast: Bool = false) {
             Task { [weak self] in
@@ -178,7 +185,11 @@ extension FindRouteInTransportNetworkView {
             stopGraphicsOverlay.addGraphic(stopGraphic)
         }
         
-        /// Updates the route parameters stops using graphics in the stop graphics overlay.
+        /// Rebuilds the active stop list from a range of stop graphics.
+        ///
+        /// This helper is used both when extending the route and when replacing
+        /// the last stop so the underlying route parameters always describe the
+        /// exact segment that will be solved next.
         /// - Parameter indices: A range of indices corresponding to the graphics to create the stops from.
         private func updateRouteParametersStops(using indices: Range<Int>) {
             guard indices.lowerBound >= 0 && indices.upperBound <= stopGraphicsCount else { return }

--- a/Shared/Samples/Generate geodatabase replica from feature service/GenerateGeodatabaseReplicaFromFeatureServiceView.Model.swift
+++ b/Shared/Samples/Generate geodatabase replica from feature service/GenerateGeodatabaseReplicaFromFeatureServiceView.Model.swift
@@ -16,7 +16,12 @@ import ArcGIS
 import Foundation
 
 extension GenerateGeodatabaseReplicaFromFeatureServiceView {
-    /// The view model for the sample.
+    /// Generates a local replica from a sync-enabled feature service and swaps the map over to it.
+    ///
+    /// The sample first shows service-backed layers, then creates a local
+    /// geodatabase for a chosen extent, replaces the operational layers with the
+    /// replica tables, and unregisters the replica because the workflow is meant
+    /// for local viewing rather than edit-and-sync.
     @MainActor
     @Observable
     final class Model {
@@ -64,7 +69,11 @@ extension GenerateGeodatabaseReplicaFromFeatureServiceView {
             map.addOperationalLayers(featureLayers)
         }
         
-        /// Generates a geodatabase from the feature service.
+        /// Creates the local replica, loads it, and replaces the online layers with replica layers.
+        ///
+        /// Once the tables are swapped into the map, the replica is unregistered
+        /// because this sample is intentionally demonstrating one-way generation
+        /// instead of a persistent sync relationship.
         /// - Parameter extent: The extent of the data to be included in the generated geodatabase.
         func generateGeodatabase(extent: Envelope) async throws {
             // Creates the parameters for generating the geodatabase.

--- a/Shared/Samples/Generate offline map with custom parameters/GenerateOfflineMapWithCustomParametersView.Model.swift
+++ b/Shared/Samples/Generate offline map with custom parameters/GenerateOfflineMapWithCustomParametersView.Model.swift
@@ -16,8 +16,11 @@ import ArcGIS
 import Foundation
 
 extension GenerateOfflineMapWithCustomParametersView {
-    /// The model used to store the geo model and other expensive objects
-    /// used in this view.
+    /// Owns the offline map generation workflow and its parameter customization points.
+    ///
+    /// The model loads the source web map, creates the default offline map
+    /// parameters and overrides, and exposes focused helpers that demonstrate
+    /// how individual basemap and operational-layer options affect the download.
     @MainActor
     class Model: ObservableObject {
         /// The offline map that is generated.
@@ -95,8 +98,11 @@ extension GenerateOfflineMapWithCustomParametersView {
             )
         }
         
-        /// Sets up the model by getting the generate offline map parameters and parameter
-        /// overrides.
+        /// Loads the default offline map parameters and the mutable overrides used by the sample.
+        ///
+        /// This method should be called after the user has defined an area of
+        /// interest because the returned parameter objects become the backing
+        /// state for all later customization helpers.
         func setUpParametersAndOverrides() async throws {
             guard let extent else { return }
             offlineMapParameters = try await makeGenerateOfflineMapParameters(areaOfInterest: extent)
@@ -166,9 +172,11 @@ extension GenerateOfflineMapWithCustomParametersView {
             }
         }
         
-        /// Sets the scale level range so that only the levels between the min and max inclusive,
-        /// are downloaded. Note that lower values are zoomed further out,
-        /// i.e. 0 has the least detail, but one tile covers the entire Earth.
+        /// Restricts the basemap export to an inclusive range of scale level IDs.
+        ///
+        /// Lower scale level IDs represent less detail, so this helper trims the
+        /// default level set to reduce package size while keeping only the levels
+        /// relevant to the sample's chosen area of interest.
         /// Parameters:
         /// - minScaleLevel: The minimum scale level to download for the basemap.
         /// - maxScaleLevel: The maximum scale level to download for the basemap.
@@ -222,8 +230,11 @@ extension GenerateOfflineMapWithCustomParametersView {
             return nil
         }
         
-        /// Filters the hydrants that will be shown in the map by flow rate. Only hydrants the have
-        /// a higher flow rate than the minimum flow rate will be shown.
+        /// Filters hydrant features in the generated geodatabase by minimum flow rate.
+        ///
+        /// The helper updates the generated layer options rather than the source
+        /// map itself, which makes it clear that the filter only affects offline
+        /// content included in the download package.
         /// - Parameter minHydrantFlowRate: The minimum flow rate for hydrants shown on the map.
         func filterHydrantFlowRate(to minHydrantFlowRate: Double) {
             for option in getGenerateGeodatabaseParametersLayerOptions(forLayerNamed: "Hydrant") {

--- a/Shared/Samples/Navigate route with rerouting/NavigateRouteWithReroutingView.Model.swift
+++ b/Shared/Samples/Navigate route with rerouting/NavigateRouteWithReroutingView.Model.swift
@@ -17,7 +17,11 @@ import AVFAudio
 import Combine
 
 extension NavigateRouteWithReroutingView {
-    /// The view model for the sample.
+    /// Manages route solving, simulated navigation, and automatic rerouting for the sample.
+    ///
+    /// The model prepares the solved route, wires a simulated location source to
+    /// a `RouteTracker`, keeps the route graphics current, and converts tracker
+    /// status changes into text and voice guidance for the UI.
     @MainActor
     class Model: ObservableObject {
         // MARK: Properties
@@ -162,7 +166,11 @@ extension NavigateRouteWithReroutingView {
             try await initializeNavigation()
         }
         
-        /// Updates the status message and route graphics using the progress from a given tracking status.
+        /// Updates the displayed route progress and status text from the latest tracker event.
+        ///
+        /// This method keeps the remaining and traversed route graphics in sync
+        /// with the snapped navigation position and derives user-facing distance,
+        /// time, and maneuver text from the tracker state.
         /// - Parameter status: The `TrackingStatus`.
         func updateProgress(using status: TrackingStatus) async {
             // Update the route graphics.
@@ -222,7 +230,11 @@ extension NavigateRouteWithReroutingView {
             speechSynthesizer.speak(utterance)
         }
         
-        /// Initializes the route tracker, location display, and route graphic.
+        /// Rebuilds the tracker-backed navigation state after setup or reset.
+        ///
+        /// Initialization recreates the route tracker, connects it to the route
+        /// tracker location data source, and resets the route graphics and
+        /// viewpoint so navigation can start from a clean state.
         private func initializeNavigation() async throws {
             // Make the route tracker.
             routeTracker = try await makeRouteTracker(

--- a/Shared/Samples/Query dynamic entities/QueryDynamicEntitiesView.Model.swift
+++ b/Shared/Samples/Query dynamic entities/QueryDynamicEntitiesView.Model.swift
@@ -16,7 +16,11 @@ import ArcGIS
 import Foundation
 
 extension QueryDynamicEntitiesView {
-    /// The view model for this sample.
+    /// Manages the dynamic entity query experience for the sample air-traffic feed.
+    ///
+    /// The model owns the custom dynamic entity data source, configures the map
+    /// layer used to render aircraft observations, and exposes query entry points
+    /// for geometry, attribute, and track-ID driven selection.
     @MainActor
     @Observable
     final class Model {
@@ -109,7 +113,11 @@ extension QueryDynamicEntitiesView {
             }
         }
         
-        /// Queries the dynamic entities on the data source.
+        /// Runs one of the sample's supported dynamic entity queries and updates the display.
+        ///
+        /// The method delegates to a query-specific helper, reveals the airport
+        /// buffer only for geometry queries, and selects the returned entities on
+        /// the dynamic entity layer when the query succeeds.
         /// - Parameter type: The type of query to perform.
         /// - Returns: The result of the query operation.
         func queryDynamicEntities(type: QueryType) async -> Result<[DynamicEntity], any Error> {
@@ -139,7 +147,11 @@ extension QueryDynamicEntitiesView {
             graphicsOverlay.isVisible = false
         }
         
-        /// Sets up the dynamic entity layer's properties and adds it to the map.
+        /// Configures how live aircraft observations are rendered, labeled, and tracked on the map.
+        ///
+        /// This setup enables track lines and recent observations so query results
+        /// are easier to interpret in the context of current and historical plane
+        /// positions.
         private func setUpDynamicEntityLayer() {
             // Sets display tracking properties on the layer.
             let trackDisplayProperties = dynamicEntityLayer.trackDisplayProperties

--- a/Shared/Samples/Run valve isolation trace/RunValveIsolationTraceView.Model.swift
+++ b/Shared/Samples/Run valve isolation trace/RunValveIsolationTraceView.Model.swift
@@ -17,7 +17,11 @@ import Combine
 import Foundation
 
 extension RunValveIsolationTraceView {
-    /// The view model for this sample.
+    /// Coordinates the valve isolation trace workflow for the gas utility sample.
+    ///
+    /// The model loads the utility network, seeds a fixed starting location,
+    /// lets the user add optional filter barriers or category filters, and then
+    /// applies the resulting trace configuration to the map's operational layers.
     @MainActor
     class Model: ObservableObject {
         /// A web map with a utility network used to run the isolation trace.
@@ -266,7 +270,11 @@ extension RunValveIsolationTraceView {
             resetEnabled = false
         }
         
-        /// Gets the utility tier's trace configuration and apply category comparison.
+        /// Creates the trace configuration used for the current isolation run.
+        ///
+        /// The configuration starts from the tier default and then layers on the
+        /// optional category filter and the caller's choice to include isolated
+        /// features in the trace output.
         private func makeTraceConfiguration(category: UtilityCategory?, includeIsolatedFeatures: Bool) -> UtilityTraceConfiguration {
             // Get a default trace configuration from a tier in the network.
             guard let configuration = utilityNetwork
@@ -291,7 +299,11 @@ extension RunValveIsolationTraceView {
             return configuration
         }
         
-        /// Adds a graphic at the tapped location for the filter barrier.
+        /// Adds a feature as a filter barrier and records any required terminal or edge metadata.
+        ///
+        /// Junction barriers may require terminal selection before they are fully
+        /// usable, while edge barriers compute `fractionAlongEdge` from the tap so
+        /// the trace uses the correct position on the network.
         /// - Parameters:
         ///   - feature: The geo element retrieved as a `Feature`.
         ///   - location: The `Point` used to identify utility elements in the utility network.

--- a/Shared/Samples/Set up location-driven geotriggers/SetUpLocationDrivenGeotriggersView.Model.swift
+++ b/Shared/Samples/Set up location-driven geotriggers/SetUpLocationDrivenGeotriggersView.Model.swift
@@ -17,7 +17,12 @@ import Combine
 import Foundation
 
 extension SetUpLocationDrivenGeotriggersView {
-    /// The view model for the sample.
+    /// Coordinates the geotrigger workflow for the simulated Santa Barbara garden walk.
+    ///
+    /// The model builds one fence monitor for garden sections and another for
+    /// points of interest, then translates fence enter and exit notifications
+    /// into view-friendly state such as the current section, nearby features,
+    /// and popups for the most relevant feature.
     @MainActor
     class Model: ObservableObject {
         // MARK: Properties
@@ -77,7 +82,11 @@ extension SetUpLocationDrivenGeotriggersView {
             locationDisplay = Self.makeLocationDisplay(dataSource: locationDataSource)
         }
         
-        /// Creates fence geotrigger monitors from the map's operational layers.
+        /// Creates the section and point-of-interest fence monitors used by the sample.
+        ///
+        /// The monitors share one simulated location feed but use different fence
+        /// tables and buffer distances so the sample can model both exact section
+        /// membership and looser nearby point-of-interest detection.
         func makeGeotriggerMonitors() -> [GeotriggerMonitor] {
             // Get the service feature tables from the map's operational layers.
             guard let operationalLayers = map.operationalLayers as? [FeatureLayer],
@@ -141,8 +150,11 @@ extension SetUpLocationDrivenGeotriggersView {
             return GeotriggerMonitor(geotrigger: fenceGeotrigger)
         }
         
-        /// Handles a notification posted by a geotrigger monitor when a fence geotrigger
-        /// condition has been met.
+        /// Handles a fence notification and updates the derived section and POI state.
+        ///
+        /// Enter and exit events are stored as stack-like name lists per monitor so
+        /// the sample can infer the current section and nearby points of interest
+        /// from the most recent active fences.
         /// - Parameter fenceNotificationInfo: The information about the geotrigger monitor
         /// and the geofence that was triggered.
         func handleGeotriggerNotification(_ fenceNotificationInfo: FenceGeotriggerNotificationInfo) {

--- a/Shared/Samples/Show device location using indoor positioning/ShowDeviceLocationUsingIndoorPositioningView.Model.swift
+++ b/Shared/Samples/Show device location using indoor positioning/ShowDeviceLocationUsingIndoorPositioningView.Model.swift
@@ -17,6 +17,12 @@ import Combine
 import Foundation
 
 extension ShowDeviceLocationUsingIndoorPositioningView {
+    /// Drives indoor positioning setup and maps live indoor updates into view state.
+    ///
+    /// The model loads an IPS-aware, floor-aware web map, installs an
+    /// `IndoorsLocationDataSource` from the map's positioning definition, and
+    /// keeps the displayed floor, signal source metadata, and accuracy labels in
+    /// sync with the incoming indoor locations.
     @MainActor
     class Model: ObservableObject {
         /// An IPS-aware and floor-aware web map for all three floors of
@@ -65,8 +71,11 @@ extension ShowDeviceLocationUsingIndoorPositioningView {
             try await setUpIndoorsLocationDataSource()
         }
         
-        /// Sets the indoors location data source on the location display
-        /// using the map's indoor positioning definition.
+        /// Replaces the default system data source with the map-defined indoor one.
+        ///
+        /// The indoor positioning definition contains the data needed to produce
+        /// indoor-aware locations, so loading it is the boundary between merely
+        /// opening the map and actually starting IPS tracking.
         private func setUpIndoorsLocationDataSource() async throws {
             if let indoorPositioningDefinition = map.indoorPositioningDefinition {
                 // Gets indoor positioning definition from the IPS-aware map
@@ -81,7 +90,11 @@ extension ShowDeviceLocationUsingIndoorPositioningView {
             try await locationDisplay.dataSource.start()
         }
         
-        /// Updates the location when the location data source is triggered.
+        /// Projects each indoor location update into floor visibility and status text.
+        ///
+        /// Additional source properties expose indoor-specific metadata such as the
+        /// current floor and signal source counts, which the sample surfaces
+        /// alongside the map display.
         func updateDisplayOnLocationChange() async {
             for await location in locationDisplay.dataSource.locations {
                 // The floor level from the location.

--- a/Shared/Samples/Snap geometry edits with utility network rules/SnapGeometryEditsWithUtilityNetworkRulesView.Model.swift
+++ b/Shared/Samples/Snap geometry edits with utility network rules/SnapGeometryEditsWithUtilityNetworkRulesView.Model.swift
@@ -17,7 +17,11 @@ import Combine
 import Foundation
 
 extension SnapGeometryEditsWithUtilityNetworkRulesView {
-    /// The view model for the sample.
+    /// Drives the snapping workflow for geometry edits constrained by utility network rules.
+    ///
+    /// The model loads the local utility network data, derives valid snap sources
+    /// from network connectivity rules, and keeps the geometry editor and layer
+    /// rendering in sync with the currently selected feature.
     @MainActor
     final class Model: ObservableObject {
         // MARK: Properties
@@ -203,7 +207,10 @@ extension SnapGeometryEditsWithUtilityNetworkRulesView {
             geometryEditor.start(withInitial: geometry)
         }
         
-        /// Sets up the snap source settings.
+        /// Builds snap source settings from utility network rules for the selected asset type.
+        ///
+        /// The resulting settings mirror the rule analysis so the editor only
+        /// offers snap targets that would produce valid utility network edits.
         /// - Parameter assetType: The utility asset type for selected feature.
         private func setUpSnapSourcesSettings(using assetType: UtilityAssetType) async throws {
             // Analyzes the utility network to get the snap rules for the asset type.
@@ -228,7 +235,11 @@ extension SnapGeometryEditsWithUtilityNetworkRulesView {
             }
         }
         
-        /// Recursively filters a list of snap source settings.
+        /// Recursively reduces the full snap source tree to the sources highlighted by this sample.
+        ///
+        /// The geometry editor may surface many sources after rule analysis. This
+        /// helper keeps only the relevant graphics and subtype layers so the UI
+        /// and custom symbology stay focused on the example workflow.
         /// - Parameter settings: The list of snap source settings to filter.
         /// - Returns: The snap sources settings used by this sample.
         private func filterSnapSourceSettings(

--- a/Shared/Samples/Snap geometry edits/SnapGeometryEditsView.GeometryEditorModel.swift
+++ b/Shared/Samples/Snap geometry edits/SnapGeometryEditsView.GeometryEditorModel.swift
@@ -16,7 +16,12 @@ import ArcGIS
 import Combine
 
 extension SnapGeometryEditsView {
-    /// An object that acts as a view model for the geometry editor menu.
+    /// Wraps the geometry editor state used by the sample's snapping workflow.
+    ///
+    /// The model chooses the editing tool best suited to the current platform,
+    /// exposes save and reset actions for completed sketches, and stores saved
+    /// geometries in a separate graphics overlay so they remain visible after the
+    /// active editor session stops.
     @MainActor
     class GeometryEditorModel: ObservableObject {
         /// The geometry editor.
@@ -68,7 +73,11 @@ extension SnapGeometryEditsView {
             geometryEditor.tool = adaptiveVertexTool
         }
         
-        /// Saves the current geometry to the graphics overlay and stops editing.
+        /// Saves the current sketch into the overlay that represents completed edits.
+        ///
+        /// The editor itself only manages the in-progress sketch, so saving turns
+        /// the current geometry into a standalone graphic with symbolization based
+        /// on the geometry type.
         /// - Precondition: Geometry's sketch must be valid.
         func save() {
             precondition(geometryEditor.geometry?.sketchIsValid ?? false)
@@ -91,7 +100,11 @@ extension SnapGeometryEditsView {
             isStarted = false
         }
         
-        /// Returns the symbology for graphics saved to the graphics overlay.
+        /// Returns a symbol that matches the geometry family of a completed sketch.
+        ///
+        /// Saved graphics are symbolized independently from the editor so the
+        /// overlay can present points, lines, and polygons consistently after the
+        /// active sketch session has ended.
         /// - Parameter geometry: The geometry of the graphic to be saved.
         /// - Returns: Either a marker or fill symbol depending on the type of provided geometry.
         private func symbol(for geometry: Geometry) -> Symbol {

--- a/Shared/Samples/Trace utility network/TraceUtilityNetworkView.Model.swift
+++ b/Shared/Samples/Trace utility network/TraceUtilityNetworkView.Model.swift
@@ -16,7 +16,11 @@ import ArcGIS
 import UIKit.UIColor
 
 extension TraceUtilityNetworkView {
-    /// The model used to manage the state of the trace view.
+    /// Coordinates the interactive utility trace workflow for the sample.
+    ///
+    /// The model owns the loaded utility network, tracks whether the user is
+    /// adding start locations or barriers, and translates map taps into
+    /// `UtilityElement` inputs that can be passed into a trace.
     @MainActor
     class Model: ObservableObject {
         // MARK: Properties
@@ -124,11 +128,12 @@ extension TraceUtilityNetworkView {
             lastAddedElement = element
         }
         
-        /// Adds a provided feature to the pending trace.
+        /// Converts an identified feature into a trace input and updates map state.
         ///
-        /// For junction features with more than one terminal, the user should be prompted to pick a
-        /// terminal. For edge features, the fractional point along the feature's edge should be
-        /// computed.
+        /// Junction features are added at their feature geometry and may require
+        /// terminal disambiguation. Edge features are converted into trace
+        /// elements by computing the fractional distance along the line nearest
+        /// the tap location.
         /// - Parameters:
         ///   - feature: The feature to be added to the pending trace.
         ///   - mapPoint: The location on the map where the feature was discovered. If the feature is a
@@ -203,11 +208,10 @@ extension TraceUtilityNetworkView {
             }
         }
         
-        /// Runs a trace with the pending trace configuration and selects features in the map that
-        /// correspond to the element results.
+        /// Executes the pending trace and selects the returned features in the map.
         ///
-        /// - Note: Elements are grouped by network source prior to selection so that all selections
-        /// per operational layer can be made at once.
+        /// Trace results are grouped by network source before selection so each
+        /// feature layer can fetch and highlight its result set in a single pass.
         func trace() async throws {
             guard let pendingTraceParameters = pendingTraceParameters else { return }
             let traceResults = try await network

--- a/Shared/Samples/Validate utility network topology/ValidateUtilityNetworkTopologyView.Model.swift
+++ b/Shared/Samples/Validate utility network topology/ValidateUtilityNetworkTopologyView.Model.swift
@@ -17,7 +17,11 @@ import Combine
 import UIKit
 
 extension ValidateUtilityNetworkTopologyView {
-    /// The view model for the sample.
+    /// Manages the edit, validate, and trace cycle for a branch-versioned utility network.
+    ///
+    /// The model loads the sample web map, creates an isolated service version,
+    /// exposes the current network state to the UI, and coordinates the edits
+    /// required to produce dirty areas before validating network topology.
     @MainActor
     class Model: ObservableObject {
         // MARK: Properties
@@ -67,7 +71,11 @@ extension ValidateUtilityNetworkTopologyView {
         
         // MARK: Methods
         
-        /// Gets the current state of the utility network and updates the status with the results.
+        /// Reads the current utility network state and derives the UI's enabled actions.
+        ///
+        /// This is the main status refresh entry point after edits or validation
+        /// because it determines whether tracing is currently allowed and whether
+        /// the network still contains dirty areas or errors.
         func getState() async throws {
             statusMessage = "Getting utility network state…"
             
@@ -268,7 +276,11 @@ extension ValidateUtilityNetworkTopologyView {
             addLabels(to: .lineTableName, for: .nominalVoltageField, color: .red)
         }
         
-        /// Loads the utility network and switches to a new version on the service.
+        /// Loads the utility network and switches the backing geodatabase to a new private version.
+        ///
+        /// The sample performs edits against a fresh branch version so topology
+        /// changes stay isolated from the default version while still exercising
+        /// the full validate-and-trace workflow.
         private func setupUtilityNetwork() async throws {
             statusMessage = "Loading utility network…"
             

--- a/Shared/Supporting Files/Views/DownloadOfflineResourcesView.swift
+++ b/Shared/Supporting Files/Views/DownloadOfflineResourcesView.swift
@@ -14,7 +14,12 @@
 
 import SwiftUI
 
-/// A view with controls for downloading the app's on-demand resources.
+/// Displays and coordinates bulk download state for every sample that has on-demand resources.
+///
+/// The view discovers all downloadable sample resource groups, exposes both
+/// per-sample and download-all actions, aggregates child progress objects for a
+/// shared progress indicator, and adjusts its dismissal behavior while
+/// downloads are still active.
 struct DownloadOfflineResourcesView: View {
     /// The action to dismiss the view.
     @Environment(\.dismiss) private var dismiss
@@ -118,7 +123,11 @@ struct DownloadOfflineResourcesView: View {
         }
     }
     
-    /// Downloads all of the on-demand resources that haven't started a request yet.
+    /// Starts downloads for every resource that is still eligible to be requested.
+    ///
+    /// The root `Progress` object is built by attaching each child request's
+    /// progress so the Download All row can reflect a combined operation rather
+    /// than independent per-sample requests.
     /// - Note: The system may purge the resources at any time after the request object is deallocated.
     private func downloadAll() async {
         await withTaskGroup { group in

--- a/Shared/Supporting Files/Views/SampleDetailView.swift
+++ b/Shared/Supporting Files/Views/SampleDetailView.swift
@@ -14,6 +14,12 @@
 
 import SwiftUI
 
+/// Hosts a sample view inside the shared detail-shell UI used across the app.
+///
+/// This wrapper is responsible for deciding whether a sample can be shown
+/// immediately or must wait for on-demand resources, and for attaching the
+/// shared toolbar actions, info sheet, review tracking, and optional full-screen
+/// behavior around the sample's own body.
 struct SampleDetailView: View {
     /// The sample to display in the view.
     let sample: Sample
@@ -44,7 +50,10 @@ struct SampleDetailView: View {
 #endif
     }
     
-    /// The sample's view body.
+    /// The sample content wrapped with request-review lifecycle updates.
+    ///
+    /// The sample body itself is created lazily so the surrounding view can add
+    /// shared app-shell behavior without changing each sample implementation.
     private var sampleBody: some View {
         sample.makeBody()
             .onAppear {


### PR DESCRIPTION
## Summary
- add class-level and workflow-boundary inline docs to 20 underdocumented Swift sample and supporting files
- document complex utility network, offline, routing, geotrigger, indoor positioning, and editing flows
- add clearer app-shell documentation for shared sample detail and on-demand resource download views

## Validation
- validated touched Swift files with file-level error checks after each documentation batch