### PR TITLE
[Update] world-scale AR samples

### DIFF
--- a/Shared/Samples/Augment reality to collect data/AugmentRealityToCollectDataView.swift
+++ b/Shared/Samples/Augment reality to collect data/AugmentRealityToCollectDataView.swift
@@ -20,6 +20,9 @@ import SwiftUI
 struct AugmentRealityToCollectDataView: View {
     /// The view model for this sample.
     @StateObject private var model = Model()
+    
+    /// The world-tracking provider used by this sample.
+    @State private var provider = AppleWorldTracking(mode: .worldTracking)
     /// The status text displayed to the user.
     @State private var statusText = "Tap to create a feature"
     /// A Boolean value indicating whether a feature can be added .
@@ -31,8 +34,13 @@ struct AugmentRealityToCollectDataView: View {
     
     var body: some View {
         VStack(spacing: 0) {
-            WorldScaleSceneView { _ in
-                SceneView(scene: model.scene, graphicsOverlays: [model.graphicsOverlay])
+            WorldScaleSceneView(provider: provider) { context in
+                AppleWorldTrackingCameraFeedView(context: context)
+            } sceneView: { _ in
+                SceneView(
+                    scene: model.scene,
+                    graphicsOverlays: [model.graphicsOverlay]
+                )
             }
             .calibrationButtonAlignment(.bottomLeading)
             .onCalibratingChanged { newCalibrating in

--- a/Shared/Samples/Augment reality to navigate route/AugmentRealityToNavigateRouteView.ARSceneView.swift
+++ b/Shared/Samples/Augment reality to navigate route/AugmentRealityToNavigateRouteView.ARSceneView.swift
@@ -24,15 +24,18 @@ extension AugmentRealityToNavigateRouteView {
         /// The view model for scene view in the sample.
         @ObservedObject var model: SceneModel
         
+        /// The world-tracking provider used by this view.
+        @State private var provider = AppleWorldTracking(mode: .worldTracking)
         /// A Boolean value indicating whether the use is navigating the route.
         @State private var isNavigating = false
-        
         /// The error shown in the error alert.
         @State private var error: (any Error)?
         
         var body: some View {
             VStack(spacing: 0) {
-                WorldScaleSceneView { _ in
+                WorldScaleSceneView(provider: provider) { context in
+                    AppleWorldTrackingCameraFeedView(context: context)
+                } sceneView: { _ in
                     SceneView(
                         scene: model.scene,
                         graphicsOverlays: [model.routeGraphicsOverlay]

--- a/Shared/Samples/Augment reality to show hidden infrastructure/AugmentRealityToShowHiddenInfrastructureView.ARSceneView.swift
+++ b/Shared/Samples/Augment reality to show hidden infrastructure/AugmentRealityToShowHiddenInfrastructureView.ARSceneView.swift
@@ -23,20 +23,26 @@ extension AugmentRealityToShowHiddenInfrastructureView {
         /// The view model for scene view in the sample.
         @ObservedObject var model: SceneModel
         
+        /// The world-tracking provider used by this view.
+        @State private var provider = AppleWorldTracking(mode: .worldTracking)
         /// A Boolean value indicating whether the shadow graphics are visible.
         @State private var shadowsAreVisible = true
-        
         /// A Boolean value indicating whether the leader line graphics are visible.
         @State private var leadersAreVisible = true
         
         var body: some View {
             VStack(spacing: 0) {
-                WorldScaleSceneView { _ in
-                    SceneView(scene: model.scene, graphicsOverlays: [
-                        model.pipeGraphicsOverlay,
-                        model.shadowGraphicsOverlay,
-                        model.leaderGraphicsOverlay
-                    ])
+                WorldScaleSceneView(provider: provider) { context in
+                    AppleWorldTrackingCameraFeedView(context: context)
+                } sceneView: { _ in
+                    SceneView(
+                        scene: model.scene,
+                        graphicsOverlays: [
+                            model.pipeGraphicsOverlay,
+                            model.shadowGraphicsOverlay,
+                            model.leaderGraphicsOverlay
+                        ]
+                    )
                 }
                 .calibrationButtonAlignment(.bottomLeading)
                 .onCalibratingChanged { newCalibrating in


### PR DESCRIPTION
Updates the relevant samples to use the new `WorldScaleSceneView`, addressing deprecation warnings.