### PR TITLE
[Update] Improve error message when location display fails due to permission denied error.

### DIFF
--- a/Shared/Samples/Show device location/ShowDeviceLocationView.swift
+++ b/Shared/Samples/Show device location/ShowDeviceLocationView.swift
@@ -114,11 +114,11 @@ private extension ShowDeviceLocationView {
                 try await locationDisplay.dataSource.start()
             } catch {
                 // Provide a more helpful error message when location permissions are denied.
-                let nsError = error as NSError
-                if nsError.domain == kCLErrorDomain && nsError.code == CLError.Code.denied.rawValue {
+                if let clError = error as? CLError, clError.code == .denied {
                     throw LocationPermissionDeniedError()
+                } else {
+                    throw error
                 }
-                throw error
             }
         }
         

--- a/Shared/Samples/Show device location/ShowDeviceLocationView.swift
+++ b/Shared/Samples/Show device location/ShowDeviceLocationView.swift
@@ -116,7 +116,8 @@ private extension ShowDeviceLocationView {
 #if targetEnvironment(macCatalyst)
                 // On Mac Catalyst, provide a more helpful error message when location
                 // permissions are not enabled.
-                if (error as NSError).domain == kCLErrorDomain && (error as NSError).code == CLError.Code.denied.rawValue {
+                let nsError = error as NSError
+                if nsError.domain == kCLErrorDomain && nsError.code == CLError.Code.denied.rawValue {
                     throw LocationError.macCatalystPermissionDenied
                 }
 #endif

--- a/Shared/Samples/Show device location/ShowDeviceLocationView.swift
+++ b/Shared/Samples/Show device location/ShowDeviceLocationView.swift
@@ -110,13 +110,43 @@ private extension ShowDeviceLocationView {
                 locationManager.requestWhenInUseAuthorization()
             }
             // Starts the location display data source.
-            try await locationDisplay.dataSource.start()
+            do {
+                try await locationDisplay.dataSource.start()
+            } catch {
+#if targetEnvironment(macCatalyst)
+                // On Mac Catalyst, provide a more helpful error message when location
+                // permissions are not enabled.
+                if (error as NSError).domain == kCLErrorDomain && (error as NSError).code == 1 {
+                    throw LocationError.macCatalystPermissionDenied
+                }
+#endif
+                throw error
+            }
         }
         
         /// Stops the location data source.
         func stopLocationDataSource() {
             Task {
                 await locationDisplay.dataSource.stop()
+            }
+        }
+        
+        /// Errors that can occur when working with location services.
+        enum LocationError: LocalizedError {
+            case macCatalystPermissionDenied
+            
+            var errorDescription: String? {
+                switch self {
+                case .macCatalystPermissionDenied:
+                    return "Location services are not enabled for this app. Please enable location permissions in System Settings."
+                }
+            }
+            
+            var recoverySuggestion: String? {
+                switch self {
+                case .macCatalystPermissionDenied:
+                    return "Open System Settings > Privacy & Security > Location Services and ensure this app has permission to access your location."
+                }
             }
         }
     }

--- a/Shared/Samples/Show device location/ShowDeviceLocationView.swift
+++ b/Shared/Samples/Show device location/ShowDeviceLocationView.swift
@@ -132,7 +132,7 @@ private extension ShowDeviceLocationView {
     
     /// An error that occurs when location display fails due to a permission denied error.
     struct LocationPermissionDeniedError: LocalizedError {
-        var errorDescription: String {
+        var errorDescription: String? {
             "Location permission denied. Please authorize location access for this application in Settings."
         }
     }

--- a/Shared/Samples/Show device location/ShowDeviceLocationView.swift
+++ b/Shared/Samples/Show device location/ShowDeviceLocationView.swift
@@ -113,7 +113,7 @@ private extension ShowDeviceLocationView {
             do {
                 try await locationDisplay.dataSource.start()
             } catch {
-                // Provide a more helpful error message when location permissions are denied.
+                // Provides a more helpful error message when location permissions are denied.
                 if let clError = error as? CLError, clError.code == .denied {
                     throw LocationPermissionDeniedError()
                 } else {
@@ -133,7 +133,7 @@ private extension ShowDeviceLocationView {
     /// An error that occurs when location display fails due to a permission denied error.
     struct LocationPermissionDeniedError: LocalizedError {
         var errorDescription: String {
-            return "Location permission denied. Please authorize location access for this application in Settings."
+           "Location permission denied. Please authorize location access for this application in Settings."
         }
     }
 }

--- a/Shared/Samples/Show device location/ShowDeviceLocationView.swift
+++ b/Shared/Samples/Show device location/ShowDeviceLocationView.swift
@@ -133,7 +133,7 @@ private extension ShowDeviceLocationView {
     /// An error that occurs when location display fails due to a permission denied error.
     struct LocationPermissionDeniedError: LocalizedError {
         var errorDescription: String {
-           "Location permission denied. Please authorize location access for this application in Settings."
+            "Location permission denied. Please authorize location access for this application in Settings."
         }
     }
 }

--- a/Shared/Samples/Show device location/ShowDeviceLocationView.swift
+++ b/Shared/Samples/Show device location/ShowDeviceLocationView.swift
@@ -113,14 +113,11 @@ private extension ShowDeviceLocationView {
             do {
                 try await locationDisplay.dataSource.start()
             } catch {
-#if targetEnvironment(macCatalyst)
-                // On Mac Catalyst, provide a more helpful error message when location
-                // permissions are not enabled.
+                // Provide a more helpful error message when location permissions are denied.
                 let nsError = error as NSError
                 if nsError.domain == kCLErrorDomain && nsError.code == CLError.Code.denied.rawValue {
-                    throw LocationError.macCatalystPermissionDenied
+                    throw LocationPermissionDeniedError()
                 }
-#endif
                 throw error
             }
         }
@@ -131,17 +128,12 @@ private extension ShowDeviceLocationView {
                 await locationDisplay.dataSource.stop()
             }
         }
-        
-        /// Errors that can occur when working with location services.
-        enum LocationError: LocalizedError {
-            case macCatalystPermissionDenied
-            
-            var errorDescription: String? {
-                switch self {
-                case .macCatalystPermissionDenied:
-                    return "Location services are not enabled for this app. Please enable location permissions in System Settings.\nOpen System Settings > Privacy & Security > Location Services and ensure this app has permission to access your location."
-                }
-            }
+    }
+    
+    /// An error that occurs when location display fails due to a permission denied error.
+    struct LocationPermissionDeniedError: LocalizedError {
+        var errorDescription: String? {
+            return "Location permission denied. Please enable location access for this app in Settings."
         }
     }
 }

--- a/Shared/Samples/Show device location/ShowDeviceLocationView.swift
+++ b/Shared/Samples/Show device location/ShowDeviceLocationView.swift
@@ -138,7 +138,7 @@ private extension ShowDeviceLocationView {
             var errorDescription: String? {
                 switch self {
                 case .macCatalystPermissionDenied:
-                    return "Location services are not enabled for this app. Please enable location permissions in System Settings.\n Open System Settings > Privacy & Security > Location Services and ensure this app has permission to access your location."
+                    return "Location services are not enabled for this app. Please enable location permissions in System Settings.\nOpen System Settings > Privacy & Security > Location Services and ensure this app has permission to access your location."
                 }
             }
         }

--- a/Shared/Samples/Show device location/ShowDeviceLocationView.swift
+++ b/Shared/Samples/Show device location/ShowDeviceLocationView.swift
@@ -132,7 +132,7 @@ private extension ShowDeviceLocationView {
     
     /// An error that occurs when location display fails due to a permission denied error.
     struct LocationPermissionDeniedError: LocalizedError {
-        var errorDescription: String? {
+        var errorDescription: String {
             return "Location permission denied. Please authorize location access for this application in Settings."
         }
     }

--- a/Shared/Samples/Show device location/ShowDeviceLocationView.swift
+++ b/Shared/Samples/Show device location/ShowDeviceLocationView.swift
@@ -133,7 +133,7 @@ private extension ShowDeviceLocationView {
     /// An error that occurs when location display fails due to a permission denied error.
     struct LocationPermissionDeniedError: LocalizedError {
         var errorDescription: String? {
-            return "Location permission denied. Please enable location access for this app in Settings."
+            return "Location permission denied. Please authorize location access for this application in Settings."
         }
     }
 }

--- a/Shared/Samples/Show device location/ShowDeviceLocationView.swift
+++ b/Shared/Samples/Show device location/ShowDeviceLocationView.swift
@@ -116,7 +116,7 @@ private extension ShowDeviceLocationView {
 #if targetEnvironment(macCatalyst)
                 // On Mac Catalyst, provide a more helpful error message when location
                 // permissions are not enabled.
-                if (error as NSError).domain == kCLErrorDomain && (error as NSError).code == 1 {
+                if (error as NSError).domain == kCLErrorDomain && (error as NSError).code == CLError.Code.denied.rawValue {
                     throw LocationError.macCatalystPermissionDenied
                 }
 #endif
@@ -138,14 +138,7 @@ private extension ShowDeviceLocationView {
             var errorDescription: String? {
                 switch self {
                 case .macCatalystPermissionDenied:
-                    return "Location services are not enabled for this app. Please enable location permissions in System Settings."
-                }
-            }
-            
-            var recoverySuggestion: String? {
-                switch self {
-                case .macCatalystPermissionDenied:
-                    return "Open System Settings > Privacy & Security > Location Services and ensure this app has permission to access your location."
+                    return "Location services are not enabled for this app. Please enable location permissions in System Settings.\n Open System Settings > Privacy & Security > Location Services and ensure this app has permission to access your location."
                 }
             }
         }


### PR DESCRIPTION
## Description

Show an error when location display fails due to permission denied error.

## Linked Issue(s)

- `swift/issues/8021`

## How To Test

To test run the Show device location sample with system location permissions for the app turned off and then turned on.

## Screenshots

<img width="585" height="1266" alt="IMG_1944" src="https://github.com/user-attachments/assets/d3e1a41a-fb08-4119-82d6-146ca9f0f75c" />

<img width="1020" height="772" alt="Screenshot 2026-05-20 at 4 10 52 PM" src="https://github.com/user-attachments/assets/21b322a8-64ac-4b0d-a96d-90f0b6bc6f43" />




