### PR TITLE
[Update] Fix `UtilityTraceFunction`-related error

### DIFF
--- a/Shared/Samples/Create load report/CreateLoadReportView.Model.swift
+++ b/Shared/Samples/Create load report/CreateLoadReportView.Model.swift
@@ -132,7 +132,7 @@ extension CreateLoadReportView {
                 operator: .exists
             )
             let addLoadAttributeFunction = UtilityTraceFunction(
-                functionType: .add,
+                kind: .add,
                 networkAttribute: loadAttribute,
                 condition: serviceCategoryComparison
             )


### PR DESCRIPTION
Error (soon to be warning) was a result of API changes introduced in swift/8304.

<img width="875" height="101" alt="image" src="https://github.com/user-attachments/assets/150229e9-8185-4858-b18a-b6546d81258a" />