### PR TITLE
[Fix] `Set visibility of subtype sublayer` toggles

### DIFF
--- a/Shared/Samples/Set visibility of subtype sublayer/SetVisibilityOfSubtypeSublayerView.Model.swift
+++ b/Shared/Samples/Set visibility of subtype sublayer/SetVisibilityOfSubtypeSublayerView.Model.swift
@@ -60,12 +60,12 @@ extension SetVisibilityOfSubtypeSublayerView {
         @Published private(set) var minimumScaleText: String = "Not Set"
         
         /// A Boolean value indicating whether to show the subtype sublayer.
-        @Published var showsSublayer = true {
+        @Published var showsSublayer = false {
             didSet { subtypeSublayer?.isVisible = showsSublayer }
         }
         
         /// A Boolean value indicating whether to show the subtype sublayer's renderer.
-        @Published var showsOriginalRenderer = true {
+        @Published var showsOriginalRenderer = false {
             didSet { toggleRenderer(showsOriginalRenderer: showsOriginalRenderer) }
         }
         
@@ -87,6 +87,8 @@ extension SetVisibilityOfSubtypeSublayerView {
             originalRenderer = subtypeSublayer.renderer
             subtypeSublayer.addLabelDefinition(labelDefinition)
             self.subtypeSublayer = subtypeSublayer
+            showsSublayer = subtypeSublayer.isVisible
+            showsOriginalRenderer = subtypeSublayer.renderer == originalRenderer
         }
         
         /// Cleans up the model's setup.

--- a/Shared/Samples/Set visibility of subtype sublayer/SetVisibilityOfSubtypeSublayerView.Model.swift
+++ b/Shared/Samples/Set visibility of subtype sublayer/SetVisibilityOfSubtypeSublayerView.Model.swift
@@ -59,6 +59,16 @@ extension SetVisibilityOfSubtypeSublayerView {
         /// The subtype sublayer's minimum scale value in text.
         @Published private(set) var minimumScaleText: String = "Not Set"
         
+        /// A Boolean value indicating whether to show the subtype sublayer.
+        @Published var showsSublayer = true {
+            didSet { subtypeSublayer?.isVisible = showsSublayer }
+        }
+        
+        /// A Boolean value indicating whether to show the subtype sublayer's renderer.
+        @Published var showsOriginalRenderer = true {
+            didSet { toggleRenderer(showsOriginalRenderer: showsOriginalRenderer) }
+        }
+        
         init() {
             map.initialViewpoint = .initialViewpoint
             subtypeFeatureLayer = SubtypeFeatureLayer(featureTable: featureTable)
@@ -84,11 +94,7 @@ extension SetVisibilityOfSubtypeSublayerView {
             ArcGISEnvironment.authenticationManager.arcGISCredentialStore.removeAll()
         }
         
-        func toggleSublayer(isVisible: Bool) {
-            subtypeSublayer?.isVisible = isVisible
-        }
-        
-        func toggleRenderer(showsOriginalRenderer: Bool) {
+        private func toggleRenderer(showsOriginalRenderer: Bool) {
             if showsOriginalRenderer {
                 subtypeSublayer?.renderer = originalRenderer
             } else {

--- a/Shared/Samples/Set visibility of subtype sublayer/SetVisibilityOfSubtypeSublayerView.Views.swift
+++ b/Shared/Samples/Set visibility of subtype sublayer/SetVisibilityOfSubtypeSublayerView.Views.swift
@@ -22,23 +22,11 @@ extension SetVisibilityOfSubtypeSublayerView {
         /// The action to dismiss the view.
         @Environment(\.dismiss) private var dismiss
         
-        /// A Boolean value indicating whether to show the subtype sublayer.
-        @State private var showsSublayer = true
-        
-        /// A Boolean value indicating whether to show the subtype sublayer's renderer.
-        @State private var showsOriginalRenderer = true
-        
         var body: some View {
             Form {
                 Section("Layers") {
-                    Toggle("Show Sublayer", isOn: $showsSublayer)
-                        .onChange(of: showsSublayer) {
-                            model.toggleSublayer(isVisible: showsSublayer)
-                        }
-                    Toggle("Show Original Renderer", isOn: $showsOriginalRenderer)
-                        .onChange(of: showsOriginalRenderer) {
-                            model.toggleRenderer(showsOriginalRenderer: showsOriginalRenderer)
-                        }
+                    Toggle("Show Sublayer", isOn: $model.showsSublayer)
+                    Toggle("Show Original Renderer", isOn: $model.showsOriginalRenderer)
                 }
                 Section("Sublayer Minimum Scale") {
                     LabeledContent("Minimum Scale", value: model.minimumScaleText)


### PR DESCRIPTION
## Description

This PR fixes a bug in `Set visibility of subtype sublayer` where the "Visibility Settings" toggles' state would reset after closing the sheet.

## Linked Issue(s)

- `swift/issues/8420`

## How To Test

- Tap "Visibility Settings" to open the sheet.
- Adjust the "Layers" toggles.
- Close and re-open the sheet and ensure the toggles' state does not reset. 

## Screenshots

|Before|After|
|:-:|:-:|
| <img width="230" height="500" alt="After" src="https://github.com/user-attachments/assets/523338e7-b343-4c6b-8315-ece75b2e96fe" /> | <img width="230" height="500" alt="Before" src="https://github.com/user-attachments/assets/87b2403e-f468-4af2-ae03-0b0ff4cf6ffb" /> |
