### PR TITLE
[Update] Remove main actor on a view

### DIFF
--- a/Samples.xcodeproj/project.pbxproj
+++ b/Samples.xcodeproj/project.pbxproj
@@ -5066,6 +5066,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_STRICT_CONCURRENCY = complete;
 			};
 			name = Debug;
 		};
@@ -5121,6 +5122,7 @@
 				MTL_FAST_MATH = YES;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_STRICT_CONCURRENCY = complete;
 			};
 			name = Release;
 		};

--- a/Shared/Samples/Add WFS layer/AddWFSLayerView.swift
+++ b/Shared/Samples/Add WFS layer/AddWFSLayerView.swift
@@ -15,7 +15,6 @@
 import ArcGIS
 import SwiftUI
 
-@MainActor
 struct AddWFSLayerView: View {
     /// A map with a topographic basemap centered on downtown Seattle.
     @State private var map: Map = {


### PR DESCRIPTION
## Description

Remove main actor annotation on views because views are main actor isolated [by default](https://developer.apple.com/videos/play/wwdc2025/266/?time=170).

I also enabled complete strict concurrency on the project, as Swift 6 has become more mature since #435 .

## Linked Issue(s)

- https://github.com/orgs/Esri/projects/50/views/1?pane=issue&itemId=69587304

## How To Test

Check if the project has other views that have explicit main actor isolation.
